### PR TITLE
Collapse nested event-list allocations into a shared accumulator

### DIFF
--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -171,7 +171,7 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
-            events.AddRange(Match());
+            Match(events);
 
             if (order.Validity == OrderValidity.FillAndKill && order.Status == OrderStatus.Working)
                 events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
@@ -374,7 +374,7 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new UpdateOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId));
-            events.AddRange(Match());
+            Match(events);
             return events;
         }
 
@@ -477,14 +477,13 @@ namespace Circus.OrderBook
         private InternalOrder? BestOrder(Side side) =>
             _working[side].TryGetBest(out _, out var order) ? order : null;
 
-        private IEnumerable<OrderBookEvent> Match()
+        private void Match(List<OrderBookEvent> events)
         {
             if (_status != OrderBookStatus.Open)
             {
-                return Array.Empty<OrderBookEvent>();
+                return;
             }
 
-            var events = new List<OrderBookEvent>();
             var time = Now();
 
             var buy = BestOrder(Side.Buy);
@@ -538,14 +537,12 @@ namespace Circus.OrderBook
                 {
                     _lastTradedPrice = priceTicks;
                     _bandReferencePriceTicks = priceTicks;
-                    events.AddRange(CheckStops());
+                    CheckStops(events);
                 }
 
                 buy = BestOrder(Side.Buy);
                 sell = BestOrder(Side.Sell);
             }
-
-            return events;
         }
 
         // Two orders are a prevented self-match only if both carry the same non-null
@@ -572,7 +569,7 @@ namespace Circus.OrderBook
             return true;
         }
 
-        private IEnumerable<OrderBookEvent> CheckStops()
+        private void CheckStops(List<OrderBookEvent> events)
         {
             var time = Now();
             var triggered = new SortedDictionary<long, InternalOrder>();
@@ -591,12 +588,10 @@ namespace Circus.OrderBook
                 _stops[Side.Sell].RemoveLevel(sellTick);
             }
 
-            var events = new List<OrderBookEvent>();
-
             if (triggered.Any())
             {
-                events.AddRange(TriggerStops(triggered, time));
-                events.AddRange(Match());
+                TriggerStops(triggered, time, events);
+                Match(events);
 
                 foreach (var order in triggered.Values)
                 {
@@ -604,14 +599,11 @@ namespace Circus.OrderBook
                         events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
                 }
             }
-
-            return events;
         }
 
-        private IList<OrderBookEvent> TriggerStops(SortedDictionary<long, InternalOrder> orders, DateTime time)
+        private void TriggerStops(SortedDictionary<long, InternalOrder> orders, DateTime time,
+            List<OrderBookEvent> events)
         {
-            var events = new List<OrderBookEvent>();
-
             foreach (var (_, order) in orders)
             {
                 // calculate price for stop market orders
@@ -650,8 +642,6 @@ namespace Circus.OrderBook
                 events.Add(new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
                     order.ClientOrderId));
             }
-
-            return events;
         }
 
         public IList<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null)
@@ -681,7 +671,7 @@ namespace Circus.OrderBook
         {
             _status = OrderBookStatus.Open;
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
-            events.AddRange(Match());
+            Match(events);
             return events;
         }
 


### PR DESCRIPTION
## Summary
`Match`/`CheckStops`/`TriggerStops` each built and returned their own `List<OrderBookEvent>`, merged into the caller's list via `.AddRange(...)`. For a single aggressive order that cascades through several triggered stop levels (`Match` → `CheckStops` → `TriggerStops`, then back into `Match` for the resulting trades), that's several `List<T>` + backing-array allocations that exist only to be copied into their caller and immediately discarded.

They now take a shared `List<OrderBookEvent> events` accumulator and append directly into it, returning `void` instead. All three are private methods, so this is purely internal plumbing — no public API change, and event ordering is preserved exactly (every `Add`/`AddRange` becomes an `Add`/direct call in the identical relative position, just against a shared list instead of a local one). Confirmed by the full test suite passing unchanged.

## Benchmark
Before/after using `Circus.Benchmarks.OrderBookThroughputBenchmarks.ReplayTrace` (BenchmarkDotNet default job), isolated worktrees run sequentially — baseline is #22's intrusive-linked-list `PriceLadder`:

| ActionCount | Mean (before) | Mean (after) | Δ Mean | Allocated (before) | Allocated (after) | Δ Alloc |
|---|---|---|---|---|---|---|
| 1,000 | 400.2 µs | 394.2 µs | −1.5% | 908.96 KB | 869.47 KB | **−4.3%** |
| 10,000 | 8,927.2 µs | 8,167.3 µs | −8.5% | 8,551.5 KB | 8,184.2 KB | **−4.3%** |
| 100,000 | 139,470.2 µs | 132,677.7 µs | −4.9% | 84,454.8 KB | 80,780.3 KB | **−4.3%** |

Modest, as expected — this only touches event-list plumbing, not order storage, so it's a much smaller effect than #18/#20/#22. Allocation reduction is a very consistent ~4.3% across all three trace sizes.

## Test plan
- [x] `dotnet build Circus.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test Circus.Tests` — all 188 tests pass unchanged
- [x] Before/after benchmark captured via isolated git worktrees run sequentially (same methodology as #18/#20/#22)

https://claude.ai/code/session_01K4xvmUHQF8PaZYi3QHWSAu