### PR TITLE
Update feature checklist to reflect shipped work

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ Time in force/order validity
 - [x] Day orders
 - [x] GTC orders
 - [x] FAK/FOK orders
-- [ ] GTD orders
+- [x] GTD orders
 
 Sessions
 - [x] Time provider
@@ -34,17 +34,17 @@ Market data
 - [x] Trades
 - [x] Price/qty/count for x levels
 - [ ] All order updates
-- [ ] Indicative open
+- [x] Indicative open
 
 Safety features
-- [ ] Banding
-- [ ] Limits
+- [x] Banding
+- [ ] Daily price limits (static, session-long limit up/down)
 - [ ] Circuit breakers
 - [ ] Stop & velocity logic
-- [ ] Self-match prevention
+- [x] Self-match prevention
 
 Matching algorithms
 - [x] FIFO
-- [ ] Open auction
+- [x] Open auction
 - [ ] Allocation
 - [ ] Pro-rata


### PR DESCRIPTION
## Summary
- Checked off GTD orders, indicative open (`TryGetIndicativeAuctionPrice`), self-match prevention, banding, and the open auction algorithm - all implemented across the last several merged PRs (#21, #23, #25) but never reflected in the README
- Renamed "Limits" to "Daily price limits (static, session-long limit up/down)" for clarity - this is a distinct, still-unimplemented CME mechanism (a static per-session cap on where a trade can print, anchored to the prior settlement price) from the dynamic `PriceBandTicks`/`VolatilityAuctionBandTicks` banding that's already built, and the old one-word label was easy to conflate with it

## Test plan
- [x] Docs-only change, no code affected