### PR TITLE
Verify tick-size validation handles negative prices correctly

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
@@ -1850,6 +1850,24 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(OrderId1, rejected.OrderId);
         }
 
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void NegativePriceOnTick_Success(decimal price)
+        {
+            // arrange - negative prices are legitimate (e.g. calendar spreads, or the 2020 WTI
+            // crude event) and must still be accepted as long as they're on a valid tick
+            Book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            var events = Book.CreateOrder(ClientId1, OrderId1, OrderValidity.Day, Side.Buy, 6, price);
+
+            // assert
+            Assert.IsNotNull(events);
+            var created = events[0] as CreateOrderConfirmed;
+            Assert.IsNotNull(created);
+            Assert.AreEqual(price, created.Order.Price);
+        }
+
         [TestCase(8)]
         [TestCase(-8)]
         [TestCase(-108)]

--- a/Readme.md
+++ b/Readme.md
@@ -6,10 +6,6 @@ A financial exchange simulator.
 
 [.NET 10](https://dotnet.microsoft.com/download) is required. There are no other dependencies.
 
-## Known bugs
-
-- Add price validation against tick size
-
 ## Features
 
 Order types


### PR DESCRIPTION
## Summary
Checked the README's last remaining "Known bugs" item ("Add price validation against tick size") against negative prices specifically, since negative prices are legitimate here (calendar spreads, commodities trading below zero - e.g. WTI crude in 2020) and must not be rejected outright, only when misaligned to the tick grid.

Turned out to already be correct and this item was stale:
- `price % TickSize != 0` rejects misalignment regardless of sign. C# decimal modulo preserves the sign of the remainder, but the check only cares whether it's exactly zero, so `-10 % 10 == 0` and `-20 % 10 == 0` (correctly accepted) while `-15 % 10 == -5` (correctly rejected) - same as the positive case.
- `CreateOrder`/`UpdateOrder` never reject a price just for being negative.
- The existing `InvalidPriceIncrement_Rejected` test cases (`-8`, `-108`) already covered the misaligned-and-rejected side; nothing covered the aligned-and-accepted side for a negative price.

No behavior change. Added `NegativePriceOnTick_Success` covering the previously-untested case, and dropped the item (and now-empty "Known bugs" section) from the README.

## Test plan
- [x] `dotnet test` — 149/149 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bAgRnEY2ewRDWJVhLtiFt