### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,12 @@ jobs:
     name: build, pack & publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 10.0.x
 
       - name: publish on version change
         id: publish_nuget

--- a/Circus.Examples/Circus.Examples.csproj
+++ b/Circus.Examples/Circus.Examples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/Circus.Tests/Circus.Tests.csproj
+++ b/Circus.Tests/Circus.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Circus/Circus.csproj
+++ b/Circus/Circus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageVersion>0.3.4</PackageVersion>

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ A financial exchange simulator.
 
 ## Dependencies
 
-[.NET 5](https://dotnet.microsoft.com/download) is required. There are no other dependencies.
+[.NET 10](https://dotnet.microsoft.com/download) is required. There are no other dependencies.
 
 ## To Do
 


### PR DESCRIPTION
## Summary
- Bump `Circus`, `Circus.Tests`, and `Circus.Examples` from `net5.0` to `net10.0` (current LTS).
- Update the NUnit test stack: NUnit 3.12.0 -> 4.6.1, NUnit3TestAdapter 3.16.1 -> 6.2.0, Microsoft.NET.Test.Sdk 16.5.0 -> 18.7.0 - this also clears a transitive high-severity `Newtonsoft.Json` vulnerability warning pulled in by the old test SDK.
- Update CI to match: `actions/setup-dotnet@v1` -> `v4` with `dotnet-version: 10.0.x`, `actions/checkout@v2` -> `v4`.
- Update README's stated dependency (.NET 5 -> .NET 10).

## Test plan
- [x] Clean build (`rm -rf`'d bin/obj) with zero warnings
- [x] `dotnet test` - all 129 tests pass
- [x] `dotnet run --project Circus.Examples` - runs end-to-end on net10.0