### PR TITLE
Replace per-level SortedDictionary with an intrusive linked list

### DIFF
--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -51,11 +51,16 @@ namespace Circus.OrderBook
         public IList<Level> GetLevels(Side side, int maxPrices)
         {
             return _working[side].EnumerateFromBest().Take(maxPrices)
-                .Select(x => new Level(
-                    ToDecimal(x.Tick),
-                    x.Level.Sum(y => y.Value.RemainingQuantity),
-                    x.Level.Count))
+                .Select(x => new Level(ToDecimal(x.Tick), SumRemaining(x.First), x.Count))
                 .ToList();
+        }
+
+        private static int SumRemaining(InternalOrder? first)
+        {
+            var total = 0;
+            for (var order = first; order != null; order = order.LevelNext)
+                total += order.RemainingQuantity;
+            return total;
         }
 
         public IList<OrderBookEvent> Process(OrderBookAction action)
@@ -153,7 +158,7 @@ namespace Circus.OrderBook
             _clientOrderIndex.Add((companyId, clientOrderId), order);
             var orders = (triggerTicks.HasValue ? _stops : _working);
             var newPriceTicks = (triggerTicks ?? priceTicks) ?? throw new Exception("error");
-            orders[side].Add(newPriceTicks, _nextSequenceNumber, order);
+            orders[side].Add(newPriceTicks, order);
 
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
@@ -212,13 +217,13 @@ namespace Circus.OrderBook
         {
             var opposing = _working[side == Side.Buy ? Side.Sell : Side.Buy];
             var total = 0;
-            foreach (var (tick, level) in opposing.EnumerateFromBest())
+            foreach (var (tick, first, _) in opposing.EnumerateFromBest())
             {
                 var crosses = side == Side.Buy ? tick <= priceTicks : tick >= priceTicks;
                 if (!crosses)
                     break;
 
-                foreach (var (_, restingOrder) in level)
+                for (var restingOrder = first; restingOrder != null; restingOrder = restingOrder.LevelNext)
                 {
                     if (TryGetSelfMatchInstruction(restingOrder, selfMatchPreventionId,
                             selfMatchPreventionInstruction, out var instruction))
@@ -341,8 +346,8 @@ namespace Circus.OrderBook
                 var updatedPriceTicks =
                     (order.Status == OrderStatus.Hidden ? triggerTicks ?? order.TriggerPrice : priceTicks ?? order.Price) ??
                     throw new InvalidOperationException("missing price");
-                orders[order.Side].Remove(currentPriceTicks, order.SequenceNumber);
-                orders[order.Side].Add(updatedPriceTicks, sequenceNumber, order);
+                orders[order.Side].Remove(currentPriceTicks, order);
+                orders[order.Side].Add(updatedPriceTicks, order);
             }
             order.Update(sequenceNumber, Now(), quantity, triggerTicks, priceTicks, clientOrderId);
             _clientOrderIndex[(companyId, clientOrderId)] = order;
@@ -423,12 +428,12 @@ namespace Circus.OrderBook
             if (order.Type == OrderType.StopLimit || order.Type == OrderType.StopMarket)
             {
                 var price = order.TriggerPrice ?? throw new InvalidOperationException("stop order missing stop price");
-                _stops[order.Side].Remove(price, order.SequenceNumber);
+                _stops[order.Side].Remove(price, order);
             }
             else
             {
                 var price = order.Price ?? throw new InvalidOperationException("limit order missing price");
-                _working[order.Side].Remove(price, order.SequenceNumber);
+                _working[order.Side].Remove(price, order);
             }
 
             FinishOrder(order);
@@ -450,7 +455,7 @@ namespace Circus.OrderBook
         }
 
         private InternalOrder? BestOrder(Side side) =>
-            _working[side].TryGetBest(out _, out var level) ? level.FirstOrDefault().Value : null;
+            _working[side].TryGetBest(out _, out var order) ? order : null;
 
         private IEnumerable<OrderBookEvent> Match()
         {
@@ -551,21 +556,17 @@ namespace Circus.OrderBook
             var time = Now();
             var triggered = new SortedDictionary<long, InternalOrder>();
 
-            while (_stops[Side.Buy].TryGetBest(out var buyTick, out var buyLevel) && buyTick <= _lastTradedPrice)
+            while (_stops[Side.Buy].TryGetBest(out var buyTick, out var buyFirst) && buyTick <= _lastTradedPrice)
             {
-                foreach (var (seqNum, order) in buyLevel)
-                {
-                    triggered.Add(seqNum, order);
-                }
+                for (var order = buyFirst; order != null; order = order.LevelNext)
+                    triggered.Add(order.SequenceNumber, order);
                 _stops[Side.Buy].RemoveLevel(buyTick);
             }
 
-            while (_stops[Side.Sell].TryGetBest(out var sellTick, out var sellLevel) && sellTick >= _lastTradedPrice)
+            while (_stops[Side.Sell].TryGetBest(out var sellTick, out var sellFirst) && sellTick >= _lastTradedPrice)
             {
-                foreach (var (seqNum, order) in sellLevel)
-                {
-                    triggered.Add(seqNum, order);
-                }
+                for (var order = sellFirst; order != null; order = order.LevelNext)
+                    triggered.Add(order.SequenceNumber, order);
                 _stops[Side.Sell].RemoveLevel(sellTick);
             }
 
@@ -623,7 +624,7 @@ namespace Circus.OrderBook
                 order.ConvertToLimit(time, _nextSequenceNumber, newPriceTicks);
 
                 var limitPriceTicks = order.Price ?? throw new Exception("missing price");
-                _working[order.Side].Add(limitPriceTicks, order.SequenceNumber, order);
+                _working[order.Side].Add(limitPriceTicks, order);
 
                 events.Add(new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
                     order.ClientOrderId));

--- a/Circus/OrderBook/InternalOrder.cs
+++ b/Circus/OrderBook/InternalOrder.cs
@@ -29,6 +29,12 @@ namespace Circus.OrderBook
         public string? SelfMatchPreventionId { get; }
         public SelfMatchPreventionInstruction? SelfMatchPreventionInstruction { get; }
 
+        // intrusive doubly-linked-list pointers used by PriceLadder for the price level currently
+        // holding this order (an order only ever rests in one level at a time, so a single pair of
+        // pointers is unambiguous). Avoids allocating a separate node object per order.
+        internal InternalOrder? LevelNext { get; set; }
+        internal InternalOrder? LevelPrev { get; set; }
+
         public InternalOrder(long sequenceNumber, string companyId, string clientOrderId, Security security, DateTime time,
             OrderStatus status, OrderType type, OrderValidity validity, Side side, int quantity, long? price,
             long? triggerPrice, DateOnly? goodTilDate = null, string? selfMatchPreventionId = null,

--- a/Circus/OrderBook/PriceLadder.cs
+++ b/Circus/OrderBook/PriceLadder.cs
@@ -8,13 +8,16 @@ namespace Circus.OrderBook
     // level access instead of an O(log n) tree lookup, with a cached best-price index so callers
     // don't need to scan the array to find the touch.
     //
-    // This type has no notion of a price band/limit — it grows on demand (like List<T>'s doubling)
-    // if an order arrives outside the currently allocated range, so it stays correct even when no
-    // session price band was configured, organically sizing itself to whatever ticks actually show
-    // up. Reset() is purely an optimization for the common case where the eventual range is known
-    // up front (a configured session band): it pre-sizes the array so no growth/copy happens during
-    // the session. Band enforcement (rejecting out-of-range orders) is a separate concern handled by
-    // InMemoryOrderBook.
+    // Each price level is an intrusive doubly-linked list threaded through InternalOrder.LevelNext/
+    // LevelPrev rather than a System.Collections.Generic.LinkedList<T> — that would still allocate a
+    // separate LinkedListNode<InternalOrder> wrapper per order, which is exactly the kind of
+    // per-order allocation this replaces the SortedDictionary to avoid. With the pointers embedded
+    // directly on InternalOrder (and per-level state as three more parallel arrays alongside
+    // _minTick), a newly-touched price level costs nothing beyond flipping array slots — no node
+    // object, no level container object, at all.
+    //
+    // It grows on demand (like List<T>'s doubling) if an order arrives outside the currently
+    // allocated range, so it stays correct with no pre-sizing at all.
     internal sealed class PriceLadder(bool descending)
     {
         private const int InitialRadius = 64;
@@ -22,57 +25,59 @@ namespace Circus.OrderBook
         // true for sides whose priority order runs from high tick to low tick (Side.Buy in the
         // working book, Side.Sell in the stops book) — mirrors what DescendingComparer did.
 
-        private SortedDictionary<long, InternalOrder>?[] _levels = [];
+        private InternalOrder?[] _heads = [];
+        private InternalOrder?[] _tails = [];
+        private int[] _counts = [];
         private long _minTick;
-        private int _bestIndex; // index into _levels of the best (nearest-to-crossing) occupied slot; _levels.Length means "none"
-        private int _count;
+        private int _bestIndex; // index of the best (nearest-to-crossing) occupied slot; _heads.Length means "none"
 
-        public bool Any => _count > 0;
-
-        // Wipes the index and pre-sizes it to [centerTick - radiusTicks, centerTick + radiusTicks].
-        // Callers are responsible for relocating (or cancelling) any orders that were resting before
-        // calling this — nothing is preserved across a Reset.
-        public void Reset(long centerTick, int radiusTicks)
-        {
-            var length = checked((int) (2L * radiusTicks + 1));
-            _levels = new SortedDictionary<long, InternalOrder>?[length];
-            _minTick = centerTick - radiusTicks;
-            _count = 0;
-            _bestIndex = _levels.Length;
-        }
-
-        public void Add(long tick, long sequenceNumber, InternalOrder order)
+        public void Add(long tick, InternalOrder order)
         {
             EnsureCapacity(tick);
             var index = (int) (tick - _minTick);
 
-            if (_levels[index] == null)
+            var tail = _tails[index];
+            order.LevelPrev = tail;
+            order.LevelNext = null;
+
+            if (tail != null)
             {
-                _levels[index] = new SortedDictionary<long, InternalOrder>();
-                _count++;
+                tail.LevelNext = order;
+            }
+            else
+            {
+                _heads[index] = order;
                 if (IsBetter(index, _bestIndex))
                 {
                     _bestIndex = index;
                 }
             }
 
-            _levels[index]!.Add(sequenceNumber, order);
+            _tails[index] = order;
+            _counts[index]++;
         }
 
-        public void Remove(long tick, long sequenceNumber)
+        public void Remove(long tick, InternalOrder order)
         {
             var index = (int) (tick - _minTick);
-            var level = _levels[index] ?? throw new InvalidOperationException("no orders at this price");
-            level.Remove(sequenceNumber);
 
-            if (level.Count == 0)
+            if (order.LevelPrev != null)
+                order.LevelPrev.LevelNext = order.LevelNext;
+            else
+                _heads[index] = order.LevelNext;
+
+            if (order.LevelNext != null)
+                order.LevelNext.LevelPrev = order.LevelPrev;
+            else
+                _tails[index] = order.LevelPrev;
+
+            order.LevelNext = null;
+            order.LevelPrev = null;
+            _counts[index]--;
+
+            if (_heads[index] == null && index == _bestIndex)
             {
-                _levels[index] = null;
-                _count--;
-                if (index == _bestIndex)
-                {
-                    AdvanceBest();
-                }
+                AdvanceBest();
             }
         }
 
@@ -80,70 +85,76 @@ namespace Circus.OrderBook
         public void RemoveLevel(long tick)
         {
             var index = (int) (tick - _minTick);
-            if (_levels[index] == null)
+            if (_heads[index] == null)
                 return;
 
-            _levels[index] = null;
-            _count--;
+            _heads[index] = null;
+            _tails[index] = null;
+            _counts[index] = 0;
             if (index == _bestIndex)
             {
                 AdvanceBest();
             }
         }
 
-        public bool TryGetBest(out long tick, out SortedDictionary<long, InternalOrder> level)
+        public bool TryGetBest(out long tick, out InternalOrder? firstOrder)
         {
-            if (_bestIndex >= _levels.Length || _levels[_bestIndex] == null)
+            if (_bestIndex >= _heads.Length || _heads[_bestIndex] == null)
             {
                 tick = 0;
-                level = null!;
+                firstOrder = null;
                 return false;
             }
 
             tick = _minTick + _bestIndex;
-            level = _levels[_bestIndex]!;
+            firstOrder = _heads[_bestIndex];
             return true;
         }
 
-        public IEnumerable<(long Tick, SortedDictionary<long, InternalOrder> Level)> EnumerateFromBest()
+        // Yields, from best outward, each occupied level's tick, its first (FIFO-earliest) order —
+        // walk `.LevelNext` from there to see the rest — and its order count.
+        public IEnumerable<(long Tick, InternalOrder First, int Count)> EnumerateFromBest()
         {
             var step = descending ? -1 : 1;
-            for (var i = _bestIndex; i >= 0 && i < _levels.Length; i += step)
+            for (var i = _bestIndex; i >= 0 && i < _heads.Length; i += step)
             {
-                if (_levels[i] != null)
+                if (_heads[i] != null)
                 {
-                    yield return (_minTick + i, _levels[i]!);
+                    yield return (_minTick + i, _heads[i]!, _counts[i]);
                 }
             }
         }
 
         private bool IsBetter(int candidateIndex, int currentBestIndex) =>
-            currentBestIndex >= _levels.Length ||
+            currentBestIndex >= _heads.Length ||
             (descending ? candidateIndex > currentBestIndex : candidateIndex < currentBestIndex);
 
         private void AdvanceBest()
         {
             var step = descending ? -1 : 1;
             var i = _bestIndex + step;
-            while (i >= 0 && i < _levels.Length && _levels[i] == null)
+            while (i >= 0 && i < _heads.Length && _heads[i] == null)
             {
                 i += step;
             }
 
-            _bestIndex = (i < 0 || i >= _levels.Length) ? _levels.Length : i;
+            _bestIndex = (i < 0 || i >= _heads.Length) ? _heads.Length : i;
         }
 
         private void EnsureCapacity(long tick)
         {
-            if (_levels.Length == 0)
+            if (_heads.Length == 0)
             {
                 _minTick = tick - InitialRadius;
-                _levels = new SortedDictionary<long, InternalOrder>?[InitialRadius * 2 + 1];
-                _bestIndex = _levels.Length;
+                var length = InitialRadius * 2 + 1;
+                _heads = new InternalOrder?[length];
+                _tails = new InternalOrder?[length];
+                _counts = new int[length];
+                _bestIndex = _heads.Length;
                 return;
             }
 
-            var maxTick = _minTick + _levels.Length - 1;
+            var maxTick = _minTick + _heads.Length - 1;
             if (tick >= _minTick && tick <= maxTick)
                 return;
 
@@ -153,42 +164,49 @@ namespace Circus.OrderBook
             if (tick < _minTick)
             {
                 var deficit = _minTick - tick;
-                newMin = _minTick - Math.Max(deficit, _levels.Length);
+                newMin = _minTick - Math.Max(deficit, _heads.Length);
             }
 
             if (tick > maxTick)
             {
                 var deficit = tick - maxTick;
-                newMax = maxTick + Math.Max(deficit, _levels.Length);
+                newMax = maxTick + Math.Max(deficit, _heads.Length);
             }
 
             Grow(newMin, newMax);
         }
 
-        // Like Reset, but preserves existing levels — used for organic on-demand growth mid-session,
-        // as opposed to Reset's deliberate wipe at a session boundary.
+        // Preserves existing levels while growing the backing arrays to cover [newMin, newMax].
         private void Grow(long newMin, long newMax)
         {
-            var newLevels = new SortedDictionary<long, InternalOrder>?[checked((int) (newMax - newMin + 1))];
+            var newLength = checked((int) (newMax - newMin + 1));
+            var newHeads = new InternalOrder?[newLength];
+            var newTails = new InternalOrder?[newLength];
+            var newCounts = new int[newLength];
 
-            for (var i = 0; i < _levels.Length; i++)
+            for (var i = 0; i < _heads.Length; i++)
             {
-                if (_levels[i] == null)
+                if (_heads[i] == null)
                     continue;
 
-                newLevels[(_minTick + i) - newMin] = _levels[i];
+                var newIndex = (int) ((_minTick + i) - newMin);
+                newHeads[newIndex] = _heads[i];
+                newTails[newIndex] = _tails[i];
+                newCounts[newIndex] = _counts[i];
             }
 
-            _levels = newLevels;
+            _heads = newHeads;
+            _tails = newTails;
+            _counts = newCounts;
             _minTick = newMin;
 
             // Grow is rare (amortized via doubling), so a full recompute here is cheap relative to
             // how infrequently it happens.
-            _bestIndex = _levels.Length;
+            _bestIndex = _heads.Length;
             var step = descending ? -1 : 1;
-            for (var i = descending ? _levels.Length - 1 : 0; i >= 0 && i < _levels.Length; i += step)
+            for (var i = descending ? _heads.Length - 1 : 0; i >= 0 && i < _heads.Length; i += step)
             {
-                if (_levels[i] != null)
+                if (_heads[i] != null)
                 {
                     _bestIndex = i;
                     break;


### PR DESCRIPTION
## Summary
`PriceLadder`'s per-tick storage was still a `SortedDictionary<long, InternalOrder>` keyed by sequence number, existing purely to get FIFO order within a price level. But every insertion site (`CreateOrder`, the price/quantity-change branch in `UpdateOrder`, and `TriggerStops`' conversion-to-limit) already assigns a freshly-incremented, monotonically increasing sequence number immediately before adding — so "insert in sequence order" was always equivalent to "append to the end." The `SortedDictionary` was sorting something that arrives pre-sorted.

Replaces it with a doubly-linked list threaded directly through two new fields on `InternalOrder` (`LevelNext`/`LevelPrev`) rather than `System.Collections.Generic.LinkedList<T>` — that would still allocate a separate `LinkedListNode<InternalOrder>` wrapper per order, exactly the kind of per-order allocation this is meant to eliminate. An order only ever rests in one level at a time, so a single pair of pointers is unambiguous, and a newly-touched price level now costs nothing beyond flipping array slots (three parallel arrays — head/tail/count per tick — alongside the existing tick-offset array from #20).

Rebased on top of #21 (self-trade prevention): `HasSufficientLiquidity`'s STP-aware per-order walk is preserved, just traversing via `LevelNext` instead of the old `SortedDictionary` iteration.

## Benchmark
Before/after using `Circus.Benchmarks.OrderBookThroughputBenchmarks.ReplayTrace` (BenchmarkDotNet default job), isolated worktrees run sequentially — baseline is #20's array-of-`SortedDictionary` `PriceLadder`:

| ActionCount | Mean (before) | Mean (after) | Δ Mean | Allocated (before) | Allocated (after) | Δ Alloc |
|---|---|---|---|---|---|---|
| 1,000 | 617.6 µs | 417.5 µs | **−32.4%** | 1.17 MB | 874.7 KB | **−27.0%** |
| 10,000 | 12,144.0 µs | 8,324.6 µs | **−31.5%** | 10.95 MB | 8,219.7 KB | **−26.7%** |
| 100,000 | 183,052.3 µs | 138,713.4 µs | **−24.2%** | 110.14 MB | 81,085.9 KB | **−28.1%** |

This eliminates the last per-order allocation in the resting-order storage path — no `SortedDictionary` entry, no `LinkedListNode<T>` wrapper, just two reference fields on an object that was being allocated anyway.

## Test plan
- [x] `dotnet build Circus.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test Circus.Tests` — all 188 tests pass (including #21's self-trade prevention tests)
- [x] Before/after benchmark captured via isolated git worktrees run sequentially (same methodology as #18/#20)

https://claude.ai/code/session_01K4xvmUHQF8PaZYi3QHWSAu