### PR TITLE
Clarify UpdateOrder quantity semantics (not a bug)

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
@@ -378,6 +379,33 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(5, cancelled.Order.Quantity);
             Assert.AreEqual(4, cancelled.Order.FilledQuantity);
             Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+        }
+
+        [Test]
+        public void UpdateQuantityAfterPartialFill_RemainingReflectsNewTotalMinusFilled()
+        {
+            // arrange - quantity on UpdateOrder is the order's new TOTAL size (filled + remaining),
+            // not the new remaining/resting amount (see issue #1, finding 2)
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateOrder(ClientId1, OrderId1, OrderValidity.Day, Side.Sell, 10, 100);
+            Book.CreateOrder(ClientId2, OrderId2, OrderValidity.Day, Side.Buy, 4, 100); // partial fill: 4@100
+            TimeProvider.SetCurrentTime(Now2);
+
+            // act
+            var events = Book.UpdateOrder(ClientId1, OrderId1, 6, 110);
+
+            // assert
+            Assert.IsNotNull(events);
+            var updated = events[0] as UpdateOrderConfirmed;
+            Assert.IsNotNull(updated);
+            Assert.AreEqual(6, updated.Order.Quantity);
+            Assert.AreEqual(4, updated.Order.FilledQuantity);
+            Assert.AreEqual(2, updated.Order.RemainingQuantity);
+
+            // a follow-up buy for the full new total should only find the 2 that remain
+            var matched = Book.CreateOrder(ClientId3, OrderId3, OrderValidity.Day, Side.Buy, 6, 110)
+                .OfType<OrdersMatched>().Single();
+            Assert.AreEqual(2, matched.Quantity);
         }
 
         [Test]

--- a/Circus/OrderBook/IOrderBook.cs
+++ b/Circus/OrderBook/IOrderBook.cs
@@ -16,6 +16,7 @@ namespace Circus.OrderBook
         IList<OrderBookEvent> CreateOrder(Guid clientId, Guid orderId, OrderValidity validity, Side side, int quantity,
             decimal? price = null, decimal? triggerPrice = null);
 
+        // quantity is the order's new total size (filled + remaining), not the new remaining/resting amount
         IList<OrderBookEvent> UpdateOrder(Guid clientId, Guid orderId, int? quantity = null, decimal? price = null,
             decimal? triggerPrice = null);
 

--- a/Circus/OrderBook/InternalOrder.cs
+++ b/Circus/OrderBook/InternalOrder.cs
@@ -71,6 +71,7 @@ namespace Circus.OrderBook
             ModifiedTime = time;
             if (quantity.HasValue)
             {
+                // quantity is the new total size, so remaining = new total - already filled
                 RemainingQuantity -= (Quantity - quantity.Value);
                 Quantity = quantity.Value;
             }

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,6 @@ A financial exchange simulator.
 
 - Add price validation against tick size
 - An order id that has ever completed (by cancel or fill) permanently poisons that id — reusing it crashes the engine
-- A resting order that is partially filled, then modified, rests short by exactly its pre-modify filled quantity
 - Process(OrderBookAction) swaps Price and TriggerPrice for both CreateOrder and UpdateOrder
 
 ## Features


### PR DESCRIPTION
## Summary
Investigated finding 2 of #1 ("a resting order that is partially filled, then modified, rests short by exactly its pre-modify filled quantity"). Concluded this is not a defect:

- `RemainingQuantity -= (Quantity - quantity.Value)` is algebraically equivalent to `quantity.Value - FilledQuantity`, once you substitute in the invariant `RemainingQuantity == Quantity - FilledQuantity`.
- That's exactly the CME-style "quantity is the new total order size" amend convention — and this codebase already committed to that convention via the pre-existing `quantity <= order.FilledQuantity` → cancel guard (`OrderCancelledReason.UpdatedQuantityLowerThanFilledQuantity`, added in `d0d3691`, long before this issue existed). That guard only makes sense under total-quantity semantics.
- The reporter flagged this themselves as a possible semantics difference rather than an outright defect — external integrators comparing against other engines' cancel+reinsert convention would see this as "wrong," but it's correct for this engine's own established design.

## Changes
- One-line doc comments at `IOrderBook.UpdateOrder` and at the formula in `InternalOrder.Update` clarifying the convention, so this doesn't trip up the next person.
- New regression test (`UpdateQuantityAfterPartialFill_RemainingReflectsNewTotalMinusFilled`) covering the previously-untested partial-fill-then-modify case, including a follow-up match to prove the resting size is actually correct in practice.
- Removed this item from the README's Known bugs list.

No behavior change.

## Test plan
- [x] `dotnet test` — 145/145 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bAgRnEY2ewRDWJVhLtiFt