### PR TITLE
Bump PackageVersion to 0.5.0

### DIFF
--- a/Circus/Circus.csproj
+++ b/Circus/Circus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.4.0</PackageVersion>
+        <PackageVersion>0.5.0</PackageVersion>
         <Title>Circus</Title>
         <Authors>seanoflynn</Authors>
         <Description>Financial exchange simulator.</Description>


### PR DESCRIPTION
## Summary
Every push to `main` since 0.4.0 has failed the `publish to nuget` workflow with `409 Conflict` (`A package with ID 'Circus' and version '0.4.0' already exists`) - trusted publishing dropped the old skip-if-version-unchanged behavior, so a stale version just fails outright now.

`main` has accumulated since 0.4.0:
- FAK/FOK order validity (#9)
- Stop-trigger direction/crash fix (#2)
- Order id reuse crash fix (#10)
- `Process()` Price/TriggerPrice swap fix (#12)

Bumping to 0.5.0 (minor), matching the precedent set when 0.4.0 itself was cut for a similar accumulated batch.

## Test plan
- [x] `dotnet build Circus/Circus.csproj -c Release` — packs as `Circus.0.5.0.nupkg` locally.
- [ ] Merging this will push to `main` and trigger `publish.yml`, which should now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bAgRnEY2ewRDWJVhLtiFt