### PR TITLE
Add order flow simulator and throughput benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ ModelManifest.xml
 
 .DS_Store
 .idea
+
+# BenchmarkDotNet run output
+BenchmarkDotNet.Artifacts/

--- a/Circus.Benchmarks/Circus.Benchmarks.csproj
+++ b/Circus.Benchmarks/Circus.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Circus\Circus.csproj" />
+        <ProjectReference Include="..\Circus.Simulator\Circus.Simulator.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
+++ b/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Circus.OrderBook;
+using Circus.Simulator;
+using Circus.TimeProviders;
+
+namespace Circus.Benchmarks
+{
+    // Replays a fixed, seeded trace of realistic order flow against a fresh order book each
+    // invocation. This is the headline number: throughput/allocations for a whole session's
+    // worth of activity, rather than any single operation in isolation.
+    [MemoryDiagnoser]
+    public class OrderBookThroughputBenchmarks
+    {
+        [Params(1_000, 10_000, 100_000)]
+        public int ActionCount;
+
+        private Security _security = null!;
+        private IReadOnlyList<OrderBookAction> _trace = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _security = new Security("BENCH", SecurityType.Future, 1m, 10m);
+            var simulator = new OrderFlowSimulator(_security, seed: 12345);
+            _trace = simulator.Generate(ActionCount);
+        }
+
+        [Benchmark]
+        public int ReplayTrace()
+        {
+            var book = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            var eventCount = 0;
+            foreach (var action in _trace)
+                eventCount += book.Process(action).Count;
+
+            return eventCount;
+        }
+    }
+}

--- a/Circus.Benchmarks/Program.cs
+++ b/Circus.Benchmarks/Program.cs
@@ -1,0 +1,7 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+internal static partial class Program
+{
+}

--- a/Circus.Simulator/Circus.Simulator.csproj
+++ b/Circus.Simulator/Circus.Simulator.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Circus\Circus.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Circus.Simulator/OrderFlowSimulator.cs
+++ b/Circus.Simulator/OrderFlowSimulator.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+
+namespace Circus.Simulator
+{
+    // Generates a plausible, replayable stream of order book actions (create/cancel/update,
+    // limit/market) for a single security. Drives a private "shadow" order book purely to keep
+    // track of which orders are currently live, so that generated cancels/updates always target
+    // a real resting order instead of a random, possibly-already-filled id.
+    //
+    // Pass a seed for a deterministic, reproducible trace (e.g. a committed benchmark baseline);
+    // omit it to get a fresh random trace each run (e.g. fuzzing).
+    public sealed class OrderFlowSimulator
+    {
+        private readonly Security _security;
+        private readonly SimulatorOptions _options;
+        private readonly Random _random;
+        private readonly int _seed;
+
+        private readonly InMemoryOrderBook _shadowBook;
+
+        private readonly List<Guid> _liveIds = new();
+        private readonly Dictionary<Guid, int> _liveIndex = new();
+        private readonly Dictionary<Guid, LiveOrderInfo> _liveInfo = new();
+
+        public OrderFlowSimulator(Security security, SimulatorOptions? options = null, int? seed = null)
+        {
+            _security = security;
+            _options = options ?? new SimulatorOptions();
+            _seed = seed ?? Random.Shared.Next();
+            _random = new Random(_seed);
+
+            _shadowBook = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
+            _shadowBook.UpdateStatus(OrderBookStatus.Open);
+        }
+
+        public int Seed => _seed;
+
+        // Generates the next `actionCount` actions, continuing from wherever the internal
+        // shadow book currently is (i.e. calling this repeatedly extends the same session
+        // rather than restarting it). The returned list contains only the newly generated
+        // batch, not the full history.
+        public IReadOnlyList<OrderBookAction> Generate(int actionCount)
+        {
+            var actions = new List<OrderBookAction>(actionCount);
+
+            for (var i = 0; i < actionCount; i++)
+            {
+                var action = NextAction();
+                actions.Add(action);
+                Apply(action);
+            }
+
+            return actions;
+        }
+
+        private void Apply(OrderBookAction action)
+        {
+            var events = _shadowBook.Process(action);
+            foreach (var e in events)
+            {
+                switch (e)
+                {
+                    case CreateOrderConfirmed c:
+                        Track(c.Order);
+                        break;
+                    case UpdateOrderConfirmed u:
+                        Track(u.Order);
+                        break;
+                    case CancelOrderConfirmed cancel:
+                        RemoveLive(cancel.Order.OrderId);
+                        break;
+                    case ExpireOrderConfirmed expire:
+                        RemoveLive(expire.Order.OrderId);
+                        break;
+                    case OrdersMatched matched:
+                        foreach (var fill in matched.Fills)
+                        {
+                            if (fill.Order.RemainingQuantity == 0)
+                                RemoveLive(fill.Order.OrderId);
+                        }
+                        break;
+                }
+            }
+        }
+
+        private void Track(Order order)
+        {
+            if (order.RemainingQuantity == 0)
+            {
+                RemoveLive(order.OrderId);
+                return;
+            }
+
+            if (!_liveIndex.ContainsKey(order.OrderId))
+            {
+                _liveIndex[order.OrderId] = _liveIds.Count;
+                _liveIds.Add(order.OrderId);
+            }
+
+            _liveInfo[order.OrderId] = new LiveOrderInfo(order.ClientId, order.Side, order.Price, order.TriggerPrice);
+        }
+
+        private void RemoveLive(Guid orderId)
+        {
+            if (!_liveIndex.TryGetValue(orderId, out var index))
+                return;
+
+            var lastIndex = _liveIds.Count - 1;
+            var lastId = _liveIds[lastIndex];
+            _liveIds[index] = lastId;
+            _liveIndex[lastId] = index;
+            _liveIds.RemoveAt(lastIndex);
+
+            _liveIndex.Remove(orderId);
+            _liveInfo.Remove(orderId);
+        }
+
+        private bool TryPickLive(out Guid orderId, out LiveOrderInfo info)
+        {
+            if (_liveIds.Count == 0)
+            {
+                orderId = default;
+                info = default!;
+                return false;
+            }
+
+            orderId = _liveIds[_random.Next(_liveIds.Count)];
+            info = _liveInfo[orderId];
+            return true;
+        }
+
+        private OrderBookAction NextAction()
+        {
+            var hasLive = _liveIds.Count > 0;
+            var roll = _random.NextDouble();
+
+            if (hasLive)
+            {
+                if (roll < _options.CancelWeight)
+                    return BuildCancel();
+                roll -= _options.CancelWeight;
+
+                if (roll < _options.UpdateWeight)
+                    return BuildUpdate();
+                roll -= _options.UpdateWeight;
+            }
+
+            if (roll < _options.MarketOrderWeight)
+                return BuildCreateMarket();
+
+            return BuildCreateLimit();
+        }
+
+        private CreateOrder BuildCreateLimit()
+        {
+            var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
+            var price = ComputePrice(side);
+            var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
+
+            return new CreateOrder(_security, Guid.NewGuid(), Guid.NewGuid(), OrderValidity.GoodTilCanceled, side,
+                quantity, price);
+        }
+
+        private CreateOrder BuildCreateMarket()
+        {
+            var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
+            var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
+
+            return new CreateOrder(_security, Guid.NewGuid(), Guid.NewGuid(), OrderValidity.GoodTilCanceled, side,
+                quantity);
+        }
+
+        private CancelOrder BuildCancel()
+        {
+            TryPickLive(out var orderId, out var info);
+            return new CancelOrder(_security, info.ClientId, orderId);
+        }
+
+        private UpdateOrder BuildUpdate()
+        {
+            TryPickLive(out var orderId, out var info);
+
+            // stop orders keep a Price/TriggerPrice relationship that a blind tweak could
+            // violate, so only ever adjust their quantity.
+            var updateQuantityOnly = info.TriggerPrice.HasValue;
+            if (updateQuantityOnly || _random.NextDouble() < 0.5)
+            {
+                var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
+                return new UpdateOrder(_security, info.ClientId, orderId, Quantity: quantity);
+            }
+
+            var tick = _security.TickSize;
+            var direction = info.Side == Side.Buy ? -1 : 1; // move away from touch, staying passive
+            var reference = info.Price ?? AlignToTick(_options.StartingPrice);
+            var newPrice = reference + direction * _random.Next(1, 4) * tick;
+
+            return new UpdateOrder(_security, info.ClientId, orderId, Price: newPrice);
+        }
+
+        private decimal ComputePrice(Side side)
+        {
+            var tick = _security.TickSize;
+            var bestBuy = _shadowBook.GetLevels(Side.Buy, 1);
+            var bestSell = _shadowBook.GetLevels(Side.Sell, 1);
+
+            if (bestBuy.Count == 0 && bestSell.Count == 0)
+                return AlignToTick(_options.StartingPrice);
+
+            var opposite = side == Side.Buy ? bestSell : bestBuy;
+            var own = side == Side.Buy ? bestBuy : bestSell;
+
+            if (opposite.Count > 0 && _random.NextDouble() < _options.CrossProbability)
+            {
+                var throughTicks = _random.Next(0, 3);
+                return side == Side.Buy
+                    ? opposite[0].Price + throughTicks * tick
+                    : opposite[0].Price - throughTicks * tick;
+            }
+
+            var reference = own.Count > 0 ? own[0].Price : opposite[0].Price;
+            var offsetTicks = _random.Next(0, _options.PriceRangeTicks + 1);
+
+            return side == Side.Buy ? reference - offsetTicks * tick : reference + offsetTicks * tick;
+        }
+
+        private decimal AlignToTick(decimal price)
+        {
+            var tick = _security.TickSize;
+            return Math.Round(price / tick) * tick;
+        }
+
+        private readonly record struct LiveOrderInfo(Guid ClientId, Side Side, decimal? Price, decimal? TriggerPrice);
+    }
+}

--- a/Circus.Simulator/SimulatorOptions.cs
+++ b/Circus.Simulator/SimulatorOptions.cs
@@ -1,0 +1,15 @@
+namespace Circus.Simulator
+{
+    // Weights are threshold cut-offs evaluated in order (cancel, then update, then market),
+    // not probabilities that must sum to 1 — whatever mass is left over produces a limit order.
+    public record SimulatorOptions(
+        decimal StartingPrice = 1000m,
+        int MinQuantity = 1,
+        int MaxQuantity = 10,
+        int PriceRangeTicks = 100,
+        double CancelWeight = 0.2,
+        double UpdateWeight = 0.1,
+        double MarketOrderWeight = 0.05,
+        double CrossProbability = 0.15
+    );
+}

--- a/Circus.sln
+++ b/Circus.sln
@@ -6,23 +6,82 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circus.Tests", "Circus.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circus.Examples", "Circus.Examples\Circus.Examples.csproj", "{6BA53765-A118-41CD-9BBC-28C0904EFD36}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circus.Simulator", "Circus.Simulator\Circus.Simulator.csproj", "{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circus.Benchmarks", "Circus.Benchmarks\Circus.Benchmarks.csproj", "{9AAADD20-6473-4A0D-BA43-CE936C83435F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Debug|x64.Build.0 = Debug|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Debug|x86.Build.0 = Debug|Any CPU
 		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Release|x64.ActiveCfg = Release|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Release|x64.Build.0 = Release|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Release|x86.ActiveCfg = Release|Any CPU
+		{5D83AF31-799F-4130-9DE8-388F17DEEFAE}.Release|x86.Build.0 = Release|Any CPU
 		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Debug|x86.Build.0 = Debug|Any CPU
 		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Release|x64.Build.0 = Release|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E6DC327-731A-49AE-9A18-2CDE5867F75C}.Release|x86.Build.0 = Release|Any CPU
 		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Debug|x64.Build.0 = Debug|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Debug|x86.Build.0 = Debug|Any CPU
 		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Release|x64.ActiveCfg = Release|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Release|x64.Build.0 = Release|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Release|x86.ActiveCfg = Release|Any CPU
+		{6BA53765-A118-41CD-9BBC-28C0904EFD36}.Release|x86.Build.0 = Release|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Release|x64.Build.0 = Release|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{67401FA1-C1B4-4AAA-8DF3-B1DD7FDD55A1}.Release|x86.Build.0 = Release|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Debug|x64.Build.0 = Debug|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Debug|x86.Build.0 = Debug|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Release|x64.ActiveCfg = Release|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Release|x64.Build.0 = Release|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Release|x86.ActiveCfg = Release|Any CPU
+		{9AAADD20-6473-4A0D-BA43-CE936C83435F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- Adds `Circus.Simulator`, a seeded/random order-flow generator (`OrderFlowSimulator`) that drives a private order book to track live orders, so generated cancels/updates always target real resting orders instead of arbitrary ids.
- Adds `Circus.Benchmarks`, a BenchmarkDotNet harness (`OrderBookThroughputBenchmarks`) that replays a fixed generated trace of 1k/10k/100k mixed actions (creates, cancels, updates, market orders, crossing trades) against a fresh order book each invocation, reporting throughput and allocations via `[MemoryDiagnoser]`.

## Test plan
- [x] `dotnet build Circus.sln -c Release` succeeds
- [x] `dotnet run -c Release --project Circus.Benchmarks -- --job dry --filter '*'` runs all benchmark combinations end-to-end with no errors
- [ ] Full benchmark run (`dotnet run -c Release --project Circus.Benchmarks`) for a real baseline, if useful to capture in this PR

https://claude.ai/code/session_01K4xvmUHQF8PaZYi3QHWSAu