### PR TITLE
Add CI build/test workflow, coverage reporting, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-test:
+    name: build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build
+        run: dotnet build --configuration Release
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --collect:"XPlat Code Coverage"
+
+      - name: Generate coverage summary
+        if: always()
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10
+        with:
+          reports: "**/coverage.cobertura.xml"
+          targetdir: coveragereport
+          reporttypes: MarkdownSummaryGithub
+
+      - name: Publish coverage summary
+        if: always()
+        run: cat coveragereport/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"

--- a/Circus.Tests/Circus.Tests.csproj
+++ b/Circus.Tests/Circus.Tests.csproj
@@ -7,6 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml`: builds and runs the full test suite on every pull request and on push to `main`, independent of the nuget publish workflow.
- Collect test coverage via `coverlet.collector` (added to `Circus.Tests.csproj`) and summarize it in the job's step summary using `danielpalme/ReportGenerator-GitHub-Action`. This is report-only for now - no pass/fail threshold - per the tradeoff discussed: a hard gate risks blocking PRs on noise, so start with visibility and tighten later if useful.
- Add `.github/dependabot.yml` for the `nuget` and `github-actions` ecosystems on a weekly schedule, so dependency and Action version bumps (like the stale `checkout@v2`/`setup-dotnet@v1` we caught manually last week) surface automatically as PRs.

## Test plan
- [x] `dotnet build` / `dotnet test` pass locally on net10.0
- [x] `dotnet test --collect:"XPlat Code Coverage"` produces `coverage.cobertura.xml` with `coverlet.collector` installed
- [x] Verified locally with `reportgenerator` that `MarkdownSummaryGithub` output renders correctly (89% line / 87.5% branch coverage currently)
- [ ] First real run of `ci.yml` on this PR