### PR TITLE
Fix Process() swapping Price and TriggerPrice

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
@@ -26,15 +26,40 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void Process_CreateOrder_Success()
         {
-            // act
-            Book.Process(new CreateOrder(Sec, ClientId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100));
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+
+            // act - only Price set, no TriggerPrice: this must rest as a plain working limit
+            // order, not get misrouted into the TriggerPrice slot as a hidden stop order
+            var events = Book.Process(new CreateOrder(Sec, ClientId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100));
+
+            // assert
+            Assert.IsNotNull(events);
+            var created = events[0] as CreateOrderConfirmed;
+            Assert.IsNotNull(created);
+            Assert.AreEqual(OrderStatus.Working, created.Order.Status);
+            Assert.AreEqual(OrderType.Limit, created.Order.Type);
+            Assert.AreEqual(100, created.Order.Price);
+            Assert.IsNull(created.Order.TriggerPrice);
+            Assert.AreEqual(1, Book.GetLevels(Side.Buy, 10).Count);
         }
 
         [Test]
         public void Process_UpdateOrder_Success()
         {
-            // act
-            Book.Process(new UpdateOrder(Sec, ClientId1, OrderId1, 3));
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateOrder(ClientId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+
+            // act - only Price set, no TriggerPrice: this must actually reprice the order
+            var events = Book.Process(new UpdateOrder(Sec, ClientId1, OrderId1, Price: 110));
+
+            // assert
+            Assert.IsNotNull(events);
+            var updated = events[0] as UpdateOrderConfirmed;
+            Assert.IsNotNull(updated);
+            Assert.AreEqual(110, updated.Order.Price);
+            Assert.IsNull(updated.Order.TriggerPrice);
         }
 
         [Test]

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -58,9 +58,9 @@ namespace Circus.OrderBook
             return action switch
             {
                 CreateOrder create => CreateOrder(create.ClientId, create.OrderId, create.OrderValidity, create.Side,
-                    create.Quantity, create.TriggerPrice, create.Price),
-                UpdateOrder update => UpdateOrder(update.ClientId, update.OrderId, update.Quantity, update.TriggerPrice,
-                    update.Price),
+                    create.Quantity, create.Price, create.TriggerPrice),
+                UpdateOrder update => UpdateOrder(update.ClientId, update.OrderId, update.Quantity, update.Price,
+                    update.TriggerPrice),
                 CancelOrder cancel => CancelOrder(cancel.ClientId, cancel.OrderId),
                 UpdateStatus update => UpdateStatus(update.Status),
                 _ => throw new ArgumentException("Unknown order book action")

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,6 @@ A financial exchange simulator.
 
 - Add price validation against tick size
 - An order id that has ever completed (by cancel or fill) permanently poisons that id — reusing it crashes the engine
-- Process(OrderBookAction) swaps Price and TriggerPrice for both CreateOrder and UpdateOrder
 
 ## Features
 


### PR DESCRIPTION
## Summary
Fixes finding 3 of #1: `Process(OrderBookAction)`'s `CreateOrder`/`UpdateOrder` switch arms passed `TriggerPrice` and `Price` to the underlying `CreateOrder`/`UpdateOrder` methods in reversed order relative to both those methods' own parameters and the action records' own property order.

Effect: a plain limit order submitted only via `Price` (no `TriggerPrice`) had that price land in the `triggerPrice` slot instead — misrouting it into a hidden stop order. On a fresh book (no last-traded price yet) this got rejected outright (`NoLastTradedPrice`); on a book that had already traded, it was silently accepted as an invisible `StopMarket`/`StopLimit` order instead of a working limit order.

- Swapped the argument order back to match the methods being called.
- Rewrote `InMemoryOrderBookProcessTests`'s `Process_CreateOrder_Success`/`Process_UpdateOrder_Success`, which previously asserted nothing beyond "didn't throw" (the create test didn't even open the book first, so it only ever exercised the `MarketClosed` rejection path and could never have caught this). Both now assert the resulting order state, and I confirmed both fail against the pre-fix code.

## Test plan
- [x] `dotnet test` — 145/145 passing.
- [x] Verified both rewritten `Process_*` tests fail when the fix is reverted, confirming they actually exercise this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bAgRnEY2ewRDWJVhLtiFt