### PR TITLE
Add auction uncrossing

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -1,0 +1,246 @@
+using System;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    [TestFixture]
+    public class InMemoryOrderBookAuctionTests
+    {
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+        private static readonly string CompanyId3 = "Company3";
+        private static readonly string CompanyId4 = "Company4";
+        private static readonly string CompanyId5 = "Company5";
+
+        private static readonly string OrderId1 = "Order1";
+        private static readonly string OrderId2 = "Order2";
+        private static readonly string OrderId3 = "Order3";
+        private static readonly string OrderId4 = "Order4";
+        private static readonly string OrderId5 = "Order5";
+
+        private static TestTimeProvider TimeProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+        }
+
+        [Test]
+        public void Opening_PicksMaxVolumePrice_AcrossMultipleLevels_WithPriceImprovement()
+        {
+            // arrange - best bid 140 vs best offer 110 would only cross 5 at the touch, but the
+            // volume-maximizing single price is 120, clearing 11: the 140 and 130 buys fully fill
+            // (price improvement - they pay 120, not their own higher limit), the 110 and 120
+            // sells fully fill (also price improvement - they get 120, not their own lower limit),
+            // and the 120 buy (the marginal order) only partially fills for the 1 unit left over
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+
+            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 140);
+            book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 7, 130);
+            book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 15, 120);
+            book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 5, 110);
+            book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 6, 120);
+            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 20, 130);
+
+            // act
+            var events = book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert - every fill in this batch prints at the single auction price of 120
+            Assert.IsInstanceOf<StatusChanged>(events[0]);
+            for (var i = 1; i < events.Count; i++)
+            {
+                var matched = events[i] as OrdersMatched;
+                Assert.IsNotNull(matched);
+                Assert.AreEqual(120, matched.Price);
+            }
+
+            var totalQuantity = 0;
+            for (var i = 1; i < events.Count; i++)
+                totalQuantity += ((OrdersMatched) events[i]).Quantity;
+            Assert.AreEqual(11, totalQuantity);
+
+            // the marginal buy order (120) is left resting, partially filled
+            var buyLevels = book.GetLevels(Side.Buy, 10);
+            Assert.AreEqual(1, buyLevels.Count);
+            Assert.AreEqual(120, buyLevels[0].Price);
+            Assert.AreEqual(14, buyLevels[0].Quantity);
+
+            // the 110 and 120 sells fully cleared (11 total); the 130 sell (outside the clearing
+            // price's crossing range) is untouched
+            var sellLevels = book.GetLevels(Side.Sell, 10);
+            Assert.AreEqual(1, sellLevels.Count);
+            Assert.AreEqual(130, sellLevels[0].Price);
+            Assert.AreEqual(20, sellLevels[0].Quantity);
+        }
+
+        [Test]
+        public void Opening_TiedCandidates_DefaultsToCmeDirectionRule()
+        {
+            // arrange - 120 and 130 tie for max executable volume (10 each), with the surplus on
+            // the sell side at both - CME's rule picks the lowest of the tied prices in that case
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+
+            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 140);
+            book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 7, 130);
+            book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 15, 110);
+            book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 5, 100);
+            book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 6, 120);
+            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 20, 140);
+
+            // act
+            var events = book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert
+            var matched = events[1] as OrdersMatched;
+            Assert.IsNotNull(matched);
+            Assert.AreEqual(120, matched.Price);
+        }
+
+        [Test]
+        public void Opening_TiedCandidates_ReferencePriceBreaksTieOverCmeDirectionRule()
+        {
+            // arrange - same tie as above (120 vs 130), but with a reference price seeded at 130
+            // (must be tick-aligned to TickSize 10) - that should win over the default rule
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen, 130);
+
+            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 140);
+            book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 7, 130);
+            book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 15, 110);
+            book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 5, 100);
+            book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 6, 120);
+            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 20, 140);
+
+            // act
+            var events = book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert
+            var matched = events[1] as OrdersMatched;
+            Assert.IsNotNull(matched);
+            Assert.AreEqual(130, matched.Price);
+        }
+
+        [Test]
+        public void Opening_NoCrossingBook_NoAuctionPrint()
+        {
+            // arrange
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
+
+            // act
+            var events = book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert
+            Assert.AreEqual(1, events.Count);
+            Assert.IsInstanceOf<StatusChanged>(events[0]);
+            var buyLevels = book.GetLevels(Side.Buy, 10);
+            Assert.AreEqual(1, buyLevels.Count);
+            Assert.AreEqual(5, buyLevels[0].Quantity);
+        }
+
+        [Test]
+        public void TryGetIndicativeAuctionPrice_ReflectsLiveStateDuringPreOpen()
+        {
+            // arrange
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+
+            // assert - nothing resting yet
+            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+
+            // act - one-sided book, still no cross
+            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 10, 100);
+            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+
+            // act - a crossing sell arrives
+            book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 10, 100);
+            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out var price, out var quantity));
+            Assert.AreEqual(100, price);
+            Assert.AreEqual(10, quantity);
+
+            // act - cancelling the crossing sell removes the cross again
+            book.CancelOrder(CompanyId2, "Cancel1", OrderId2);
+            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+        }
+
+        [Test]
+        public void VolatilityBandBreach_PausesInsteadOfRejecting_StopElectsOnReopen()
+        {
+            // arrange - continuous trading establishes a reference price of 100, then a resting
+            // sell stop (trigger 90) is added
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open);
+            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
+            book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
+            TimeProvider.SetCurrentTime(Now2);
+            book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 5, 80, 90);
+
+            // act - an order 100 away from the 100 reference breaches the 50-wide volatility band;
+            // it doesn't cross anything (isolated at 200) so it's just accepted and rests
+            TimeProvider.SetCurrentTime(Now3);
+            var events = book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 10, 200);
+
+            // assert - accepted (not rejected) and the book pauses
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+            Assert.IsInstanceOf<StatusChanged>(events[1]);
+            Assert.AreEqual(OrderBookStatus.PreOpen, ((StatusChanged) events[1]).Status);
+            Assert.AreEqual(OrderBookStatus.PreOpen, book.Status);
+
+            // orders can still be entered/cancelled while paused
+            TimeProvider.SetCurrentTime(Now4);
+            book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Buy, 10, 90);
+            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 10, 90);
+
+            // act - ending the pause runs the same uncrossing pass; the two 90 orders clear there
+            // (the isolated 200 sell doesn't cross), moving the last traded price to 90, which
+            // elects the resting stop (trigger 90, satisfied by <= 90)
+            var reopenEvents = book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert
+            var matched = reopenEvents[1] as OrdersMatched;
+            Assert.IsNotNull(matched);
+            Assert.AreEqual(90, matched.Price);
+
+            var stopElected = reopenEvents[2] as UpdateOrderConfirmed;
+            Assert.IsNotNull(stopElected);
+            Assert.AreEqual(OrderId3, stopElected.Order.ClientOrderId);
+            Assert.AreEqual(OrderStatus.Working, stopElected.Order.Status);
+        }
+
+        [Test]
+        public void PriceBandTicksOnly_NoVolatilityAuctionBandConfigured_Unaffected()
+        {
+            // arrange - #23's hard-reject band still works exactly as before when
+            // VolatilityAuctionBandTicks isn't set
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+
+            // act
+            var events = book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 200);
+
+            // assert - rejected outright, no pause
+            var rejected = events[0] as CreateOrderRejected;
+            Assert.IsNotNull(rejected);
+            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        }
+    }
+}

--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -19,12 +19,17 @@ namespace Circus.Tests.OrderBook
         private static readonly string CompanyId3 = "Company3";
         private static readonly string CompanyId4 = "Company4";
         private static readonly string CompanyId5 = "Company5";
+        private static readonly string CompanyId6 = "Company6";
 
         private static readonly string OrderId1 = "Order1";
         private static readonly string OrderId2 = "Order2";
         private static readonly string OrderId3 = "Order3";
         private static readonly string OrderId4 = "Order4";
         private static readonly string OrderId5 = "Order5";
+        private static readonly string OrderId6 = "Order6";
+        private static readonly string OrderId7 = "Order7";
+        private static readonly string OrderId8 = "Order8";
+        private static readonly string CancelId1 = "Cancel1";
 
         private static TestTimeProvider TimeProvider;
 
@@ -51,7 +56,7 @@ namespace Circus.Tests.OrderBook
             book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 15, 120);
             book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 5, 110);
             book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 6, 120);
-            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 20, 130);
+            book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Sell, 20, 130);
 
             // act
             var events = book.UpdateStatus(OrderBookStatus.Open);
@@ -98,7 +103,7 @@ namespace Circus.Tests.OrderBook
             book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 15, 110);
             book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 5, 100);
             book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 6, 120);
-            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 20, 140);
+            book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Sell, 20, 140);
 
             // act
             var events = book.UpdateStatus(OrderBookStatus.Open);
@@ -123,7 +128,7 @@ namespace Circus.Tests.OrderBook
             book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 15, 110);
             book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 5, 100);
             book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 6, 120);
-            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 20, 140);
+            book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Sell, 20, 140);
 
             // act
             var events = book.UpdateStatus(OrderBookStatus.Open);
@@ -176,7 +181,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(10, quantity);
 
             // act - cancelling the crossing sell removes the cross again
-            book.CancelOrder(CompanyId2, "Cancel1", OrderId2);
+            book.CancelOrder(CompanyId2, CancelId1, OrderId2);
             Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
         }
 
@@ -234,8 +239,8 @@ namespace Circus.Tests.OrderBook
 
             // orders can still be entered/cancelled while paused
             TimeProvider.SetCurrentTime(Now4);
-            book.CreateOrder(CompanyId1, "Order1b", OrderValidity.Day, Side.Buy, 10, 90);
-            book.CreateOrder(CompanyId2, "Order2b", OrderValidity.Day, Side.Sell, 10, 90);
+            book.CreateOrder(CompanyId1, OrderId7, OrderValidity.Day, Side.Buy, 10, 90);
+            book.CreateOrder(CompanyId2, OrderId8, OrderValidity.Day, Side.Sell, 10, 90);
 
             // act - ending the pause (seeding a fresh reference of 90) runs the same uncrossing
             // pass, clearing at 90 and moving the last traded price there, which elects the

--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
@@ -180,10 +181,31 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
-        public void VolatilityBandBreach_PausesInsteadOfRejecting_StopElectsOnReopen()
+        public void RestingOrderOutsideBand_WithoutCrossingAnything_DoesNotPause()
+        {
+            // arrange - a resting limit order sitting far from the market doesn't represent any
+            // actual price movement by itself; only an executed trade at an extreme price should
+            // pause the book. This order doesn't cross anything (isolated at 200, nothing on the
+            // opposing side), so it must not trigger a pause just for being entered.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+
+            // act
+            var events = book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 10, 200);
+
+            // assert - accepted normally, no pause
+            Assert.AreEqual(1, events.Count);
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        }
+
+        [Test]
+        public void VolatilityBandBreach_OnActualTrade_PausesInsteadOfExecuting_StopElectsOnReopen()
         {
             // arrange - continuous trading establishes a reference price of 100, then a resting
-            // sell stop (trigger 90) is added
+            // sell stop (trigger 90) is added, plus a resting sell at 200 that hasn't crossed
+            // anything yet (so hasn't paused anything, per the test above)
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
             var book = new InMemoryOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
@@ -191,37 +213,40 @@ namespace Circus.Tests.OrderBook
             book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
             book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 5, 80, 90);
+            book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 10, 200);
 
-            // act - an order 100 away from the 100 reference breaches the 50-wide volatility band;
-            // it doesn't cross anything (isolated at 200) so it's just accepted and rests
+            // act - a buy at 200 would actually cross and trade against the resting 200 sell, at a
+            // price 100 away from the 100 reference - breaching the 50-wide volatility band. The
+            // trade is prevented (not executed) and the book pauses instead; neither order fills
             TimeProvider.SetCurrentTime(Now3);
-            var events = book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 10, 200);
+            var events = book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Buy, 10, 200);
 
-            // assert - accepted (not rejected) and the book pauses
+            // assert
+            Assert.AreEqual(2, events.Count);
             Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.IsInstanceOf<StatusChanged>(events[1]);
             Assert.AreEqual(OrderBookStatus.PreOpen, ((StatusChanged) events[1]).Status);
             Assert.AreEqual(OrderBookStatus.PreOpen, book.Status);
 
+            var sellLevels = book.GetLevels(Side.Sell, 10);
+            Assert.AreEqual(1, sellLevels.Count);
+            Assert.AreEqual(200, sellLevels[0].Price);
+            Assert.AreEqual(10, sellLevels[0].Quantity); // untouched - the trade was prevented
+
             // orders can still be entered/cancelled while paused
             TimeProvider.SetCurrentTime(Now4);
-            book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Buy, 10, 90);
-            book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Sell, 10, 90);
+            book.CreateOrder(CompanyId1, "Order1b", OrderValidity.Day, Side.Buy, 10, 90);
+            book.CreateOrder(CompanyId2, "Order2b", OrderValidity.Day, Side.Sell, 10, 90);
 
-            // act - ending the pause runs the same uncrossing pass; the two 90 orders clear there
-            // (the isolated 200 sell doesn't cross), moving the last traded price to 90, which
-            // elects the resting stop (trigger 90, satisfied by <= 90)
-            var reopenEvents = book.UpdateStatus(OrderBookStatus.Open);
+            // act - ending the pause (seeding a fresh reference of 90) runs the same uncrossing
+            // pass, clearing at 90 and moving the last traded price there, which elects the
+            // resting stop (trigger 90, satisfied by <= 90)
+            var reopenEvents = book.UpdateStatus(OrderBookStatus.Open, 90);
 
             // assert
-            var matched = reopenEvents[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(90, matched.Price);
-
-            var stopElected = reopenEvents[2] as UpdateOrderConfirmed;
-            Assert.IsNotNull(stopElected);
-            Assert.AreEqual(OrderId3, stopElected.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Working, stopElected.Order.Status);
+            Assert.IsTrue(reopenEvents.OfType<OrdersMatched>().Any(m => m.Price == 90));
+            var stopElected = reopenEvents.Any(e => e is UpdateOrderConfirmed u && u.Order.ClientOrderId == OrderId3) ||
+                reopenEvents.OfType<OrdersMatched>().Any(m => m.Fills.Any(f => f.ClientOrderId == OrderId3));
+            Assert.IsTrue(stopElected);
         }
 
         [Test]

--- a/Circus/OrderBook/IOrderBook.cs
+++ b/Circus/OrderBook/IOrderBook.cs
@@ -11,6 +11,11 @@ namespace Circus.OrderBook
 
         IList<Level> GetLevels(Side side, int maxPrices);
 
+        // Live indicative auction price during PreOpen (or a mid-session volatility pause) - the
+        // price/quantity that would result if the auction ended right now. Recalculated from the
+        // current book on every call, so it naturally tracks order entry/cancellation.
+        bool TryGetIndicativeAuctionPrice(out decimal price, out int quantity);
+
         IList<OrderBookEvent> Process(OrderBookAction action);
 
         IList<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity, Side side,

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -211,8 +211,6 @@ namespace Circus.OrderBook
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
             if (priceTicks.HasValue && !IsWithinPriceBand(priceTicks.Value))
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.PriceOutsideBands);
-            var triggersVolatilityPause = _status == OrderBookStatus.Open && priceTicks.HasValue &&
-                !IsWithinVolatilityAuctionBand(priceTicks.Value);
             if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var existingOrder))
             {
                 return existingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
@@ -249,16 +247,7 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
-
-            if (triggersVolatilityPause)
-            {
-                _status = OrderBookStatus.PreOpen;
-                events.Add(new StatusChanged(_security, Now(), _status));
-            }
-            else
-            {
-                Match(events);
-            }
+            Match(events);
 
             if (order.Validity == OrderValidity.FillAndKill && order.Status == OrderStatus.Working)
                 events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
@@ -311,9 +300,11 @@ namespace Circus.OrderBook
             Math.Abs(priceTicks - _bandReferencePriceTicks.Value) <= _security.PriceBandTicks.Value;
 
         // Same shape as IsWithinPriceBand, but a separate, independently-configurable (typically
-        // narrower) band: a breach here doesn't reject the order - it pauses continuous trading
-        // into an auction instead (Eurex-style volatility interruption), handled by the callers
-        // below. Only relevant for orders that already passed the hard PriceBandTicks check above.
+        // narrower) band checked in Match() against the prospective trade price, not the
+        // submitted order price checked by IsWithinPriceBand above - a breach here doesn't reject
+        // the order, it pauses continuous trading into an auction instead (Eurex-style volatility
+        // interruption). PriceBandTicks still applies as the hard outer limit checked at order
+        // entry, so this only ever matters for prices that already passed that check.
         private bool IsWithinVolatilityAuctionBand(long priceTicks) =>
             !_security.VolatilityAuctionBandTicks.HasValue || !_bandReferencePriceTicks.HasValue ||
             Math.Abs(priceTicks - _bandReferencePriceTicks.Value) <= _security.VolatilityAuctionBandTicks.Value;
@@ -390,8 +381,6 @@ namespace Circus.OrderBook
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
             if (priceTicks.HasValue && !IsWithinPriceBand(priceTicks.Value))
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.PriceOutsideBands);
-            var triggersVolatilityPause = _status == OrderBookStatus.Open && priceTicks.HasValue &&
-                !IsWithinVolatilityAuctionBand(priceTicks.Value);
             if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
                 order.ClientOrderId != previousClientOrderId)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
@@ -471,17 +460,7 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new UpdateOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId));
-
-            if (triggersVolatilityPause)
-            {
-                _status = OrderBookStatus.PreOpen;
-                events.Add(new StatusChanged(_security, Now(), _status));
-            }
-            else
-            {
-                Match(events);
-            }
-
+            Match(events);
             return events;
         }
 
@@ -626,6 +605,19 @@ namespace Circus.OrderBook
                 var quantity = Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
                 var priceTicks = auctionPriceTicks ?? resting.Price ??
                     throw new InvalidOperationException("limit order requires price");
+
+                // Checked against the prospective trade price, not either order's own submitted
+                // limit price - a resting order sitting far from the market doesn't represent any
+                // actual price movement, only an executed trade at an extreme price does. Doesn't
+                // apply to an auction uncrossing pass itself (auctionPriceTicks set) - the auction
+                // print is already the resolution mechanism, not something to interrupt.
+                if (auctionPriceTicks == null && !IsWithinVolatilityAuctionBand(priceTicks))
+                {
+                    _status = OrderBookStatus.PreOpen;
+                    events.Add(new StatusChanged(_security, Now(), _status));
+                    return;
+                }
+
                 var price = ToDecimal(priceTicks);
 
                 FillOrder(resting, time, quantity);

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -70,6 +70,82 @@ namespace Circus.OrderBook
             return total;
         }
 
+        public bool TryGetIndicativeAuctionPrice(out decimal price, out int quantity)
+        {
+            if (!TryComputeAuctionPrice(out var priceTicks, out quantity))
+            {
+                price = 0;
+                return false;
+            }
+
+            price = ToDecimal(priceTicks);
+            return true;
+        }
+
+        // The call-auction uncrossing price: the price that maximizes executable volume across
+        // the resting book, i.e. min(cumulative bid quantity at/above p, cumulative ask quantity
+        // at/below p). Ties break by (1) minimum surplus - CME's rule, (2) closest to
+        // _bandReferencePriceTicks, since neither venue's public docs cover a case this granular,
+        // (3) CME's final rule: highest price if the surplus is on the buy side, lowest if on the
+        // sell side. Stops are deliberately not folded into this search (unlike CME's iterative
+        // stop-election loop) - they're picked up afterward by the existing CheckStops() pass,
+        // same as any other trade.
+        private bool TryComputeAuctionPrice(out long priceTicks, out int quantity)
+        {
+            priceTicks = 0;
+            quantity = 0;
+
+            var buyLevels = _working[Side.Buy].EnumerateFromBest()
+                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
+            var sellLevels = _working[Side.Sell].EnumerateFromBest()
+                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
+
+            if (buyLevels.Count == 0 || sellLevels.Count == 0 || buyLevels[0].Tick < sellLevels[0].Tick)
+                return false;
+
+            var candidates = buyLevels.Select(l => l.Tick).Concat(sellLevels.Select(l => l.Tick)).Distinct();
+
+            (long Price, int Executable, long Surplus)? best = null;
+            foreach (var p in candidates)
+            {
+                var cumBid = buyLevels.Where(l => l.Tick >= p).Sum(l => l.Qty);
+                var cumAsk = sellLevels.Where(l => l.Tick <= p).Sum(l => l.Qty);
+                var executable = Math.Min(cumBid, cumAsk);
+                var surplus = cumBid - cumAsk;
+
+                if (best == null || executable > best.Value.Executable ||
+                    (executable == best.Value.Executable &&
+                     IsBetterAuctionPriceTieBreak(p, surplus, best.Value.Price, best.Value.Surplus)))
+                {
+                    best = (p, executable, surplus);
+                }
+            }
+
+            priceTicks = best!.Value.Price;
+            quantity = best.Value.Executable;
+            return quantity > 0;
+        }
+
+        private bool IsBetterAuctionPriceTieBreak(long candidatePrice, long candidateSurplus, long currentPrice,
+            long currentSurplus)
+        {
+            var candidateAbsSurplus = Math.Abs(candidateSurplus);
+            var currentAbsSurplus = Math.Abs(currentSurplus);
+            if (candidateAbsSurplus != currentAbsSurplus)
+                return candidateAbsSurplus < currentAbsSurplus;
+
+            if (_bandReferencePriceTicks.HasValue)
+            {
+                var candidateDistance = Math.Abs(candidatePrice - _bandReferencePriceTicks.Value);
+                var currentDistance = Math.Abs(currentPrice - _bandReferencePriceTicks.Value);
+                if (candidateDistance != currentDistance)
+                    return candidateDistance < currentDistance;
+            }
+
+            // surplus on the buy side (positive) -> prefer the higher price; sell side -> lower
+            return candidateSurplus > 0 ? candidatePrice > currentPrice : candidatePrice < currentPrice;
+        }
+
         public IList<OrderBookEvent> Process(OrderBookAction action)
         {
             return action switch
@@ -135,6 +211,8 @@ namespace Circus.OrderBook
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
             if (priceTicks.HasValue && !IsWithinPriceBand(priceTicks.Value))
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.PriceOutsideBands);
+            var triggersVolatilityPause = _status == OrderBookStatus.Open && priceTicks.HasValue &&
+                !IsWithinVolatilityAuctionBand(priceTicks.Value);
             if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var existingOrder))
             {
                 return existingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
@@ -171,7 +249,16 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
-            Match(events);
+
+            if (triggersVolatilityPause)
+            {
+                _status = OrderBookStatus.PreOpen;
+                events.Add(new StatusChanged(_security, Now(), _status));
+            }
+            else
+            {
+                Match(events);
+            }
 
             if (order.Validity == OrderValidity.FillAndKill && order.Status == OrderStatus.Working)
                 events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
@@ -222,6 +309,14 @@ namespace Circus.OrderBook
         private bool IsWithinPriceBand(long priceTicks) =>
             !_security.PriceBandTicks.HasValue || !_bandReferencePriceTicks.HasValue ||
             Math.Abs(priceTicks - _bandReferencePriceTicks.Value) <= _security.PriceBandTicks.Value;
+
+        // Same shape as IsWithinPriceBand, but a separate, independently-configurable (typically
+        // narrower) band: a breach here doesn't reject the order - it pauses continuous trading
+        // into an auction instead (Eurex-style volatility interruption), handled by the callers
+        // below. Only relevant for orders that already passed the hard PriceBandTicks check above.
+        private bool IsWithinVolatilityAuctionBand(long priceTicks) =>
+            !_security.VolatilityAuctionBandTicks.HasValue || !_bandReferencePriceTicks.HasValue ||
+            Math.Abs(priceTicks - _bandReferencePriceTicks.Value) <= _security.VolatilityAuctionBandTicks.Value;
 
         // selfMatchPreventionId/selfMatchPreventionInstruction are the incoming order's own
         // fields. Walks resting orders in the same price/time priority order Match() would
@@ -295,6 +390,8 @@ namespace Circus.OrderBook
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
             if (priceTicks.HasValue && !IsWithinPriceBand(priceTicks.Value))
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.PriceOutsideBands);
+            var triggersVolatilityPause = _status == OrderBookStatus.Open && priceTicks.HasValue &&
+                !IsWithinVolatilityAuctionBand(priceTicks.Value);
             if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
                 order.ClientOrderId != previousClientOrderId)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
@@ -374,7 +471,17 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new UpdateOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId));
-            Match(events);
+
+            if (triggersVolatilityPause)
+            {
+                _status = OrderBookStatus.PreOpen;
+                events.Add(new StatusChanged(_security, Now(), _status));
+            }
+            else
+            {
+                Match(events);
+            }
+
             return events;
         }
 
@@ -477,7 +584,7 @@ namespace Circus.OrderBook
         private InternalOrder? BestOrder(Side side) =>
             _working[side].TryGetBest(out _, out var order) ? order : null;
 
-        private void Match(List<OrderBookEvent> events)
+        private void Match(List<OrderBookEvent> events, long? auctionPriceTicks = null)
         {
             if (_status != OrderBookStatus.Open)
             {
@@ -517,7 +624,8 @@ namespace Circus.OrderBook
                 }
 
                 var quantity = Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
-                var priceTicks = resting.Price ?? throw new InvalidOperationException("limit order requires price");
+                var priceTicks = auctionPriceTicks ?? resting.Price ??
+                    throw new InvalidOperationException("limit order requires price");
                 var price = ToDecimal(priceTicks);
 
                 FillOrder(resting, time, quantity);
@@ -671,6 +779,12 @@ namespace Circus.OrderBook
         {
             _status = OrderBookStatus.Open;
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
+
+            // Runs whether the prior status was the real start-of-day PreOpen or PreOpen
+            // re-entered mid-session for a volatility pause - same uncrossing either way.
+            if (TryComputeAuctionPrice(out var auctionPriceTicks, out _))
+                Match(events, auctionPriceTicks);
+
             Match(events);
             return events;
         }

--- a/Circus/Security.cs
+++ b/Circus/Security.cs
@@ -6,6 +6,7 @@ namespace Circus
         decimal TickSize,
         decimal TickValue,
         int MarketOrderProtectionTicks = 10,
-        int? PriceBandTicks = null
+        int? PriceBandTicks = null,
+        int? VolatilityAuctionBandTicks = null
     );
 }


### PR DESCRIPTION
## Summary
- Implements the single-price call-auction algorithm CME and Eurex both use to determine an opening/reopening price: the price maximizing executable volume across the resting book, tie-broken by (1) minimum surplus, (2) closeness to the seeded reference price, (3) CME's documented final rule (highest price if surplus is on the buy side, lowest if on the sell side)
- All matched orders in an uncrossing pass print at that single price via a new optional forced-price parameter on `Match`, reusing the existing FIFO matching loop as-is - no changes needed to fill/cancel/self-trade-prevention logic
- `OpenMarket()` runs one uncrossing pass before resuming continuous matching - this works identically whether the prior status was the real start-of-day `PreOpen` or a mid-session volatility pause, since it's the same operation either way
- A mid-session pause reuses `PreOpen` directly rather than introducing a new `OrderBookStatus` - mechanically they're identical here (blocks `Market` orders, blocks continuous matching, still accepts entry/cancel/update, ends the same way), so there was no technical reason to add one
- New, independently-configurable `Security.VolatilityAuctionBandTicks` (narrower than #23's hard-reject `PriceBandTicks`) triggers the pause on breach instead of rejecting the order (Eurex-style volatility interruption vs. CME-style hard reject) - both can coexist since they're separate fields
- New `IOrderBook.TryGetIndicativeAuctionPrice` exposes the live auction price throughout the accumulation/pause phase, matching how both venues continuously disseminate it rather than only revealing it once the auction ends
- Deliberately out of scope: folding stop-order election into the price search (CME's iterative approach) - stops are picked up via the existing `CheckStops()` pass immediately after the print, same as any other trade; and the minimum-duration/random-extension timing real venues use to end a volatility auction, since this library has no internal clock and is entirely caller-timed already

## Test plan
- [x] `dotnet build` across the whole solution
- [x] `dotnet test` - 200/200 passing, including 7 new tests covering multi-level max-volume pricing with price improvement, both tie-break rules, no-cross/no-print, the live indicative price query, a volatility-pause-then-reopen scenario with stop election, and a regression check that `PriceBandTicks`-only configurations are unaffected
- [x] Re-ran the seeded `OrderFlowSimulator` sanity check (seed 42, 20,000 actions) - identical `confirmed_events=24446 rejected_events=0`