### PR TITLE
Switch NuGet publishing to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ jobs:
   publish:
     name: build, pack & publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required to request the OIDC token for trusted publishing
     steps:
       - uses: actions/checkout@v4
 
@@ -15,11 +17,17 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: publish on version change
-        id: publish_nuget
-        uses: rohith/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc
+      - name: Build
+        run: dotnet build Circus/Circus.csproj -c Release
+
+      - name: Pack
+        run: dotnet pack Circus/Circus.csproj -c Release -o artifacts --no-build
+
+      - name: NuGet login (OIDC -> temporary API key)
+        uses: NuGet/login@v1
+        id: login
         with:
-          PROJECT_FILE_PATH: Circus/Circus.csproj
-          VERSION_REGEX: ^\s*<PackageVersion>(.*)<\/PackageVersion>\s*$          
-          INCLUDE_SYMBOLS: true
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          user: seanoflynn
+
+      - name: Push to NuGet
+        run: dotnet nuget push "artifacts/*.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/Circus/Circus.csproj
+++ b/Circus/Circus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.3.4</PackageVersion>
+        <PackageVersion>0.4.0</PackageVersion>
         <Title>Circus</Title>
         <Authors>seanoflynn</Authors>
         <Description>Financial exchange simulator.</Description>


### PR DESCRIPTION
## Summary
- Replace the third-party `rohith/publish-nuget` action and the stored `NUGET_API_KEY` secret with NuGet.org's trusted publishing: the workflow now requests a short-lived API key via OIDC (`NuGet/login@v1`) instead of a long-lived secret.
- `permissions: id-token: write` added to the job so it can request the OIDC token.
- Build/pack/push are now plain `dotnet` CLI steps (`dotnet build`, `dotnet pack --no-build`, `dotnet nuget push`).
- Bump `PackageVersion` 0.3.4 -> 0.4.0 so a new version actually publishes on merge. This also reflects that main has accumulated real changes under the unpublished 0.3.4 version: the stop order feature, the stop-trigger bug fix, and the .NET 10 upgrade.

## Behavior change
This drops the old "skip publish if version unchanged" logic from `rohith/publish-nuget`. Future merges to `main` need `PackageVersion` bumped, or the workflow will fail with a 409 from nuget.org rather than silently skipping.

## Prerequisite (done)
Trusted publishing policy configured on nuget.org for `seanoflynn/circus`, workflow file `publish.yml`.

## Test plan
- [x] `dotnet build` / `dotnet pack --no-build` produce both `.nupkg` and `.snupkg` locally
- [x] Confirmed `dotnet nuget push` auto-discovers and pushes a matching `.snupkg` alongside the `.nupkg`
- [ ] First actual publish via the new workflow, on merge