### PR TITLE
Represent order book prices as integer ticks internally

### DIFF
--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -20,7 +20,7 @@ namespace Circus.OrderBook
         private readonly Dictionary<Side, SortedDictionary<long, SortedDictionary<long, InternalOrder>>> _working =
             new()
             {
-                {Side.Buy, new(new DescendingComparer<long>())},
+                {Side.Buy, new(new DescendingComparer())},
                 {Side.Sell, new()}
             };
 
@@ -28,7 +28,7 @@ namespace Circus.OrderBook
             new()
             {
                 {Side.Buy, new()},
-                {Side.Sell, new(new DescendingComparer<long>())}
+                {Side.Sell, new(new DescendingComparer())}
             };
 
         private readonly Dictionary<Guid, InternalOrder> _orders = new();

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -134,7 +134,6 @@ namespace Circus.OrderBook
             var orders = (triggerTicks.HasValue ? _stops : _working);
             var newPriceTicks = (triggerTicks ?? priceTicks) ?? throw new Exception("error");
             orders[side].Add(newPriceTicks, _nextSequenceNumber, order);
-            Console.WriteLine($"order added: {order}");
 
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), clientId, order.ToOrder()));
@@ -255,7 +254,6 @@ namespace Circus.OrderBook
             {
                 order.Cancel(Now());
                 CompleteOrder(order);
-                Console.WriteLine($"order cancelled on update as new quantity <= filled quantity: {order}");
 
                 return new List<OrderBookEvent>
                 {
@@ -284,7 +282,6 @@ namespace Circus.OrderBook
                 orders[order.Side].Add(updatedPriceTicks, sequenceNumber, order);
             }
             order.Update(sequenceNumber, Now(), quantity, triggerTicks, priceTicks);
-            Console.WriteLine($"order updated: {order}");
 
             List<OrderBookEvent> events = new();
             events.Add(new UpdateOrderConfirmed(_security, Now(), order.ClientId, order.ToOrder()));
@@ -304,7 +301,6 @@ namespace Circus.OrderBook
 
             order.Cancel(Now());
             CompleteOrder(order);
-            Console.WriteLine($"order cancelled: {order}");
 
             return new List<OrderBookEvent>
             {
@@ -327,7 +323,6 @@ namespace Circus.OrderBook
             order.Expire(Now());
             CompleteOrder(order);
 
-            Console.WriteLine($"order expired: {order}");
 
             return new ExpireOrderConfirmed(_security, Now(), order.ClientId, order.ToOrder());
         }
@@ -395,9 +390,6 @@ namespace Circus.OrderBook
                 var priceTicks = resting.Price ?? throw new InvalidOperationException("limit order requires price");
                 var price = ToDecimal(priceTicks);
 
-                Console.WriteLine($"matched orders: {quantity}@{price}");
-                Console.WriteLine($"- resting   {resting}");
-                Console.WriteLine($"- aggressor {aggressor}");
 
                 FillOrder(resting, time, quantity);
                 FillOrder(aggressor, time, quantity);
@@ -484,7 +476,6 @@ namespace Circus.OrderBook
                 {
                     order.Cancel(Now());
                     FinishOrder(order);
-                    Console.WriteLine($"order cancelled, book empty when order triggered: {order}");
 
                     events.Add(new CancelOrderConfirmed(_security, Now(), order.ClientId, order.ToOrder(),
                         OrderCancelledReason.NoOrdersToMatchMarketOrder));
@@ -496,7 +487,6 @@ namespace Circus.OrderBook
                 {
                     order.Cancel(Now());
                     FinishOrder(order);
-                    Console.WriteLine($"order cancelled, insufficient liquidity when fill-or-kill order triggered: {order}");
 
                     events.Add(new CancelOrderConfirmed(_security, Now(), order.ClientId, order.ToOrder(),
                         OrderCancelledReason.FillOrKillNotFilled));

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -10,23 +10,25 @@ namespace Circus.OrderBook
     {
         private readonly Security _security;
         private readonly ITimeProvider _timeProvider;
-        
+
         private OrderBookStatus _status = OrderBookStatus.Closed;
         private long _nextSequenceNumber;
-        private decimal? _lastTradedPrice;
+        private long? _lastTradedPrice;
 
-        private readonly Dictionary<Side, SortedDictionary<decimal, SortedDictionary<long, InternalOrder>>> _working =
+        // Keyed and compared as tick counts (price / Security.TickSize) rather than decimal —
+        // see InternalOrder for why.
+        private readonly Dictionary<Side, SortedDictionary<long, SortedDictionary<long, InternalOrder>>> _working =
             new()
             {
-                {Side.Buy, new(new DescendingComparer())},
+                {Side.Buy, new(new DescendingComparer<long>())},
                 {Side.Sell, new()}
             };
 
-        private readonly Dictionary<Side, SortedDictionary<decimal, SortedDictionary<long, InternalOrder>>> _stops =
+        private readonly Dictionary<Side, SortedDictionary<long, SortedDictionary<long, InternalOrder>>> _stops =
             new()
             {
                 {Side.Buy, new()},
-                {Side.Sell, new(new DescendingComparer())}
+                {Side.Sell, new(new DescendingComparer<long>())}
             };
 
         private readonly Dictionary<Guid, InternalOrder> _orders = new();
@@ -47,7 +49,7 @@ namespace Circus.OrderBook
         {
             return _working[side].Take(maxPrices)
                 .Select(x => new Level(
-                    x.Key,
+                    ToDecimal(x.Key),
                     x.Value.Sum(y => y.Value.RemainingQuantity),
                     x.Value.Count))
                 .ToList();
@@ -90,19 +92,19 @@ namespace Circus.OrderBook
                 return RejectCreate(clientId, orderId, OrderRejectedReason.MarketPreOpen);
             if (quantity < 1)
                 return RejectCreate(clientId, orderId, OrderRejectedReason.InvalidQuantity);
-            if (price != null && price % _security.TickSize != 0)
+            if (!TryConvertToTicks(price, out var priceTicks))
                 return RejectCreate(clientId, orderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (triggerPrice != null && triggerPrice % _security.TickSize != 0)
+            if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
                 return RejectCreate(clientId, orderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (triggerPrice != null && price != null && side == Side.Buy && price < triggerPrice)
+            if (triggerTicks != null && priceTicks != null && side == Side.Buy && priceTicks < triggerTicks)
                 return RejectCreate(clientId, orderId, OrderRejectedReason.TriggerPriceMustBeLessThanPrice);
-            if (triggerPrice != null && price != null && side == Side.Sell && price > triggerPrice)
+            if (triggerTicks != null && priceTicks != null && side == Side.Sell && priceTicks > triggerTicks)
                 return RejectCreate(clientId, orderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice);
-            if (triggerPrice != null && !_lastTradedPrice.HasValue)
+            if (triggerTicks != null && !_lastTradedPrice.HasValue)
                 return RejectCreate(clientId, orderId, OrderRejectedReason.NoLastTradedPrice);
-            if (triggerPrice != null && side == Side.Buy && triggerPrice <= _lastTradedPrice)
+            if (triggerTicks != null && side == Side.Buy && triggerTicks <= _lastTradedPrice)
                 return RejectCreate(clientId, orderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice);
-            if (triggerPrice != null && side == Side.Sell && triggerPrice >= _lastTradedPrice)
+            if (triggerTicks != null && side == Side.Sell && triggerTicks >= _lastTradedPrice)
                 return RejectCreate(clientId, orderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
             if (_orders.ContainsKey(orderId))
                 return RejectCreate(clientId, orderId, OrderRejectedReason.OrderInBook);
@@ -112,12 +114,12 @@ namespace Circus.OrderBook
             if (type == OrderType.Market || type == OrderType.MarketLimit)
             {
                 var protectionTicks = type == OrderType.MarketLimit ? 0 : _security.MarketOrderProtectionTicks;
-                if(!TryGetLimitPrice(side, protectionTicks, out price))
+                if(!TryGetLimitPrice(side, protectionTicks, out priceTicks))
                     return RejectCreate(clientId, orderId, OrderRejectedReason.NoOrdersToMatchMarketOrder);
             }
 
-            if (validity == OrderValidity.FillOrKill && !triggerPrice.HasValue &&
-                !HasSufficientLiquidity(side, price!.Value, quantity))
+            if (validity == OrderValidity.FillOrKill && !triggerTicks.HasValue &&
+                !HasSufficientLiquidity(side, priceTicks!.Value, quantity))
                 return RejectCreate(clientId, orderId, OrderRejectedReason.InsufficientLiquidityForFillOrKill);
             if (validity == OrderValidity.GoodTilDate && !goodTilDate.HasValue)
                 return RejectCreate(clientId, orderId, OrderRejectedReason.GoodTilDateRequired);
@@ -126,14 +128,14 @@ namespace Circus.OrderBook
 
             _nextSequenceNumber++;
             var order = new InternalOrder(_nextSequenceNumber, clientId, orderId, _security, Now(), status, type,
-                validity, side, quantity, price, triggerPrice, goodTilDate);
+                validity, side, quantity, priceTicks, triggerTicks, goodTilDate);
 
             _orders.Add(orderId, order);
-            var orders = (triggerPrice.HasValue ? _stops : _working);
-            var newPrice = (triggerPrice ?? price) ?? throw new Exception("error");
-            orders[side].Add(newPrice, _nextSequenceNumber, order);
+            var orders = (triggerTicks.HasValue ? _stops : _working);
+            var newPriceTicks = (triggerTicks ?? priceTicks) ?? throw new Exception("error");
+            orders[side].Add(newPriceTicks, _nextSequenceNumber, order);
             Console.WriteLine($"order added: {order}");
-            
+
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), clientId, order.ToOrder()));
             events.AddRange(Match());
@@ -144,27 +146,48 @@ namespace Circus.OrderBook
             return events;
         }
 
-        private bool TryGetLimitPrice(Side side, int protectionTicks, out decimal? price)
+        private bool TryConvertToTicks(decimal? price, out long? ticks)
         {
-            price = null;
+            if (!price.HasValue)
+            {
+                ticks = null;
+                return true;
+            }
+
+            var rawTicks = price.Value / _security.TickSize;
+            var truncatedTicks = Math.Truncate(rawTicks);
+            if (rawTicks != truncatedTicks)
+            {
+                ticks = null;
+                return false;
+            }
+
+            ticks = (long) truncatedTicks;
+            return true;
+        }
+
+        private decimal ToDecimal(long ticks) => ticks * _security.TickSize;
+
+        private bool TryGetLimitPrice(Side side, int protectionTicks, out long? priceTicks)
+        {
+            priceTicks = null;
             var opposing = _working[side == Side.Buy ? Side.Sell : Side.Buy];
             if (!opposing.Any())
                 return false;
 
             // set price as best offer + protection ticks for buy orders, best bid - protection ticks for sell orders
             // TODO: option to use best bid + protection tickets for buy orders, etc (eurex)
-            price = opposing.First().Key +
-                    ((side == Side.Buy ? 1 : -1) * (protectionTicks * _security.TickSize));
+            priceTicks = opposing.First().Key + ((side == Side.Buy ? 1 : -1) * protectionTicks);
             return true;
         }
 
-        private bool HasSufficientLiquidity(Side side, decimal price, int quantity)
+        private bool HasSufficientLiquidity(Side side, long priceTicks, int quantity)
         {
             var opposing = _working[side == Side.Buy ? Side.Sell : Side.Buy];
             var total = 0;
             foreach (var level in opposing)
             {
-                var crosses = side == Side.Buy ? level.Key <= price : level.Key >= price;
+                var crosses = side == Side.Buy ? level.Key <= priceTicks : level.Key >= priceTicks;
                 if (!crosses)
                     break;
 
@@ -192,40 +215,40 @@ namespace Circus.OrderBook
                 return RejectUpdate(clientId, orderId, OrderRejectedReason.NoChange);
             if (quantity != null && quantity < 1)
                 return RejectUpdate(clientId, orderId, OrderRejectedReason.InvalidQuantity);
-            if (price != null && price % _security.TickSize != 0)
+            if (!TryConvertToTicks(price, out var priceTicks))
                 return RejectUpdate(clientId, orderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (triggerPrice != null && triggerPrice % _security.TickSize != 0)
+            if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
                 return RejectUpdate(clientId, orderId, OrderRejectedReason.InvalidPriceIncrement);
             if (_completedOrders.ContainsKey(orderId))
                 return RejectUpdate(clientId, orderId, OrderRejectedReason.TooLateToCancel);
             if (!_orders.ContainsKey(orderId))
                 return RejectUpdate(clientId, orderId, OrderRejectedReason.OrderNotInBook);
-            
+
             var order = _orders[orderId];
 
             if (order.Status == OrderStatus.Hidden)
             {
-                var newTriggerPrice = triggerPrice ?? order.TriggerPrice;
-                var newPrice = price ?? order.Price;
-                
-                if (newTriggerPrice != null && newPrice != null && order.Side == Side.Buy && newPrice < newTriggerPrice)
+                var newTriggerTicks = triggerTicks ?? order.TriggerPrice;
+                var newPriceTicks = priceTicks ?? order.Price;
+
+                if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Buy && newPriceTicks < newTriggerTicks)
                     return RejectUpdate(clientId, orderId, OrderRejectedReason.TriggerPriceMustBeLessThanPrice);
-                if (newTriggerPrice != null && newPrice != null && order.Side == Side.Sell && newPrice > newTriggerPrice)
+                if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Sell && newPriceTicks > newTriggerTicks)
                     return RejectUpdate(clientId, orderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice);
-                
-                if (triggerPrice != null && order.Side == Side.Buy && triggerPrice <= _lastTradedPrice)
+
+                if (triggerTicks != null && order.Side == Side.Buy && triggerTicks <= _lastTradedPrice)
                     return RejectUpdate(clientId, orderId,
                         OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice);
-                if (triggerPrice != null && order.Side == Side.Sell && triggerPrice >= _lastTradedPrice)
+                if (triggerTicks != null && order.Side == Side.Sell && triggerTicks >= _lastTradedPrice)
                     return RejectUpdate(clientId, orderId,
                         OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
             }
             else
             {
                 // ignore trigger price if already triggered
-                triggerPrice = null;
+                triggerTicks = null;
             }
-            
+
             // TODO: can't update price on stop market order?
 
             if (quantity <= order.FilledQuantity)
@@ -242,25 +265,25 @@ namespace Circus.OrderBook
             }
 
             var sequenceNumber = order.SequenceNumber;
-            var isPriceChange = (triggerPrice != null && order.Status == OrderStatus.Hidden && triggerPrice != order.TriggerPrice) ||
-                                (price != null && order.Status != OrderStatus.Hidden && price != order.Price);
+            var isPriceChange = (triggerTicks != null && order.Status == OrderStatus.Hidden && triggerTicks != order.TriggerPrice) ||
+                                (priceTicks != null && order.Status != OrderStatus.Hidden && priceTicks != order.Price);
             var isQuantityIncrease = (quantity != null && quantity > order.Quantity);
 
             var orders = (order.Status == OrderStatus.Hidden ? _stops : _working);
-            
+
             if (isPriceChange || isQuantityIncrease)
             {
                 _nextSequenceNumber++;
                 sequenceNumber = _nextSequenceNumber;
-                var currentPrice = (order.Status == OrderStatus.Hidden ? order.TriggerPrice : order.Price) ??
+                var currentPriceTicks = (order.Status == OrderStatus.Hidden ? order.TriggerPrice : order.Price) ??
                                    throw new InvalidOperationException("missing price");
-                var newPrice =
-                    (order.Status == OrderStatus.Hidden ? triggerPrice ?? order.TriggerPrice : price ?? order.Price) ??
+                var updatedPriceTicks =
+                    (order.Status == OrderStatus.Hidden ? triggerTicks ?? order.TriggerPrice : priceTicks ?? order.Price) ??
                     throw new InvalidOperationException("missing price");
-                orders[order.Side].Remove(currentPrice, order.SequenceNumber);
-                orders[order.Side].Add(newPrice, sequenceNumber, order);
+                orders[order.Side].Remove(currentPriceTicks, order.SequenceNumber);
+                orders[order.Side].Add(updatedPriceTicks, sequenceNumber, order);
             }
-            order.Update(sequenceNumber, Now(), quantity, triggerPrice, price);
+            order.Update(sequenceNumber, Now(), quantity, triggerTicks, priceTicks);
             Console.WriteLine($"order updated: {order}");
 
             List<OrderBookEvent> events = new();
@@ -369,7 +392,8 @@ namespace Circus.OrderBook
                 var aggressor = buy == resting ? sell : buy;
 
                 var quantity = Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
-                var price = resting.Price ?? throw new InvalidOperationException("limit order requires price");
+                var priceTicks = resting.Price ?? throw new InvalidOperationException("limit order requires price");
+                var price = ToDecimal(priceTicks);
 
                 Console.WriteLine($"matched orders: {quantity}@{price}");
                 Console.WriteLine($"- resting   {resting}");
@@ -388,9 +412,9 @@ namespace Circus.OrderBook
                     }
                 ));
 
-                if (_lastTradedPrice != price)
+                if (_lastTradedPrice != priceTicks)
                 {
-                    _lastTradedPrice = price;
+                    _lastTradedPrice = priceTicks;
                     events.AddRange(CheckStops());
                 }
 
@@ -407,7 +431,7 @@ namespace Circus.OrderBook
             var triggered = new SortedDictionary<long, InternalOrder>();
 
             var buys = _stops[Side.Buy].FirstOrDefault();
-            while (!buys.Equals(default(KeyValuePair<decimal, SortedDictionary<long, InternalOrder>>)) &&
+            while (!buys.Equals(default(KeyValuePair<long, SortedDictionary<long, InternalOrder>>)) &&
                    buys.Key <= _lastTradedPrice)
             {
                 foreach (var (seqNum, order) in buys.Value)
@@ -419,7 +443,7 @@ namespace Circus.OrderBook
             }
 
             var sells = _stops[Side.Sell].FirstOrDefault();
-            while (!sells.Equals(default(KeyValuePair<decimal, SortedDictionary<long, InternalOrder>>)) &&
+            while (!sells.Equals(default(KeyValuePair<long, SortedDictionary<long, InternalOrder>>)) &&
                    sells.Key >= _lastTradedPrice)
             {
                 foreach (var (seqNum, order) in sells.Value)
@@ -454,9 +478,9 @@ namespace Circus.OrderBook
             foreach (var (_, order) in orders)
             {
                 // calculate price for stop market orders
-                decimal? newPrice = order.Price;
+                long? newPriceTicks = order.Price;
                 if (order.Type == OrderType.StopMarket &&
-                    !TryGetLimitPrice(order.Side, _security.MarketOrderProtectionTicks, out newPrice))
+                    !TryGetLimitPrice(order.Side, _security.MarketOrderProtectionTicks, out newPriceTicks))
                 {
                     order.Cancel(Now());
                     FinishOrder(order);
@@ -468,7 +492,7 @@ namespace Circus.OrderBook
                 }
 
                 if (order.Validity == OrderValidity.FillOrKill &&
-                    !HasSufficientLiquidity(order.Side, newPrice!.Value, order.RemainingQuantity))
+                    !HasSufficientLiquidity(order.Side, newPriceTicks!.Value, order.RemainingQuantity))
                 {
                     order.Cancel(Now());
                     FinishOrder(order);
@@ -480,10 +504,10 @@ namespace Circus.OrderBook
                 }
 
                 _nextSequenceNumber++;
-                order.ConvertToLimit(time, _nextSequenceNumber, newPrice);
+                order.ConvertToLimit(time, _nextSequenceNumber, newPriceTicks);
 
-                var limitPrice = order.Price ?? throw new Exception("missing price");
-                _working[order.Side].Add(limitPrice, order.SequenceNumber, order);
+                var limitPriceTicks = order.Price ?? throw new Exception("missing price");
+                _working[order.Side].Add(limitPriceTicks, order.SequenceNumber, order);
 
                 events.Add(new UpdateOrderConfirmed(_security, time, order.ClientId, order.ToOrder()));
             }
@@ -542,8 +566,8 @@ namespace Circus.OrderBook
 
     internal static class SortedDictionaryExtensions
     {
-        internal static void Add(this SortedDictionary<decimal, SortedDictionary<long, InternalOrder>> orders,
-            decimal price, long sequenceNumber, InternalOrder order)
+        internal static void Add(this SortedDictionary<long, SortedDictionary<long, InternalOrder>> orders,
+            long price, long sequenceNumber, InternalOrder order)
         {
             if (orders.ContainsKey(price))
             {
@@ -555,8 +579,8 @@ namespace Circus.OrderBook
             }
         }
 
-        internal static void Remove(this SortedDictionary<decimal, SortedDictionary<long, InternalOrder>> orders,
-            decimal price, long sequenceNumber)
+        internal static void Remove(this SortedDictionary<long, SortedDictionary<long, InternalOrder>> orders,
+            long price, long sequenceNumber)
         {
             orders[price].Remove(sequenceNumber);
 

--- a/Circus/OrderBook/InternalOrder.cs
+++ b/Circus/OrderBook/InternalOrder.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace Circus.OrderBook
 {
+    // Price/TriggerPrice are stored as tick counts (price / Security.TickSize), not decimal.
+    // decimal division/comparison has no hardware path, so keeping the hot comparison and
+    // dictionary-key paths on long avoids that cost; conversion back to decimal only happens
+    // at the public-API boundary (ToOrder/ToString).
     internal class InternalOrder
     {
         public long SequenceNumber { get; private set; }
@@ -18,13 +22,13 @@ namespace Circus.OrderBook
         public int Quantity { get; private set; }
         public int RemainingQuantity { get; private set; }
         public int FilledQuantity { get; private set; }
-        public decimal? Price { get; private set; }
-        public decimal? TriggerPrice { get; private set; }
+        public long? Price { get; private set; }
+        public long? TriggerPrice { get; private set; }
         public DateOnly? GoodTilDate { get; }
 
         public InternalOrder(long sequenceNumber, Guid clientId, Guid orderId, Security security, DateTime time,
-            OrderStatus status, OrderType type, OrderValidity validity, Side side, int quantity, decimal? price,
-            decimal? triggerPrice, DateOnly? goodTilDate = null)
+            OrderStatus status, OrderType type, OrderValidity validity, Side side, int quantity, long? price,
+            long? triggerPrice, DateOnly? goodTilDate = null)
         {
             SequenceNumber = sequenceNumber;
             ClientId = clientId;
@@ -44,14 +48,17 @@ namespace Circus.OrderBook
             GoodTilDate = goodTilDate;
         }
 
-        public override string ToString() => 
-            $"[Order #{OrderId} {Status} {ModifiedTime:HH:mm:ss} {Side} {Quantity}@{Price}]";
+        public override string ToString() =>
+            $"[Order #{OrderId} {Status} {ModifiedTime:HH:mm:ss} {Side} {Quantity}@{ToDecimal(Price)}]";
 
         public Order ToOrder()
         {
             return new(ClientId, OrderId, Security, CreatedTime, ModifiedTime, CompletedTime, Status, Type, Validity,
-                Side, Quantity, FilledQuantity, RemainingQuantity, Price, TriggerPrice, GoodTilDate);
+                Side, Quantity, FilledQuantity, RemainingQuantity, ToDecimal(Price), ToDecimal(TriggerPrice),
+                GoodTilDate);
         }
+
+        private decimal? ToDecimal(long? ticks) => ticks.HasValue ? ticks.Value * Security.TickSize : null;
 
         public void Cancel(DateTime time)
         {
@@ -67,7 +74,7 @@ namespace Circus.OrderBook
             Status = OrderStatus.Expired;
         }
 
-        public void Update(long sequenceNumber, DateTime time, int? quantity, decimal? triggerPrice, decimal? price)
+        public void Update(long sequenceNumber, DateTime time, int? quantity, long? triggerPrice, long? price)
         {
             SequenceNumber = sequenceNumber;
             ModifiedTime = time;
@@ -103,7 +110,7 @@ namespace Circus.OrderBook
             }
         }
 
-        public void ConvertToLimit(DateTime time, long sequenceNumber, decimal? price = null)
+        public void ConvertToLimit(DateTime time, long sequenceNumber, long? price = null)
         {
             if (price.HasValue)
             {

--- a/Circus/Util/DescendingComparer.cs
+++ b/Circus/Util/DescendingComparer.cs
@@ -1,12 +1,18 @@
+using System;
 using System.Collections.Generic;
 
 namespace Circus.Util
 {
-    internal class DescendingComparer : IComparer<decimal>
+    internal class DescendingComparer<T> : IComparer<T> where T : notnull, IComparable<T>
     {
-        public int Compare(decimal x, decimal y)
+        // CS8767: BCL's IComparer<T>.Compare is annotated T? regardless of T's own nullability,
+        // so implementing it with a notnull-constrained T always trips this warning even though
+        // T is only ever instantiated here with `long`, which can never be null.
+        #pragma warning disable CS8767
+        public int Compare(T x, T y)
         {
             return y.CompareTo(x);
         }
+        #pragma warning restore CS8767
     }
 }

--- a/Circus/Util/DescendingComparer.cs
+++ b/Circus/Util/DescendingComparer.cs
@@ -1,18 +1,12 @@
-using System;
 using System.Collections.Generic;
 
 namespace Circus.Util
 {
-    internal class DescendingComparer<T> : IComparer<T> where T : notnull, IComparable<T>
+    internal class DescendingComparer : IComparer<long>
     {
-        // CS8767: BCL's IComparer<T>.Compare is annotated T? regardless of T's own nullability,
-        // so implementing it with a notnull-constrained T always trips this warning even though
-        // T is only ever instantiated here with `long`, which can never be null.
-        #pragma warning disable CS8767
-        public int Compare(T x, T y)
+        public int Compare(long x, long y)
         {
             return y.CompareTo(x);
         }
-        #pragma warning restore CS8767
     }
 }


### PR DESCRIPTION
## Summary
- Converts internal price/trigger-price representation from `decimal` to a `long` tick count (`price / Security.TickSize`), computed once at the `CreateOrder`/`UpdateOrder` boundary and validated for on-tick integrality during that same conversion (replaces the old `price % TickSize != 0` check). Every dictionary key, `InternalOrder` field, `_lastTradedPrice`, and comparison in the matching hot path now operates on `long` instead of `decimal`. Conversion back to `decimal` happens only at the public-API boundary (`Order`/`Level` records, `OrdersMatched`/`FillOrderConfirmed` events) — the public `IOrderBook` API is unchanged.
- Removes `Console.WriteLine` debug logging from the order book's create/cancel/update/match/expire paths, found while capturing a benchmark baseline — it auto-flushes per line and was producing multi-gigabyte output for a single 100k-action replay under BenchmarkDotNet's default job, dwarfing the actual matching cost.

## Benchmark
Before/after comparison using `Circus.Benchmarks` (`OrderBookThroughputBenchmarks.ReplayTrace`, BenchmarkDotNet default job), with logging removed from both sides to isolate the tick-index effect:

| ActionCount | Mean (before) | Mean (after) | Δ Mean | Allocated (before) | Allocated (after) | Δ Alloc |
|---|---|---|---|---|---|---|
| 1,000 | 957.4 µs | 930.4 µs | −2.8% | 1.52 MB | 1.50 MB | −1.3% |
| 10,000 | 13,514.5 µs | 13,543.3 µs | +0.2% (noise) | 14.45 MB | 14.25 MB | −1.4% |
| 100,000 | 192,493.6 µs | 187,752.5 µs | −2.5% | 146.93 MB | 145.0 MB | −1.3% |

Modest, not dramatic — the tick-index change only touches the comparison/validation path, while the dominant per-action costs (a `SortedDictionary` tree-node allocation per resting order, the `InternalOrder` object, the `Order` record rebuild, `List<OrderBookEvent>`) are untouched. The real payoff is that price is now a plain `long`, which is the precondition for a follow-up change: using it as an array index instead of a `SortedDictionary` key.

## Test plan
- [x] `dotnet build Circus.sln -c Release` succeeds with 0 warnings
- [x] `dotnet test Circus.Tests` — all 163 tests pass
- [x] Before/after benchmark captured via two isolated git worktrees run sequentially (avoids CPU contention skewing results)

https://claude.ai/code/session_01K4xvmUHQF8PaZYi3QHWSAu