### PR TITLE
Redesign IOrderBook's action API as a discriminated union

### DIFF
--- a/Circus.Examples/DataProducerExample.cs
+++ b/Circus.Examples/DataProducerExample.cs
@@ -21,19 +21,19 @@ namespace Circus.Examples
             var tradeDataProducer = new TradeDataProducer();
             var levelDataProducer = new LevelDataProducer(5);
 
-            void Publish(IOrderBook book, IList<OrderBookEvent> events)
+            void Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
             {
                 Print(tradeDataProducer.Process(book, events));
                 Print(levelDataProducer.Process(book, events));
             }
 
             Publish(book1, book1.UpdateStatus(OrderBookStatus.Open));
-            Publish(book1, book1.CreateOrder("Buyer", "Order1", OrderValidity.Day, Side.Buy, 3, 100));
-            Publish(book1, book1.CreateOrder("Seller", "Order2", OrderValidity.Day, Side.Sell, 5, 100));
+            Publish(book1, book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+            Publish(book1, book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
 
             Publish(book2, book2.UpdateStatus(OrderBookStatus.Open));
-            Publish(book2, book2.CreateOrder("Buyer", "Order1", OrderValidity.Day, Side.Buy, 3, 100));
-            Publish(book2, book2.CreateOrder("Seller", "Order2", OrderValidity.Day, Side.Sell, 5, 100));
+            Publish(book2, book2.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+            Publish(book2, book2.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
         }
 
         private static void Print(IEnumerable<TradedDataEvent> events)

--- a/Circus.Examples/Example.cs
+++ b/Circus.Examples/Example.cs
@@ -18,10 +18,10 @@ namespace Circus.Examples
             IOrderBook book1 = new InMemoryOrderBook(sec1, time);
 
             Print(producer.Process(book1,
-                book1.CreateOrder("Buyer", "Order1", OrderValidity.Day, Side.Buy, 3, 100)));
+                book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100)));
 
             Print(producer.Process(book1,
-                book1.CreateOrder("Seller", "Order2", OrderValidity.Day, Side.Sell, 5, 100)));
+                book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100)));
         }
 
         private static void Print(IEnumerable<TradedDataEvent> events)

--- a/Circus.Examples/OrderBookExample.cs
+++ b/Circus.Examples/OrderBookExample.cs
@@ -24,8 +24,8 @@ namespace Circus.Examples
             sessionProvider.Changed += (_, args) => book.UpdateStatus(args.Status);
             sessionProvider.Update(new DateTime(2020, 1, 1, 1, 30, 0));
 
-            Print(book.CreateOrder("Buyer", "Order1", OrderValidity.Day, Side.Buy, 3, 100));
-            Print(book.CreateOrder("Seller", "Order2", OrderValidity.Day, Side.Sell, 5, 100));
+            Print(book.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+            Print(book.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
         }
 
         public static void BackTestExample()
@@ -56,7 +56,7 @@ namespace Circus.Examples
                 timeProvider.SetCurrentTime(time);
                 // pass in data - each order needs its own ClientOrderId, since Buyer's ids are
                 // permanently reserved once used
-                Print(book.CreateOrder("Buyer", $"Order{i}", OrderValidity.Day, Side.Buy, 3, 100));
+                Print(book.CreateLimitOrder("Buyer", $"Order{i}", new OrderValidity.Day(), Side.Buy, 3, 100));
             }
         }
 
@@ -84,8 +84,8 @@ namespace Circus.Examples
                 }
             });
 
-            Print(book.CreateOrder("Buyer", "Order1", OrderValidity.Day, Side.Buy, 3, 100));
-            Print(book.CreateOrder("Seller", "Order2", OrderValidity.Day, Side.Sell, 5, 100));
+            Print(book.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+            Print(book.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
         }
 
         private static void Print(IEnumerable<OrderBookEvent> events)

--- a/Circus.Simulator/OrderFlowSimulator.cs
+++ b/Circus.Simulator/OrderFlowSimulator.cs
@@ -162,29 +162,39 @@ namespace Circus.Simulator
             return BuildCreateLimit();
         }
 
-        private CreateOrder BuildCreateLimit()
+        private CreateLimitOrder BuildCreateLimit()
         {
             var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
             var price = ComputePrice(side);
             var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
 
-            return new CreateOrder(_security, NextCompanyId(), NextClientOrderId(), OrderValidity.GoodTilCanceled,
-                side, quantity, price);
+            return new CreateLimitOrder
+            {
+                Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
+                OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity, Price = price
+            };
         }
 
-        private CreateOrder BuildCreateMarket()
+        private CreateMarketOrder BuildCreateMarket()
         {
             var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
             var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
 
-            return new CreateOrder(_security, NextCompanyId(), NextClientOrderId(), OrderValidity.GoodTilCanceled,
-                side, quantity);
+            return new CreateMarketOrder
+            {
+                Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
+                OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity
+            };
         }
 
         private CancelOrder BuildCancel()
         {
             TryPickLive(out _, out var info);
-            return new CancelOrder(_security, info.CompanyId, NextClientOrderId(), info.ClientOrderId);
+            return new CancelOrder
+            {
+                Security = _security, CompanyId = info.CompanyId, ClientOrderId = NextClientOrderId(),
+                PreviousClientOrderId = info.ClientOrderId
+            };
         }
 
         private UpdateOrder BuildUpdate()
@@ -198,8 +208,11 @@ namespace Circus.Simulator
             if (updateQuantityOnly || _random.NextDouble() < 0.5)
             {
                 var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
-                return new UpdateOrder(_security, info.CompanyId, newClientOrderId, info.ClientOrderId,
-                    Quantity: quantity);
+                return new UpdateOrder
+                {
+                    Security = _security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
+                    PreviousClientOrderId = info.ClientOrderId, NewTotalQuantity = quantity
+                };
             }
 
             var tick = _security.TickSize;
@@ -207,7 +220,11 @@ namespace Circus.Simulator
             var reference = info.Price ?? AlignToTick(_options.StartingPrice);
             var newPrice = reference + direction * _random.Next(1, 4) * tick;
 
-            return new UpdateOrder(_security, info.CompanyId, newClientOrderId, info.ClientOrderId, Price: newPrice);
+            return new UpdateOrder
+            {
+                Security = _security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
+                PreviousClientOrderId = info.ClientOrderId, Price = newPrice
+            };
         }
 
         private decimal ComputePrice(Side side)

--- a/Circus.Tests/DataProducers/LevelDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/LevelDataProducerTests.cs
@@ -29,7 +29,7 @@ namespace Circus.Tests.DataProducers
 
             Book.UpdateStatus(OrderBookStatus.Open);
             var bookEvents =
-                Book.CreateOrder("Company1", "Order1", OrderValidity.Day, Side.Sell, 3, 100);
+                Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // act
             var events = producer.Process(Book, bookEvents);
@@ -54,9 +54,9 @@ namespace Circus.Tests.DataProducers
             var producer = new LevelDataProducer(2);
 
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder("Company2", "Order2", OrderValidity.Day, Side.Sell, 5, 100);
+            Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100);
             var bookEvents =
-                Book.CreateOrder("Company3", "Order3", OrderValidity.Day, Side.Sell,3,  100);
+                Book.CreateLimitOrder("Company3", "Order3", new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // act
             var events = producer.Process(Book, bookEvents);
@@ -81,9 +81,9 @@ namespace Circus.Tests.DataProducers
             var producer = new LevelDataProducer(2);
 
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder("Company4", "Order4", OrderValidity.Day, Side.Sell, 5, 100);
+            Book.CreateLimitOrder("Company4", "Order4", new OrderValidity.Day(), Side.Sell, 5, 100);
             var bookEvents =
-                Book.CreateOrder("Company5", "Order5", OrderValidity.Day, Side.Sell, 3, 110);
+                Book.CreateLimitOrder("Company5", "Order5", new OrderValidity.Day(), Side.Sell, 3, 110);
 
             // act
             var events = producer.Process(Book, bookEvents);
@@ -111,8 +111,8 @@ namespace Circus.Tests.DataProducers
             var producer = new LevelDataProducer(2);
 
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder("Company6", "Order6", OrderValidity.Day, Side.Buy, 5, 100);
-            var bookEvents = Book.CreateOrder("Company7", "Order7", OrderValidity.Day, Side.Buy, 3, 110);
+            Book.CreateLimitOrder("Company6", "Order6", new OrderValidity.Day(), Side.Buy, 5, 100);
+            var bookEvents = Book.CreateLimitOrder("Company7", "Order7", new OrderValidity.Day(), Side.Buy, 3, 110);
 
             // act
             var events = producer.Process(Book, bookEvents);
@@ -140,9 +140,9 @@ namespace Circus.Tests.DataProducers
             var producer = new LevelDataProducer(2);
 
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder("Company8", "Order8", OrderValidity.Day, Side.Buy, 5, 100);
+            Book.CreateLimitOrder("Company8", "Order8", new OrderValidity.Day(), Side.Buy, 5, 100);
             var bookEvents =
-                Book.CreateOrder("Company9", "Order9", OrderValidity.Day, Side.Sell, 3, 110);
+                Book.CreateLimitOrder("Company9", "Order9", new OrderValidity.Day(), Side.Sell, 3, 110);
 
             // act
             var events = producer.Process(Book, bookEvents);
@@ -170,9 +170,9 @@ namespace Circus.Tests.DataProducers
             var producer = new LevelDataProducer(2);
 
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder("Company10", "Order10", OrderValidity.Day, Side.Buy, 3, 110);
-            Book.CreateOrder("Company11", "Order11", OrderValidity.Day, Side.Buy, 4, 120);
-            var bookEvents = Book.CreateOrder("Company12", "Order12", OrderValidity.Day, Side.Buy, 5, 130);
+            Book.CreateLimitOrder("Company10", "Order10", new OrderValidity.Day(), Side.Buy, 3, 110);
+            Book.CreateLimitOrder("Company11", "Order11", new OrderValidity.Day(), Side.Buy, 4, 120);
+            var bookEvents = Book.CreateLimitOrder("Company12", "Order12", new OrderValidity.Day(), Side.Buy, 5, 130);
 
             // act
             var events = producer.Process(Book, bookEvents);
@@ -200,10 +200,10 @@ namespace Circus.Tests.DataProducers
             var producer = new LevelDataProducer(2);
 
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder("Company13", "Order13", OrderValidity.Day, Side.Buy, 3, 110);
-            Book.CreateOrder("Company14", "Order14", OrderValidity.Day, Side.Buy, 4, 120);
+            Book.CreateLimitOrder("Company13", "Order13", new OrderValidity.Day(), Side.Buy, 3, 110);
+            Book.CreateLimitOrder("Company14", "Order14", new OrderValidity.Day(), Side.Buy, 4, 120);
             var bookEvents =
-                Book.CreateOrder("Company15", "Order15", OrderValidity.Day, Side.Sell, 5, 100);
+                Book.CreateLimitOrder("Company15", "Order15", new OrderValidity.Day(), Side.Sell, 5, 100);
 
             // act
             var events = producer.Process(Book, bookEvents);

--- a/Circus.Tests/DataProducers/TradeDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/TradeDataProducerTests.cs
@@ -19,9 +19,9 @@ namespace Circus.Tests.DataProducers
 
             var book = new InMemoryOrderBook(sec, timeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateOrder("Company1", "Order1", OrderValidity.Day, Side.Buy, 3, 100);
+            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100);
             var bookEvents =
-                book.CreateOrder("Company2", "Order2", OrderValidity.Day, Side.Sell, 3, 100);
+                book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // act
             var events = producer.Process(book, bookEvents);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
@@ -39,7 +39,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -63,7 +63,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
             Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, cancelled.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, cancelled.Order.Side);
             Assert.AreEqual(100, cancelled.Order.Price);
             Assert.IsNull(cancelled.Order.TriggerPrice);
@@ -77,9 +77,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, null, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -103,7 +103,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
             Assert.AreEqual(OrderType.StopMarket, cancelled.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, cancelled.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, cancelled.Order.Side);
             Assert.IsNull(cancelled.Order.Price);
             Assert.AreEqual(110, cancelled.Order.TriggerPrice);
@@ -117,7 +117,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             Book.UpdateStatus(OrderBookStatus.Closed);
 
             // act
@@ -142,7 +142,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100)
+            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
                 .OfType<CreateOrderConfirmed>().Single();
             Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
 
@@ -192,7 +192,7 @@ namespace Circus.Tests.OrderBook
             // arrange - client 2 cannot cancel client 1's order by quoting client 1's clientOrderId,
             // since the (companyId, clientOrderId) lookup is scoped per client
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // act
             var events = Book.CancelOrder(CompanyId2, OrderId4, OrderId1);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
@@ -43,7 +43,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, side, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -63,7 +63,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(created.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, created.Order.Status);
             Assert.AreEqual(OrderType.Limit, created.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, created.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
             Assert.AreEqual(side, created.Order.Side);
             Assert.AreEqual(100, created.Order.Price);
             Assert.IsNull(created.Order.TriggerPrice);
@@ -80,11 +80,11 @@ namespace Circus.Tests.OrderBook
             var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
             var book = new InMemoryOrderBook(sec, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, side == Side.Buy ? Side.Sell : Side.Buy, 3, 500);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side == Side.Buy ? Side.Sell : Side.Buy, 3, 500);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, side, 5);
+            var events = book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.Day(), side, 5);
 
             // assert
             Assert.IsNotNull(events);
@@ -103,7 +103,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(created.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, created.Order.Status);
             Assert.AreEqual(OrderType.Market, created.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, created.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
             Assert.AreEqual(side, created.Order.Side);
             Assert.AreEqual(limitPrice, created.Order.Price);
             Assert.IsNull(created.Order.TriggerPrice);
@@ -135,7 +135,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(side == Side.Buy ? Side.Sell : Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(500, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -158,7 +158,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Market, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(side, matched.Fills[1].Order.Side);
             Assert.AreEqual(limitPrice, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -173,12 +173,12 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 2, 500);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, side, 5, price, triggerPrice);
+            var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, price, triggerPrice);
 
             // assert
             Assert.IsNotNull(events);
@@ -197,7 +197,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(created.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Hidden, created.Order.Status);
             Assert.AreEqual(OrderType.StopLimit, created.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, created.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
             Assert.AreEqual(side, created.Order.Side);
             Assert.AreEqual(price, created.Order.Price);
             Assert.AreEqual(triggerPrice, created.Order.TriggerPrice);
@@ -212,12 +212,12 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 2, 500);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, side, 5, null, triggerPrice);
+            var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, triggerPrice);
 
             // assert
             Assert.IsNotNull(events);
@@ -236,7 +236,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(created.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Hidden, created.Order.Status);
             Assert.AreEqual(OrderType.StopMarket, created.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, created.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
             Assert.AreEqual(side, created.Order.Side);
             Assert.IsNull(created.Order.Price);
             Assert.AreEqual(triggerPrice, created.Order.TriggerPrice);
@@ -250,11 +250,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -284,7 +284,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(100, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -307,7 +307,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -321,11 +321,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -355,7 +355,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(110, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -378,7 +378,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -392,11 +392,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -431,7 +431,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(110, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -454,7 +454,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -468,13 +468,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 120);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -504,7 +504,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(120, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -527,7 +527,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -541,13 +541,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 120);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 8, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -577,7 +577,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
             Assert.AreEqual(120, matched1.Fills[0].Order.Price);
             Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
@@ -600,7 +600,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
             Assert.AreEqual(100, matched1.Fills[1].Order.Price);
             Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
@@ -632,7 +632,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
             Assert.AreEqual(110, matched2.Fills[0].Order.Price);
             Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
@@ -655,7 +655,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
             Assert.AreEqual(100, matched2.Fills[1].Order.Price);
             Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
@@ -669,13 +669,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -710,7 +710,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(110, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -733,7 +733,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -747,13 +747,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 8, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -783,7 +783,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
             Assert.AreEqual(110, matched1.Fills[0].Order.Price);
             Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
@@ -806,7 +806,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
             Assert.AreEqual(100, matched1.Fills[1].Order.Price);
             Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
@@ -838,7 +838,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
             Assert.AreEqual(110, matched2.Fills[0].Order.Price);
             Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
@@ -861,7 +861,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
             Assert.AreEqual(100, matched2.Fills[1].Order.Price);
             Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
@@ -875,13 +875,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 90);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 80);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -911,7 +911,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[0].Order.Side);
             Assert.AreEqual(80, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -934,7 +934,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -948,13 +948,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 90);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 80);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 8, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -984,7 +984,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched1.Fills[0].Order.Side);
             Assert.AreEqual(80, matched1.Fills[0].Order.Price);
             Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
@@ -1007,7 +1007,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched1.Fills[1].Order.Side);
             Assert.AreEqual(100, matched1.Fills[1].Order.Price);
             Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
@@ -1039,7 +1039,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched2.Fills[0].Order.Side);
             Assert.AreEqual(90, matched2.Fills[0].Order.Price);
             Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
@@ -1062,7 +1062,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched2.Fills[1].Order.Side);
             Assert.AreEqual(100, matched2.Fills[1].Order.Price);
             Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
@@ -1076,13 +1076,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 90);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1117,7 +1117,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[0].Order.Side);
             Assert.AreEqual(90, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -1140,7 +1140,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -1154,13 +1154,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 90);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 8, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1190,7 +1190,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched1.Fills[0].Order.Side);
             Assert.AreEqual(90, matched1.Fills[0].Order.Price);
             Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
@@ -1213,7 +1213,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched1.Fills[1].Order.Side);
             Assert.AreEqual(100, matched1.Fills[1].Order.Price);
             Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
@@ -1245,7 +1245,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched2.Fills[0].Order.Side);
             Assert.AreEqual(90, matched2.Fills[0].Order.Price);
             Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
@@ -1268,7 +1268,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched2.Fills[1].Order.Side);
             Assert.AreEqual(100, matched2.Fills[1].Order.Price);
             Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
@@ -1282,15 +1282,15 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now3);
             Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 7);
             TimeProvider.SetCurrentTime(Now4);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1320,7 +1320,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(110, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -1343,7 +1343,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now4, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -1357,15 +1357,15 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now3);
             Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6);
             TimeProvider.SetCurrentTime(Now4);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 8, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1395,7 +1395,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now4, matched1.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
             Assert.AreEqual(110, matched1.Fills[0].Order.Price);
             Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
@@ -1418,7 +1418,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
             Assert.AreEqual(100, matched1.Fills[1].Order.Price);
             Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
@@ -1450,7 +1450,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
             Assert.AreEqual(110, matched2.Fills[0].Order.Price);
             Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
@@ -1473,7 +1473,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now4, matched2.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
             Assert.AreEqual(100, matched2.Fills[1].Order.Price);
             Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
@@ -1487,15 +1487,15 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now3);
             Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
             TimeProvider.SetCurrentTime(Now4);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1530,7 +1530,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(110, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -1553,7 +1553,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now4, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -1567,15 +1567,15 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
             TimeProvider.SetCurrentTime(Now3);
             Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
             TimeProvider.SetCurrentTime(Now4);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 8, 100);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1605,7 +1605,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now4, matched1.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
             Assert.AreEqual(110, matched1.Fills[0].Order.Price);
             Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
@@ -1628,7 +1628,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched1.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
             Assert.AreEqual(100, matched1.Fills[1].Order.Price);
             Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
@@ -1660,7 +1660,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
             Assert.AreEqual(110, matched2.Fills[0].Order.Price);
             Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
@@ -1683,7 +1683,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now4, matched2.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched2.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
             Assert.AreEqual(100, matched2.Fills[1].Order.Price);
             Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
@@ -1697,7 +1697,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilCanceled, Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
             Book.UpdateStatus(OrderBookStatus.Closed);
             TimeProvider.SetCurrentTime(Now3);
@@ -1705,7 +1705,7 @@ namespace Circus.Tests.OrderBook
             TimeProvider.SetCurrentTime(Now4);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 8, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 8, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1735,7 +1735,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now4, matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.GoodTilCanceled, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.GoodTilCanceled(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(100, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -1758,7 +1758,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -1772,7 +1772,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1794,7 +1794,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.PreOpen);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3);
+            var events = Book.CreateMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
 
             // assert
             Assert.IsNotNull(events);
@@ -1816,7 +1816,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, quantity, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, quantity, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1840,7 +1840,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 6, price);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, price);
 
             // assert
             Assert.IsNotNull(events);
@@ -1863,7 +1863,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 6, price);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, price);
 
             // assert
             Assert.IsNotNull(events);
@@ -1882,7 +1882,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 6, null, triggerPrice);
+            var events = Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, triggerPrice);
 
             // assert
             Assert.IsNotNull(events);
@@ -1903,7 +1903,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, 90, 100);
+            var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 90, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1924,7 +1924,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 110, 100);
+            var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 110, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1945,7 +1945,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, null, 100);
+            var events = Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -1965,11 +1965,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, null, price);
+            var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, price);
 
             // assert
             Assert.IsNotNull(events);
@@ -1989,11 +1989,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, null, price);
+            var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, price);
 
             // assert
             Assert.IsNotNull(events);
@@ -2014,7 +2014,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3);
+            var events = Book.CreateMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
 
             // assert
             Assert.IsNotNull(events);
@@ -2033,10 +2033,10 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2055,11 +2055,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             Book.CancelOrder(CompanyId1, OrderId5, OrderId1);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2076,11 +2076,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 3, 100); // fully fills OrderId1
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3, 100); // fully fills OrderId1
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2097,10 +2097,10 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2116,10 +2116,10 @@ namespace Circus.Tests.OrderBook
             // arrange - the same client-supplied id is only required to be unique per client,
             // not book-wide, since uniqueness is scoped by the (CompanyId, ClientOrderId) pair
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // act - same side/price as CompanyId1's order, so it rests instead of matching
-            var events = Book.CreateOrder(CompanyId2, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2138,16 +2138,14 @@ namespace Circus.Tests.OrderBook
             var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(7);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilDate, Side.Buy, 3, 100,
-                goodTilDate: goodTilDate);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
             Assert.AreEqual(1, events.Count);
             var created = events[0] as CreateOrderConfirmed;
             Assert.IsNotNull(created);
-            Assert.AreEqual(OrderValidity.GoodTilDate, created.Order.OrderValidity);
-            Assert.AreEqual(goodTilDate, created.Order.GoodTilDate);
+            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, created.Order.OrderValidity);
         }
 
         [Test]
@@ -2158,35 +2156,14 @@ namespace Circus.Tests.OrderBook
             var goodTilDate = DateOnly.FromDateTime(Now1);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilDate, Side.Buy, 3, 100,
-                goodTilDate: goodTilDate);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
             Assert.AreEqual(1, events.Count);
             var created = events[0] as CreateOrderConfirmed;
             Assert.IsNotNull(created);
-            Assert.AreEqual(OrderValidity.GoodTilDate, created.Order.OrderValidity);
-            Assert.AreEqual(goodTilDate, created.Order.GoodTilDate);
-        }
-
-        [Test]
-        public void GoodTilDateOrder_NoDateSupplied_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilDate, Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.GoodTilDateRequired, rejected.Reason);
+            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, created.Order.OrderValidity);
         }
 
         [Test]
@@ -2197,8 +2174,7 @@ namespace Circus.Tests.OrderBook
             var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(-1);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilDate, Side.Buy, 3, 100,
-                goodTilDate: goodTilDate);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2218,7 +2194,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, clientOrderId, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2237,7 +2213,7 @@ namespace Circus.Tests.OrderBook
             var clientOrderId = new string('a', length);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, clientOrderId, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2256,7 +2232,7 @@ namespace Circus.Tests.OrderBook
             var clientOrderId = new string('a', length);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, clientOrderId, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2275,7 +2251,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(companyId, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2294,7 +2270,7 @@ namespace Circus.Tests.OrderBook
             var companyId = new string('a', length);
 
             // act
-            var events = Book.CreateOrder(companyId, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -2313,7 +2289,7 @@ namespace Circus.Tests.OrderBook
             var companyId = new string('a', length);
 
             // act
-            var events = Book.CreateOrder(companyId, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookFillAndKillTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookFillAndKillTests.cs
@@ -45,11 +45,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.FillAndKill, Side.Buy, 3, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.FillAndKill(), Side.Buy, 3, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -63,7 +63,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.FillAndKill, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.FillAndKill(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
             Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
         }
@@ -73,11 +73,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.FillAndKill, Side.Buy, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.FillAndKill(), Side.Buy, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -97,7 +97,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
             Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
             Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(OrderValidity.FillAndKill, cancelled.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.FillAndKill(), cancelled.Order.OrderValidity);
             Assert.AreEqual(5, cancelled.Order.Quantity);
             Assert.AreEqual(2, cancelled.Order.FilledQuantity);
             Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
@@ -114,7 +114,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.FillAndKill, Side.Buy, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.FillAndKill(), Side.Buy, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -140,13 +140,13 @@ namespace Circus.Tests.OrderBook
             var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
             var book = new InMemoryOrderBook(sec, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 500);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
             // NB: a Market + GTC/Day order in the same situation would instead rest the
             // remainder as a limit order at the protected price (see MarketOrder_Success).
-            var events = book.CreateOrder(CompanyId2, OrderId2, OrderValidity.FillAndKill, Side.Buy, 5);
+            var events = book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.FillAndKill(), Side.Buy, 5);
 
             // assert
             Assert.IsNotNull(events);
@@ -175,22 +175,22 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 500); // last traded price = 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
             TimeProvider.SetCurrentTime(Now2);
 
             // FAK stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.FillAndKill, Side.Buy, 5, 530, 520);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.FillAndKill(), Side.Buy, 5, 530, 520);
             TimeProvider.SetCurrentTime(Now3);
 
             // only 2 available to fill the stop once triggered
-            Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 2, 530);
+            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
             TimeProvider.SetCurrentTime(Now4);
-            Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Buy, 1, 520);
+            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
             TimeProvider.SetCurrentTime(Now5);
 
             // act - trade at 520 triggers the stop
-            var events = Book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Sell, 1, 520);
+            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
 
             // assert
             Assert.IsNotNull(events);
@@ -216,7 +216,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(OrderCancelledReason.FillAndKillNotFilled, cancelled.Reason);
             Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
             Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(OrderValidity.FillAndKill, cancelled.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.FillAndKill(), cancelled.Order.OrderValidity);
             Assert.AreEqual(2, cancelled.Order.FilledQuantity);
             Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
 

--- a/Circus.Tests/OrderBook/InMemoryOrderBookFillOrKillTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookFillOrKillTests.cs
@@ -45,11 +45,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.FillOrKill, Side.Buy, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.FillOrKill(), Side.Buy, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -69,13 +69,13 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 110);
             TimeProvider.SetCurrentTime(Now3);
 
             // act - only fills if the 3@100 and 2@110 levels are summed together
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.FillOrKill, Side.Buy, 5, 110);
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.FillOrKill(), Side.Buy, 5, 110);
 
             // assert
             Assert.IsNotNull(events);
@@ -101,11 +101,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.FillOrKill, Side.Buy, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.FillOrKill(), Side.Buy, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -132,22 +132,22 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 500); // last traded price = 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
             TimeProvider.SetCurrentTime(Now2);
 
             // FOK stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.FillOrKill, Side.Buy, 5, 530, 520);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.FillOrKill(), Side.Buy, 5, 530, 520);
             TimeProvider.SetCurrentTime(Now3);
 
             // only 2 available - not enough to fill the stop's 5 in full
-            Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 2, 530);
+            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
             TimeProvider.SetCurrentTime(Now4);
-            Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Buy, 1, 520);
+            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
             TimeProvider.SetCurrentTime(Now5);
 
             // act - trade at 520 triggers the stop
-            var events = Book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Sell, 1, 520);
+            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
 
             // assert
             Assert.IsNotNull(events);
@@ -162,7 +162,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(OrderCancelledReason.FillOrKillNotFilled, cancelled.Reason);
             Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
             Assert.AreEqual(OrderType.StopLimit, cancelled.Order.Type);
-            Assert.AreEqual(OrderValidity.FillOrKill, cancelled.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.FillOrKill(), cancelled.Order.OrderValidity);
             Assert.AreEqual(0, cancelled.Order.FilledQuantity);
             Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
 

--- a/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
@@ -36,11 +36,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 3, marketLimit: true);
+            var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3);
 
             // assert
             Assert.IsNotNull(events);
@@ -66,11 +66,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, marketLimit: true);
+            var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5);
 
             // assert
             Assert.IsNotNull(events);
@@ -103,20 +103,19 @@ namespace Circus.Tests.OrderBook
 
             var marketBook = new InMemoryOrderBook(sec, TimeProvider);
             marketBook.UpdateStatus(OrderBookStatus.Open);
-            marketBook.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 500);
-            marketBook.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 10, 600);
+            marketBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
+            marketBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
 
             var marketLimitBook = new InMemoryOrderBook(sec, TimeProvider);
             marketLimitBook.UpdateStatus(OrderBookStatus.Open);
-            marketLimitBook.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 500);
-            marketLimitBook.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 10, 600);
+            marketLimitBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
+            marketLimitBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
 
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var marketEvents = marketBook.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 5);
-            var marketLimitEvents = marketLimitBook.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 5,
-                marketLimit: true);
+            var marketEvents = marketBook.CreateMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
+            var marketLimitEvents = marketLimitBook.CreateMarketLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
 
             // assert - the plain Market order sweeps both levels and fully fills
             Assert.AreEqual(3, marketEvents.Count);
@@ -151,7 +150,7 @@ namespace Circus.Tests.OrderBook
             Book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, marketLimit: true);
+            var events = Book.CreateMarketLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
 
             // assert
             Assert.IsNotNull(events);
@@ -166,12 +165,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.FillAndKill, Side.Buy, 5,
-                marketLimit: true);
+            var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.FillAndKill(), Side.Buy, 5);
 
             // assert
             Assert.IsNotNull(events);
@@ -200,13 +198,12 @@ namespace Circus.Tests.OrderBook
             // count the best level for a market-limit order, so this must be rejected even
             // though 12 combined would be enough for an order that could sweep
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 10, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 110);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.FillOrKill, Side.Buy, 5,
-                marketLimit: true);
+            var events = Book.CreateMarketLimitOrder(CompanyId3, OrderId3, new OrderValidity.FillOrKill(), Side.Buy, 5);
 
             // assert
             Assert.IsNotNull(events);
@@ -227,12 +224,15 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.Process(new CreateOrder(Sec, CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 3,
-                MarketLimit: true));
+            var events = Book.Process(new CreateMarketLimitOrder
+            {
+                Security = Sec, CompanyId = CompanyId2, ClientOrderId = OrderId2, OrderValidity = new OrderValidity.Day(),
+                Side = Side.Buy, Quantity = 3
+            });
 
             // assert
             Assert.IsNotNull(events);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -38,7 +38,7 @@ namespace Circus.Tests.OrderBook
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // act
-            var events = book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 1000);
+            var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 1000);
 
             // assert
             Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
@@ -53,7 +53,7 @@ namespace Circus.Tests.OrderBook
             book.UpdateStatus(OrderBookStatus.Open);
 
             // act
-            var events = book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 1000);
+            var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 1000);
 
             // assert
             Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
@@ -68,15 +68,15 @@ namespace Circus.Tests.OrderBook
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // act/assert - at the reference price
-            var atReference = book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
+            var atReference = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
             Assert.IsInstanceOf<CreateOrderConfirmed>(atReference[0]);
 
             // act/assert - exactly on the band edge, inclusive
-            var atEdge = book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 150);
+            var atEdge = book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 150);
             Assert.IsInstanceOf<CreateOrderConfirmed>(atEdge[0]);
 
             // act/assert - one tick beyond the edge
-            var beyondEdge = book.CreateOrder(CompanyId1, OrderId3, OrderValidity.Day, Side.Buy, 5, 160);
+            var beyondEdge = book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 160);
             var rejected = beyondEdge[0] as CreateOrderRejected;
             Assert.IsNotNull(rejected);
             Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
@@ -91,20 +91,20 @@ namespace Circus.Tests.OrderBook
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // 160 is outside the original [50, 150] band
-            var beforeTrade = book.CreateOrder(CompanyId2, OrderId1, OrderValidity.Day, Side.Sell, 5, 160);
+            var beforeTrade = book.CreateLimitOrder(CompanyId2, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 160);
             Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (beforeTrade[0] as CreateOrderRejected)?.Reason);
 
             // act - a trade prints at 140, re-anchoring the band to [90, 190]
-            book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 140);
-            var matchEvents = book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 5, 140);
+            book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 140);
+            var matchEvents = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 140);
             Assert.IsInstanceOf<OrdersMatched>(matchEvents[^1]);
 
             // assert - 160 is now within the new [90, 190] band
-            var afterTrade = book.CreateOrder(CompanyId2, OrderId4, OrderValidity.Day, Side.Sell, 5, 160);
+            var afterTrade = book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 160);
             Assert.IsInstanceOf<CreateOrderConfirmed>(afterTrade[0]);
 
             // assert - 60 was within the original [50, 150] band, but is now outside [90, 190]
-            var nowOutOfBand = book.CreateOrder(CompanyId4, "Order5", OrderValidity.Day, Side.Buy, 5, 60);
+            var nowOutOfBand = book.CreateLimitOrder(CompanyId4, "Order5", new OrderValidity.Day(), Side.Buy, 5, 60);
             Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (nowOutOfBand[0] as CreateOrderRejected)?.Reason);
         }
 
@@ -115,7 +115,7 @@ namespace Circus.Tests.OrderBook
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
             var book = new InMemoryOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
-            book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
             // act - reprice to 200, outside the band
             var events = book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 200);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
@@ -33,7 +33,11 @@ namespace Circus.Tests.OrderBook
 
             // act - only Price set, no TriggerPrice: this must rest as a plain working limit
             // order, not get misrouted into the TriggerPrice slot as a hidden stop order
-            var events = Book.Process(new CreateOrder(Sec, CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100));
+            var events = Book.Process(new CreateLimitOrder
+            {
+                Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId1, OrderValidity = new OrderValidity.Day(),
+                Side = Side.Buy, Quantity = 3, Price = 100
+            });
 
             // assert
             Assert.IsNotNull(events);
@@ -51,10 +55,14 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // act - only Price set, no TriggerPrice: this must actually reprice the order
-            var events = Book.Process(new UpdateOrder(Sec, CompanyId1, OrderId2, OrderId1, Price: 110));
+            var events = Book.Process(new UpdateOrder
+            {
+                Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId2, PreviousClientOrderId = OrderId1,
+                Price = 110
+            });
 
             // assert
             Assert.IsNotNull(events);
@@ -68,14 +76,17 @@ namespace Circus.Tests.OrderBook
         public void Process_CancelOrder_Success()
         {
             // act
-            Book.Process(new CancelOrder(Sec, CompanyId1, OrderId3, OrderId1));
+            Book.Process(new CancelOrder
+            {
+                Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId3, PreviousClientOrderId = OrderId1
+            });
         }
 
         [Test]
         public void Process_UpdateStatus_Success()
         {
             // act
-            Book.Process(new UpdateStatus(Sec, OrderBookStatus.Open));
+            Book.Process(new OpenTrading { Security = Sec });
         }
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
@@ -39,17 +39,14 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
             TimeProvider.SetCurrentTime(Now3);
 
             // act - same SMP id as the first (older) resting sell, so that one is prevented and
             // the aggressor should fall through to the second (different company) resting sell
-            var events = Book.CreateOrder(CompanyId1, OrderId3, OrderValidity.Day, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1,
-                selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
 
             // assert
             Assert.IsNotNull(events);
@@ -85,14 +82,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1,
-                selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
 
             // assert
             Assert.IsNotNull(events);
@@ -119,14 +113,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1,
-                selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
 
             // assert
             Assert.IsNotNull(events);
@@ -154,13 +145,11 @@ namespace Circus.Tests.OrderBook
             // arrange - proves the check is id-based, not company-based: same CompanyId on both
             // sides, but different SMP ids, so it should NOT be prevented
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp2);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp2);
 
             // assert
             Assert.IsNotNull(events);
@@ -180,11 +169,11 @@ namespace Circus.Tests.OrderBook
             // arrange - same company, neither order opts into STP at all - confirms it's opt-in,
             // not automatic for same-company orders
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
 
             // assert
             Assert.IsNotNull(events);
@@ -201,13 +190,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
 
             // act - neither side specifies an instruction
-            var events = Book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
 
             // assert
             Assert.IsNotNull(events);
@@ -231,14 +218,11 @@ namespace Circus.Tests.OrderBook
             // arrange - the aggressor shares the SMP id but doesn't specify an instruction, so
             // the resting order's instruction should govern
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100,
-                selfMatchPreventionId: Smp1,
-                selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId2, OrderValidity.Day, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
 
             // assert
             Assert.IsNotNull(events);
@@ -255,13 +239,11 @@ namespace Circus.Tests.OrderBook
             // arrange - the only resting liquidity shares the incoming order's SMP id, so it
             // must be excluded from the upfront liquidity check rather than partially filled
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId2, OrderValidity.FillOrKill, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.FillOrKill(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
 
             // assert
             Assert.IsNotNull(events);
@@ -285,16 +267,13 @@ namespace Circus.Tests.OrderBook
             // from a different company right behind it. CancelResting only kills the resting
             // order, so the incoming order should keep going and see the liquidity behind it.
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId3, OrderValidity.FillOrKill, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1,
-                selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.FillOrKill(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
 
             // assert - accepted: the 2@100 self-match is skipped, the 5@100 behind it is enough
             Assert.IsNotNull(events);
@@ -324,16 +303,13 @@ namespace Circus.Tests.OrderBook
             // check must reflect that and reject upfront, not just skip the self-matched
             // quantity and keep counting past it.
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 10, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId3, OrderValidity.FillOrKill, Side.Buy, 5, 100,
-                selfMatchPreventionId: Smp1,
-                selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.FillOrKill(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
 
             // assert - rejected: reachable liquidity before the self-match is 0, well short of 5,
             // even though 10 more sits just behind it in the queue
@@ -361,16 +337,13 @@ namespace Circus.Tests.OrderBook
             // incoming order the instant it reaches the self-match, so it never gets to the
             // second price level at all, no matter how much liquidity is sitting there.
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 2, 100,
-                selfMatchPreventionId: Smp1);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 20, 110);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 110);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
-            var events = Book.CreateOrder(CompanyId1, OrderId3, OrderValidity.FillOrKill, Side.Buy, 5, 110,
-                selfMatchPreventionId: Smp1,
-                selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.FillOrKill(), Side.Buy, 5, 110, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
 
             // assert - rejected: the self-match at 100 stops the search cold, so the 20 sitting
             // at 110 is never even considered

--- a/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
@@ -48,26 +48,26 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 500); // last traded price -> 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
             TimeProvider.SetCurrentTime(Now3);
-            var restingOffer = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 5, 520);
+            var restingOffer = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520);
             Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
 
             TimeProvider.SetCurrentTime(Now4);
-            var stopEvents = Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Buy, 5, 530, 510);
+            var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
             Assert.AreEqual(1, stopEvents.Count);
             Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
             Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
 
             TimeProvider.SetCurrentTime(Now5);
-            var restingBid = Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 2, 510); // to be hit
+            var restingBid = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510); // to be hit
             Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
 
             // act - trade at the trigger price
             TimeProvider.SetCurrentTime(Now6);
-            var events = Book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Buy, 2, 510);
+            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
 
             // assert
             var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 510);
@@ -91,26 +91,26 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 500); // last traded price -> 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
             TimeProvider.SetCurrentTime(Now3);
-            var restingBid = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 5, 480);
+            var restingBid = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 480);
             Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
 
             TimeProvider.SetCurrentTime(Now4);
-            var stopEvents = Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 5, 470, 490);
+            var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 470, 490);
             Assert.AreEqual(1, stopEvents.Count);
             Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
             Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
 
             TimeProvider.SetCurrentTime(Now5);
-            var restingOffer = Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Buy, 2, 490); // to be hit
+            var restingOffer = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 490); // to be hit
             Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
 
             // act - trade at the trigger price
             TimeProvider.SetCurrentTime(Now6);
-            var events = Book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Sell, 2, 490);
+            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 2, 490);
 
             // assert
             var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 490);
@@ -134,18 +134,18 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 500); // last traded price -> 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
             // buy stop above market: only triggers once price rises to/through 510
             TimeProvider.SetCurrentTime(Now3);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 5, 520, 510);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 520, 510);
 
             // act - trade at a lower price, moving further away from the trigger
             TimeProvider.SetCurrentTime(Now4);
-            Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Buy, 1, 490);
+            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 490);
             TimeProvider.SetCurrentTime(Now5);
-            var events = Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 1, 490);
+            var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 490);
 
             // assert
             Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 490));
@@ -164,18 +164,18 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 500); // last traded price -> 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
             // sell stop below market: only triggers once price falls to/through 490
             TimeProvider.SetCurrentTime(Now3);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 5, 480, 490);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 480, 490);
 
             // act - trade at a higher price, moving further away from the trigger
             TimeProvider.SetCurrentTime(Now4);
-            Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Buy, 1, 510);
+            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 510);
             TimeProvider.SetCurrentTime(Now5);
-            var events = Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 1, 510);
+            var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 510);
 
             // assert
             Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
@@ -194,19 +194,19 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 500); // last traded price -> 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
             // buy stop market above market; when it triggers there must be resting sell orders for it to
             // convert into a priced limit order - here there are none, so it should be cancelled, not throw
             TimeProvider.SetCurrentTime(Now3);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 5, null, 510);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 510);
 
             // act - trade at the trigger price with no resting sell orders left in the book afterwards
             TimeProvider.SetCurrentTime(Now4);
-            Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Sell, 2, 510);
+            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 510);
             TimeProvider.SetCurrentTime(Now5);
-            var events = Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Buy, 2, 510);
+            var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 510);
 
             // assert
             Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
@@ -219,7 +219,7 @@ namespace Circus.Tests.OrderBook
             // an order id is a permanent identity once it completes - reuse is rejected, not silently
             // accepted (see issue #1), and book state remains consistent either way
             TimeProvider.SetCurrentTime(Now6);
-            var recreate = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 1, 510);
+            var recreate = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 510);
             var rejected = recreate[0] as CreateOrderRejected;
             Assert.IsNotNull(rejected);
             Assert.AreEqual(OrderRejectedReason.OrderIdAlreadyUsed, rejected.Reason);
@@ -230,21 +230,21 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 500);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 500); // last traded price -> 500
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
             TimeProvider.SetCurrentTime(Now3);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 1, 530, 510);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 530, 510);
 
             TimeProvider.SetCurrentTime(Now4);
-            Book.CreateOrder(CompanyId4, OrderId4, OrderValidity.Day, Side.Buy, 1, 540, 520);
+            Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 540, 520);
 
             TimeProvider.SetCurrentTime(Now5);
-            Book.CreateOrder(CompanyId5, OrderId5, OrderValidity.Day, Side.Sell, 2, 520); // resting offer for the gap trade
+            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 520); // resting offer for the gap trade
 
             // act - price gaps straight from 500 to 520, passing through both trigger levels
             TimeProvider.SetCurrentTime(Now6);
-            var events = Book.CreateOrder(CompanyId6, OrderId6, OrderValidity.Day, Side.Buy, 2, 520);
+            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 520);
 
             // assert
             Assert.IsTrue(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),

--- a/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
@@ -42,7 +42,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100)
+            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
                 .OfType<CreateOrderConfirmed>().Single();
             TimeProvider.SetCurrentTime(Now2);
 
@@ -63,7 +63,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -86,7 +86,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
             Assert.AreEqual(OrderType.Limit, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, updated.Order.Side);
             Assert.AreEqual(100, updated.Order.Price);
             Assert.IsNull(updated.Order.TriggerPrice);
@@ -101,9 +101,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, null, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -126,7 +126,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
             Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, updated.Order.Side);
             Assert.IsNull(updated.Order.Price);
             Assert.AreEqual(110, updated.Order.TriggerPrice);
@@ -143,7 +143,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, side, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -166,7 +166,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
             Assert.AreEqual(OrderType.Limit, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(side, updated.Order.Side);
             Assert.AreEqual(price, updated.Order.Price);
             Assert.IsNull(updated.Order.TriggerPrice);
@@ -183,9 +183,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, side, 3, triggerPrice, triggerPrice);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, triggerPrice, triggerPrice);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -208,7 +208,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
             Assert.AreEqual(OrderType.StopLimit, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(side, updated.Order.Side);
             Assert.AreEqual(newPrice, updated.Order.Price);
             Assert.AreEqual(triggerPrice, updated.Order.TriggerPrice);
@@ -226,9 +226,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, side, 3, price, triggerPrice);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, price, triggerPrice);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -251,7 +251,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
             Assert.AreEqual(OrderType.StopLimit, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(side, updated.Order.Side);
             Assert.AreEqual(price, updated.Order.Price);
             Assert.AreEqual(newTriggerPrice, updated.Order.TriggerPrice);
@@ -265,7 +265,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -288,7 +288,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
             Assert.AreEqual(OrderType.Limit, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, updated.Order.Side);
             Assert.AreEqual(100, updated.Order.Price);
             Assert.IsNull(updated.Order.TriggerPrice);
@@ -302,9 +302,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, null, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -327,7 +327,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
             Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, updated.Order.Side);
             Assert.IsNull(updated.Order.Price);
             Assert.AreEqual(110, updated.Order.TriggerPrice);
@@ -341,9 +341,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, null, 90);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 90);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -366,7 +366,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(updated.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
             Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, updated.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
             Assert.AreEqual(Side.Sell, updated.Order.Side);
             Assert.IsNull(updated.Order.Price);
             Assert.AreEqual(90, updated.Order.TriggerPrice);
@@ -380,8 +380,8 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 4, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -405,7 +405,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
             Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, cancelled.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, cancelled.Order.Side);
             Assert.AreEqual(100, cancelled.Order.Price);
             Assert.IsNull(cancelled.Order.TriggerPrice);
@@ -420,8 +420,8 @@ namespace Circus.Tests.OrderBook
             // arrange - quantity on UpdateOrder is the order's new TOTAL size (filled + remaining),
             // not the new remaining/resting amount (see issue #1, finding 2)
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 10, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 4, 100); // partial fill: 4@100
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 10, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 100); // partial fill: 4@100
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -436,7 +436,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(2, updated.Order.RemainingQuantity);
 
             // a follow-up buy for the full new total should only find the 2 that remain
-            var matched = Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 6, 110)
+            var matched = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 6, 110)
                 .OfType<OrdersMatched>().Single();
             Assert.AreEqual(2, matched.Quantity);
         }
@@ -446,9 +446,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Sell, 5, 90);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Buy, 5, 80);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 80);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
@@ -482,7 +482,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsNull(matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(80, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -505,7 +505,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(70, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -519,7 +519,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             Book.UpdateStatus(OrderBookStatus.Closed);
 
             // act
@@ -544,7 +544,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // act
             var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1);
@@ -568,7 +568,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
             // act
             var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, quantity, 110);
@@ -594,7 +594,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 6, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, 100);
 
             // act
             var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, price);
@@ -620,7 +620,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 6, null, 100);
+            Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, 100);
 
             // act
             var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, null, triggerPrice);
@@ -643,9 +643,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100)
+            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
                 .OfType<CreateOrderConfirmed>().Single();
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -671,7 +671,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             Book.CancelOrder(CompanyId1, OrderId6, OrderId1);
             TimeProvider.SetCurrentTime(Now2);
 
@@ -696,7 +696,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
             Book.UpdateStatus(OrderBookStatus.Closed);
             Book.UpdateStatus(OrderBookStatus.Open);
 
@@ -721,9 +721,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, null, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
             Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
             TimeProvider.SetCurrentTime(Now2);
 
@@ -748,9 +748,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, null, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
             Book.UpdateStatus(OrderBookStatus.Closed);
             Book.UpdateStatus(OrderBookStatus.Open);
 
@@ -799,9 +799,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, 110, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 100);
 
             // act
             var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: 120);
@@ -824,9 +824,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 70, 80);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 80);
 
             // act
             var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: 60);
@@ -849,9 +849,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, 110, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 110);
 
             // act
             var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: 100);
@@ -874,9 +874,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 70, 70);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 70);
 
             // act
             var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: 80);
@@ -900,9 +900,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 3, 70, 70);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 70);
 
             // act
             var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: triggerPrice);
@@ -926,9 +926,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 3, 90);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 3, 90);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Buy, 3, 110, 110);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 110);
 
             // act
             var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: triggerPrice);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
@@ -55,9 +55,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
             TimeProvider.SetCurrentTime(Now3);
 
             // act
@@ -90,7 +90,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched.Fills[0].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[0].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
             Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
             Assert.AreEqual(100, matched.Fills[0].Order.Price);
             Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
@@ -113,7 +113,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
             Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderValidity.Day, matched.Fills[1].Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
             Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
             Assert.AreEqual(100, matched.Fills[1].Order.Price);
             Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
@@ -127,7 +127,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -150,7 +150,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, expired.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
             Assert.AreEqual(OrderType.Limit, expired.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, expired.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), expired.Order.OrderValidity);
             Assert.AreEqual(Side.Buy, expired.Order.Side);
             Assert.AreEqual(100, expired.Order.Price);
             Assert.IsNull(expired.Order.TriggerPrice);
@@ -164,9 +164,9 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.Day, Side.Buy, 5, 100);
-            Book.CreateOrder(CompanyId2, OrderId2, OrderValidity.Day, Side.Sell, 5, 100);
-            Book.CreateOrder(CompanyId3, OrderId3, OrderValidity.Day, Side.Sell, 5, null, 90);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 90);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -189,7 +189,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(Now2, expired.Order.CompletedTime);
             Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
             Assert.AreEqual(OrderType.StopMarket, expired.Order.Type);
-            Assert.AreEqual(OrderValidity.Day, expired.Order.OrderValidity);
+            Assert.AreEqual(new OrderValidity.Day(), expired.Order.OrderValidity);
             Assert.AreEqual(Side.Sell, expired.Order.Side);
             Assert.IsNull(expired.Order.Price);
             Assert.AreEqual(90, expired.Order.TriggerPrice);
@@ -203,7 +203,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilCanceled, Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -226,8 +226,7 @@ namespace Circus.Tests.OrderBook
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
             var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(1);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilDate, Side.Buy, 5, 100,
-                goodTilDate: goodTilDate);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -250,8 +249,7 @@ namespace Circus.Tests.OrderBook
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
             var goodTilDate = DateOnly.FromDateTime(Now1);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilDate, Side.Buy, 5, 100,
-                goodTilDate: goodTilDate);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
             TimeProvider.SetCurrentTime(Now2);
 
             // act
@@ -269,8 +267,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(CompanyId1, expired.Order.CompanyId);
             Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
             Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-            Assert.AreEqual(OrderValidity.GoodTilDate, expired.Order.OrderValidity);
-            Assert.AreEqual(goodTilDate, expired.Order.GoodTilDate);
+            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, expired.Order.OrderValidity);
         }
 
         [Test]
@@ -280,8 +277,7 @@ namespace Circus.Tests.OrderBook
             // on the close of the session where the date is reached
             Book.UpdateStatus(OrderBookStatus.Open);
             var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(2);
-            Book.CreateOrder(CompanyId1, OrderId1, OrderValidity.GoodTilDate, Side.Buy, 5, 100,
-                goodTilDate: goodTilDate);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
             Book.UpdateStatus(OrderBookStatus.Closed); // day 1 close, not due
 
             var day2 = Now1.AddDays(1);
@@ -309,8 +305,7 @@ namespace Circus.Tests.OrderBook
             Assert.AreEqual(CompanyId1, expired.CompanyId);
             Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
             Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-            Assert.AreEqual(OrderValidity.GoodTilDate, expired.Order.OrderValidity);
-            Assert.AreEqual(goodTilDate, expired.Order.GoodTilDate);
+            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, expired.Order.OrderValidity);
         }
     }
 }

--- a/Circus/DataProducers/IDataProducer.cs
+++ b/Circus/DataProducers/IDataProducer.cs
@@ -5,6 +5,6 @@ namespace Circus.DataProducers
 {
     public interface IDataProducer<T>
     {
-        IList<T> Process(IOrderBook book, IList<OrderBookEvent> events);
+        IList<T> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events);
     }
 }

--- a/Circus/DataProducers/LevelDataProducer.cs
+++ b/Circus/DataProducers/LevelDataProducer.cs
@@ -16,7 +16,7 @@ namespace Circus.DataProducers
             _maxLevels = maxLevels;
         }
 
-        public IList<LevelsDataEvent> Process(IOrderBook book, IList<OrderBookEvent> events)
+        public IList<LevelsDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
         {
             var bids = book.GetLevels(Side.Buy, _maxLevels);
             var offers = book.GetLevels(Side.Sell, _maxLevels);
@@ -25,5 +25,5 @@ namespace Circus.DataProducers
         }
     }
 
-    public record LevelsDataEvent(DateTime Time, IList<Level> Bids, IList<Level> Offers);
+    public record LevelsDataEvent(DateTime Time, IReadOnlyList<Level> Bids, IReadOnlyList<Level> Offers);
 }

--- a/Circus/DataProducers/TradeDataProducer.cs
+++ b/Circus/DataProducers/TradeDataProducer.cs
@@ -6,7 +6,7 @@ namespace Circus.DataProducers
 {
     public class TradeDataProducer : IDataProducer<TradedDataEvent>
     {
-        public IList<TradedDataEvent> Process(IOrderBook book, IList<OrderBookEvent> events)
+        public IList<TradedDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
         {
             var output = new List<TradedDataEvent>();
 

--- a/Circus/Order.cs
+++ b/Circus/Order.cs
@@ -19,7 +19,6 @@ namespace Circus
         int RemainingQuantity,
         decimal? Price,
         decimal? TriggerPrice,
-        DateOnly? GoodTilDate = null,
         string? SelfMatchPreventionId = null,
         SelfMatchPreventionInstruction? SelfMatchPreventionInstruction = null
     );

--- a/Circus/OrderBook/IOrderBook.cs
+++ b/Circus/OrderBook/IOrderBook.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Circus.OrderBook
@@ -9,21 +8,8 @@ namespace Circus.OrderBook
 
         OrderBookStatus Status { get; }
 
-        IList<Level> GetLevels(Side side, int maxPrices);
+        IReadOnlyList<Level> GetLevels(Side side, int maxPrices);
 
-        IList<OrderBookEvent> Process(OrderBookAction action);
-
-        IList<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity, Side side,
-            int quantity, decimal? price = null, decimal? triggerPrice = null, bool marketLimit = false,
-            DateOnly? goodTilDate = null, string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null);
-
-        // quantity is the order's new total size (filled + remaining), not the new remaining/resting amount
-        IList<OrderBookEvent> UpdateOrder(string companyId, string clientOrderId, string previousClientOrderId,
-            int? quantity = null, decimal? price = null, decimal? triggerPrice = null);
-
-        IList<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId);
-
-        IList<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null);
+        IReadOnlyList<OrderBookEvent> Process(OrderBookAction action);
     }
 }

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -171,7 +171,7 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
-            events.AddRange(Match());
+            Match(events);
 
             if (order.Validity == OrderValidity.FillAndKill && order.Status == OrderStatus.Working)
                 events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
@@ -374,7 +374,7 @@ namespace Circus.OrderBook
 
             List<OrderBookEvent> events = new();
             events.Add(new UpdateOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId));
-            events.AddRange(Match());
+            Match(events);
             return events;
         }
 
@@ -477,14 +477,13 @@ namespace Circus.OrderBook
         private InternalOrder? BestOrder(Side side) =>
             _working[side].TryGetBest(out _, out var order) ? order : null;
 
-        private IEnumerable<OrderBookEvent> Match()
+        private void Match(List<OrderBookEvent> events)
         {
             if (_status != OrderBookStatus.Open)
             {
-                return Array.Empty<OrderBookEvent>();
+                return;
             }
 
-            var events = new List<OrderBookEvent>();
             var time = Now();
 
             var buy = BestOrder(Side.Buy);
@@ -538,14 +537,12 @@ namespace Circus.OrderBook
                 {
                     _lastTradedPrice = priceTicks;
                     _bandReferencePriceTicks = priceTicks;
-                    events.AddRange(CheckStops());
+                    CheckStops(events);
                 }
 
                 buy = BestOrder(Side.Buy);
                 sell = BestOrder(Side.Sell);
             }
-
-            return events;
         }
 
         // Two orders are a prevented self-match only if both carry the same non-null
@@ -572,7 +569,7 @@ namespace Circus.OrderBook
             return true;
         }
 
-        private IEnumerable<OrderBookEvent> CheckStops()
+        private void CheckStops(List<OrderBookEvent> events)
         {
             var time = Now();
             var triggered = new SortedDictionary<long, InternalOrder>();
@@ -591,12 +588,10 @@ namespace Circus.OrderBook
                 _stops[Side.Sell].RemoveLevel(sellTick);
             }
 
-            var events = new List<OrderBookEvent>();
-
             if (triggered.Any())
             {
-                events.AddRange(TriggerStops(triggered, time));
-                events.AddRange(Match());
+                TriggerStops(triggered, time, events);
+                Match(events);
 
                 foreach (var order in triggered.Values)
                 {
@@ -604,14 +599,11 @@ namespace Circus.OrderBook
                         events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
                 }
             }
-
-            return events;
         }
 
-        private IList<OrderBookEvent> TriggerStops(SortedDictionary<long, InternalOrder> orders, DateTime time)
+        private void TriggerStops(SortedDictionary<long, InternalOrder> orders, DateTime time,
+            List<OrderBookEvent> events)
         {
-            var events = new List<OrderBookEvent>();
-
             foreach (var (_, order) in orders)
             {
                 // calculate price for stop market orders
@@ -650,8 +642,6 @@ namespace Circus.OrderBook
                 events.Add(new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
                     order.ClientOrderId));
             }
-
-            return events;
         }
 
         public IList<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null)
@@ -681,7 +671,7 @@ namespace Circus.OrderBook
         {
             _status = OrderBookStatus.Open;
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
-            events.AddRange(Match());
+            Match(events);
             return events;
         }
 

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -55,7 +55,7 @@ namespace Circus.OrderBook
         public Security Security => _security;
         public OrderBookStatus Status => _status;
 
-        public IList<Level> GetLevels(Side side, int maxPrices)
+        public IReadOnlyList<Level> GetLevels(Side side, int maxPrices)
         {
             return _working[side].EnumerateFromBest().Take(maxPrices)
                 .Select(x => new Level(ToDecimal(x.Tick), SumRemaining(x.First), x.Count))
@@ -70,38 +70,37 @@ namespace Circus.OrderBook
             return total;
         }
 
-        public IList<OrderBookEvent> Process(OrderBookAction action)
+        public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
         {
             return action switch
             {
-                CreateOrder create => CreateOrder(create.CompanyId, create.ClientOrderId, create.OrderValidity,
-                    create.Side, create.Quantity, create.Price, create.TriggerPrice, create.MarketLimit,
-                    create.GoodTilDate, create.SelfMatchPreventionId, create.SelfMatchPreventionInstruction),
+                CreateLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
+                    OrderType.Limit, o.Price, null, o.SelfMatchPrevention),
+                CreateMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
+                    OrderType.Market, null, null, o.SelfMatchPrevention),
+                CreateMarketLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
+                    o.Quantity, OrderType.MarketLimit, null, null, o.SelfMatchPrevention),
+                CreateStopLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
+                    o.Quantity, OrderType.StopLimit, o.Price, o.TriggerPrice, o.SelfMatchPrevention),
+                CreateStopMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
+                    o.Quantity, OrderType.StopMarket, null, o.TriggerPrice, o.SelfMatchPrevention),
                 UpdateOrder update => UpdateOrder(update.CompanyId, update.ClientOrderId,
-                    update.PreviousClientOrderId, update.Quantity, update.Price, update.TriggerPrice),
+                    update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice),
                 CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId),
-                UpdateStatus update => UpdateStatus(update.Status, update.ReferencePrice),
+                PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice),
+                OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice),
+                CloseTrading => UpdateStatus(OrderBookStatus.Closed, null),
                 _ => throw new ArgumentException("Unknown order book action")
             };
         }
 
-        public IList<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity, Side side,
-            int quantity, decimal? price = null, decimal? triggerPrice = null, bool marketLimit = false,
-            DateOnly? goodTilDate = null, string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null)
+        private List<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity,
+            Side side, int quantity, OrderType type, decimal? price = null, decimal? triggerPrice = null,
+            SelfMatchPrevention? selfMatchPrevention = null)
         {
-            var type = price.HasValue ? OrderType.Limit : OrderType.Market;
-            var status = OrderStatus.Working;
-
-            if (triggerPrice.HasValue)
-            {
-                type = (type == OrderType.Market ? OrderType.StopMarket : OrderType.StopLimit);
-                status = OrderStatus.Hidden;
-            }
-            else if (marketLimit && type == OrderType.Market)
-            {
-                type = OrderType.MarketLimit;
-            }
+            var selfMatchPreventionId = selfMatchPrevention?.Id;
+            var selfMatchPreventionInstruction = selfMatchPrevention?.Instruction;
+            var status = triggerPrice.HasValue ? OrderStatus.Hidden : OrderStatus.Working;
 
             if (_status == OrderBookStatus.Closed)
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketClosed);
@@ -149,18 +148,16 @@ namespace Circus.OrderBook
                     return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoOrdersToMatchMarketOrder);
             }
 
-            if (validity == OrderValidity.FillOrKill && !triggerTicks.HasValue &&
+            if (validity is OrderValidity.FillOrKill && !triggerTicks.HasValue &&
                 !HasSufficientLiquidity(side, priceTicks!.Value, quantity, selfMatchPreventionId,
                     selfMatchPreventionInstruction))
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InsufficientLiquidityForFillOrKill);
-            if (validity == OrderValidity.GoodTilDate && !goodTilDate.HasValue)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.GoodTilDateRequired);
-            if (goodTilDate.HasValue && goodTilDate.Value < DateOnly.FromDateTime(Now()))
+            if (validity is OrderValidity.GoodTilDate { Date: var goodTilDate } && goodTilDate < DateOnly.FromDateTime(Now()))
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidExpireDate);
 
             _nextSequenceNumber++;
             var order = new InternalOrder(_nextSequenceNumber, companyId, clientOrderId, _security, Now(), status,
-                type, validity, side, quantity, priceTicks, triggerTicks, goodTilDate, selfMatchPreventionId,
+                type, validity, side, quantity, priceTicks, triggerTicks, selfMatchPreventionId,
                 selfMatchPreventionInstruction);
 
             _orders.Add(order.ExchangeOrderId, order);
@@ -173,7 +170,7 @@ namespace Circus.OrderBook
             events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
             Match(events);
 
-            if (order.Validity == OrderValidity.FillAndKill && order.Status == OrderStatus.Working)
+            if (order.Validity is OrderValidity.FillAndKill && order.Status == OrderStatus.Working)
                 events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
 
             return events;
@@ -272,8 +269,8 @@ namespace Circus.OrderBook
                 reason);
         }
 
-        public IList<OrderBookEvent> UpdateOrder(string companyId, string clientOrderId, string previousClientOrderId,
-            int? quantity = null, decimal? price = null, decimal? triggerPrice = null)
+        private List<OrderBookEvent> UpdateOrder(string companyId, string clientOrderId, string previousClientOrderId,
+            int? newTotalQuantity = null, decimal? price = null, decimal? triggerPrice = null)
         {
             if (_status == OrderBookStatus.Closed)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
@@ -285,9 +282,9 @@ namespace Circus.OrderBook
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired);
             if (companyId.Length > MaxClientOrderIdLength)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong);
-            if (quantity == null && price == null && triggerPrice == null)
+            if (newTotalQuantity == null && price == null && triggerPrice == null)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.NoChange);
-            if (quantity != null && quantity < 1)
+            if (newTotalQuantity != null && newTotalQuantity < 1)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidQuantity);
             if (!TryConvertToTicks(price, out var priceTicks))
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
@@ -337,7 +334,7 @@ namespace Circus.OrderBook
 
             // TODO: can't update price on stop market order?
 
-            if (quantity <= order.FilledQuantity)
+            if (newTotalQuantity <= order.FilledQuantity)
             {
                 order.Cancel(Now(), clientOrderId);
                 _clientOrderIndex[(companyId, clientOrderId)] = order;
@@ -353,7 +350,7 @@ namespace Circus.OrderBook
             var sequenceNumber = order.SequenceNumber;
             var isPriceChange = (triggerTicks != null && order.Status == OrderStatus.Hidden && triggerTicks != order.TriggerPrice) ||
                                 (priceTicks != null && order.Status != OrderStatus.Hidden && priceTicks != order.Price);
-            var isQuantityIncrease = (quantity != null && quantity > order.Quantity);
+            var isQuantityIncrease = (newTotalQuantity != null && newTotalQuantity > order.Quantity);
 
             var orders = (order.Status == OrderStatus.Hidden ? _stops : _working);
 
@@ -369,7 +366,7 @@ namespace Circus.OrderBook
                 orders[order.Side].Remove(currentPriceTicks, order);
                 orders[order.Side].Add(updatedPriceTicks, order);
             }
-            order.Update(sequenceNumber, Now(), quantity, triggerTicks, priceTicks, clientOrderId);
+            order.Update(sequenceNumber, Now(), newTotalQuantity, triggerTicks, priceTicks, clientOrderId);
             _clientOrderIndex[(companyId, clientOrderId)] = order;
 
             List<OrderBookEvent> events = new();
@@ -378,7 +375,7 @@ namespace Circus.OrderBook
             return events;
         }
 
-        public IList<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId)
+        private List<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId)
         {
             if (_status == OrderBookStatus.Closed)
                 return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
@@ -595,7 +592,7 @@ namespace Circus.OrderBook
 
                 foreach (var order in triggered.Values)
                 {
-                    if (order.Validity == OrderValidity.FillAndKill && order.RemainingQuantity > 0)
+                    if (order.Validity is OrderValidity.FillAndKill && order.RemainingQuantity > 0)
                         events.Add(CancelRemainder(order, OrderCancelledReason.FillAndKillNotFilled));
                 }
             }
@@ -620,7 +617,7 @@ namespace Circus.OrderBook
                     continue;
                 }
 
-                if (order.Validity == OrderValidity.FillOrKill &&
+                if (order.Validity is OrderValidity.FillOrKill &&
                     !HasSufficientLiquidity(order.Side, newPriceTicks!.Value, order.RemainingQuantity,
                         order.SelfMatchPreventionId, order.SelfMatchPreventionInstruction))
                 {
@@ -644,7 +641,7 @@ namespace Circus.OrderBook
             }
         }
 
-        public IList<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null)
+        private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null)
         {
             if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
                 _bandReferencePriceTicks = referenceTicks;
@@ -658,7 +655,7 @@ namespace Circus.OrderBook
             };
         }
 
-        private IList<OrderBookEvent> PreOpenMarket()
+        private List<OrderBookEvent> PreOpenMarket()
         {
             // TODO: need better system for multiple sessions per day
             var date = Now();
@@ -667,7 +664,7 @@ namespace Circus.OrderBook
             return new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
         }
 
-        private IList<OrderBookEvent> OpenMarket()
+        private List<OrderBookEvent> OpenMarket()
         {
             _status = OrderBookStatus.Open;
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
@@ -675,7 +672,7 @@ namespace Circus.OrderBook
             return events;
         }
 
-        private IList<OrderBookEvent> CloseMarket()
+        private List<OrderBookEvent> CloseMarket()
         {
             _status = OrderBookStatus.Closed;
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
@@ -687,8 +684,8 @@ namespace Circus.OrderBook
         {
             var today = DateOnly.FromDateTime(Now());
             var orders = _orders.Values.Where(o =>
-                o.Validity == OrderValidity.Day ||
-                (o.Validity == OrderValidity.GoodTilDate && o.GoodTilDate <= today)).ToList();
+                o.Validity is OrderValidity.Day ||
+                (o.Validity is OrderValidity.GoodTilDate { Date: var date } && date <= today)).ToList();
 
             return orders.Select(ExpireOrder).ToList();
         }

--- a/Circus/OrderBook/InternalOrder.cs
+++ b/Circus/OrderBook/InternalOrder.cs
@@ -25,7 +25,6 @@ namespace Circus.OrderBook
         public int FilledQuantity { get; private set; }
         public long? Price { get; private set; }
         public long? TriggerPrice { get; private set; }
-        public DateOnly? GoodTilDate { get; }
         public string? SelfMatchPreventionId { get; }
         public SelfMatchPreventionInstruction? SelfMatchPreventionInstruction { get; }
 
@@ -37,7 +36,7 @@ namespace Circus.OrderBook
 
         public InternalOrder(long sequenceNumber, string companyId, string clientOrderId, Security security, DateTime time,
             OrderStatus status, OrderType type, OrderValidity validity, Side side, int quantity, long? price,
-            long? triggerPrice, DateOnly? goodTilDate = null, string? selfMatchPreventionId = null,
+            long? triggerPrice, string? selfMatchPreventionId = null,
             SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null)
         {
             SequenceNumber = sequenceNumber;
@@ -56,7 +55,6 @@ namespace Circus.OrderBook
             FilledQuantity = 0;
             Price = price;
             TriggerPrice = triggerPrice;
-            GoodTilDate = goodTilDate;
             SelfMatchPreventionId = selfMatchPreventionId;
             SelfMatchPreventionInstruction = selfMatchPreventionInstruction;
         }
@@ -68,7 +66,7 @@ namespace Circus.OrderBook
         {
             return new(CompanyId, ExchangeOrderId, ClientOrderId, Security, CreatedTime, ModifiedTime, CompletedTime,
                 Status, Type, Validity, Side, Quantity, FilledQuantity, RemainingQuantity, ToDecimal(Price),
-                ToDecimal(TriggerPrice), GoodTilDate, SelfMatchPreventionId, SelfMatchPreventionInstruction);
+                ToDecimal(TriggerPrice), SelfMatchPreventionId, SelfMatchPreventionInstruction);
         }
 
         private decimal? ToDecimal(long? ticks) => ticks.HasValue ? ticks.Value * Security.TickSize : null;

--- a/Circus/OrderBook/OrderBookAction.cs
+++ b/Circus/OrderBook/OrderBookAction.cs
@@ -1,25 +1,76 @@
-using System;
-
 namespace Circus.OrderBook
 {
-    public record OrderBookAction(Security Security);
+    public abstract record OrderBookAction
+    {
+        public required Security Security { get; init; }
+    }
 
-    public record UpdateStatus(Security Security, OrderBookStatus Status, decimal? ReferencePrice = null)
-        : OrderBookAction(Security);
+    public sealed record PreOpenTrading : OrderBookAction
+    {
+        public decimal? ReferencePrice { get; init; }
+    }
 
-    public record OrderAction(Security Security, string CompanyId, string ClientOrderId)
-        : OrderBookAction(Security);
+    public sealed record OpenTrading : OrderBookAction
+    {
+        public decimal? ReferencePrice { get; init; }
+    }
 
-    public record CreateOrder(Security Security, string CompanyId, string ClientOrderId, OrderValidity OrderValidity,
-            Side Side, int Quantity, decimal? Price = null, decimal? TriggerPrice = null, bool MarketLimit = false,
-            DateOnly? GoodTilDate = null, string? SelfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? SelfMatchPreventionInstruction = null)
-        : OrderAction(Security, CompanyId, ClientOrderId);
+    public sealed record CloseTrading : OrderBookAction;
 
-    public record UpdateOrder(Security Security, string CompanyId, string ClientOrderId, string PreviousClientOrderId,
-            int? Quantity = null, decimal? Price = null, decimal? TriggerPrice = null)
-        : OrderAction(Security, CompanyId, ClientOrderId);
+    public abstract record OrderAction : OrderBookAction
+    {
+        public required string CompanyId { get; init; }
+        public required string ClientOrderId { get; init; }
+    }
 
-    public record CancelOrder(Security Security, string CompanyId, string ClientOrderId, string PreviousClientOrderId)
-        : OrderAction(Security, CompanyId, ClientOrderId);
+    // Id is required: an instruction with no id is meaningless (nothing to match against), so
+    // rather than let that combination be constructed and silently ignored, opting into self-match
+    // prevention at all means supplying an id - Instruction is the only genuinely optional part,
+    // falling back to CancelResting when omitted.
+    public sealed record SelfMatchPrevention
+    {
+        public required string Id { get; init; }
+        public SelfMatchPreventionInstruction? Instruction { get; init; }
+    }
+
+    public abstract record CreateOrder : OrderAction
+    {
+        public required OrderValidity OrderValidity { get; init; }
+        public required Side Side { get; init; }
+        public required int Quantity { get; init; }
+        public SelfMatchPrevention? SelfMatchPrevention { get; init; }
+    }
+
+    public sealed record CreateLimitOrder : CreateOrder
+    {
+        public required decimal Price { get; init; }
+    }
+
+    public sealed record CreateMarketOrder : CreateOrder;
+
+    public sealed record CreateMarketLimitOrder : CreateOrder;
+
+    public sealed record CreateStopLimitOrder : CreateOrder
+    {
+        public required decimal Price { get; init; }
+        public required decimal TriggerPrice { get; init; }
+    }
+
+    public sealed record CreateStopMarketOrder : CreateOrder
+    {
+        public required decimal TriggerPrice { get; init; }
+    }
+
+    public sealed record UpdateOrder : OrderAction
+    {
+        public required string PreviousClientOrderId { get; init; }
+        public int? NewTotalQuantity { get; init; }
+        public decimal? Price { get; init; }
+        public decimal? TriggerPrice { get; init; }
+    }
+
+    public sealed record CancelOrder : OrderAction
+    {
+        public required string PreviousClientOrderId { get; init; }
+    }
 }

--- a/Circus/OrderBook/OrderBookExtensions.cs
+++ b/Circus/OrderBook/OrderBookExtensions.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+
+namespace Circus.OrderBook
+{
+    public static class OrderBookExtensions
+    {
+        private static SelfMatchPrevention? BuildSelfMatchPrevention(string? id,
+            SelfMatchPreventionInstruction? instruction) =>
+            id == null ? null : new SelfMatchPrevention { Id = id, Instruction = instruction };
+
+        public static IReadOnlyList<OrderBookEvent> CreateLimitOrder(this IOrderBook book, string companyId,
+            string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
+            string? selfMatchPreventionId = null,
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            book.Process(new CreateLimitOrder
+            {
+                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+                OrderValidity = orderValidity, Side = side, Quantity = quantity, Price = price,
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+            });
+
+        public static IReadOnlyList<OrderBookEvent> CreateMarketOrder(this IOrderBook book, string companyId,
+            string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
+            string? selfMatchPreventionId = null,
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            book.Process(new CreateMarketOrder
+            {
+                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+                OrderValidity = orderValidity, Side = side, Quantity = quantity,
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+            });
+
+        public static IReadOnlyList<OrderBookEvent> CreateMarketLimitOrder(this IOrderBook book, string companyId,
+            string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
+            string? selfMatchPreventionId = null,
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            book.Process(new CreateMarketLimitOrder
+            {
+                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+                OrderValidity = orderValidity, Side = side, Quantity = quantity,
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+            });
+
+        public static IReadOnlyList<OrderBookEvent> CreateStopLimitOrder(this IOrderBook book, string companyId,
+            string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
+            decimal triggerPrice, string? selfMatchPreventionId = null,
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            book.Process(new CreateStopLimitOrder
+            {
+                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+                OrderValidity = orderValidity, Side = side, Quantity = quantity,
+                Price = price, TriggerPrice = triggerPrice,
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+            });
+
+        public static IReadOnlyList<OrderBookEvent> CreateStopMarketOrder(this IOrderBook book, string companyId,
+            string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal triggerPrice,
+            string? selfMatchPreventionId = null,
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            book.Process(new CreateStopMarketOrder
+            {
+                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+                OrderValidity = orderValidity, Side = side, Quantity = quantity,
+                TriggerPrice = triggerPrice,
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+            });
+
+        public static IReadOnlyList<OrderBookEvent> UpdateOrder(this IOrderBook book, string companyId,
+            string clientOrderId, string previousClientOrderId, int? newTotalQuantity = null, decimal? price = null,
+            decimal? triggerPrice = null) =>
+            book.Process(new UpdateOrder
+            {
+                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+                PreviousClientOrderId = previousClientOrderId, NewTotalQuantity = newTotalQuantity, Price = price,
+                TriggerPrice = triggerPrice
+            });
+
+        public static IReadOnlyList<OrderBookEvent> CancelOrder(this IOrderBook book, string companyId,
+            string clientOrderId, string previousClientOrderId) =>
+            book.Process(new CancelOrder
+            {
+                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+                PreviousClientOrderId = previousClientOrderId
+            });
+
+        public static IReadOnlyList<OrderBookEvent> PreOpenTrading(this IOrderBook book,
+            decimal? referencePrice = null) =>
+            book.Process(new PreOpenTrading { Security = book.Security, ReferencePrice = referencePrice });
+
+        public static IReadOnlyList<OrderBookEvent> OpenTrading(this IOrderBook book,
+            decimal? referencePrice = null) =>
+            book.Process(new OpenTrading { Security = book.Security, ReferencePrice = referencePrice });
+
+        public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book) =>
+            book.Process(new CloseTrading { Security = book.Security });
+
+        // Bridge for callers that only know the target status at runtime (e.g. a session/schedule
+        // provider driving the book off a clock) and so can't pick PreOpenTrading/OpenTrading/
+        // CloseTrading directly. ReferencePrice is ignored when closing - CloseTrading has no such
+        // property, since a reference price is meaningless once the book stops accepting orders.
+        public static IReadOnlyList<OrderBookEvent> UpdateStatus(this IOrderBook book, OrderBookStatus status,
+            decimal? referencePrice = null) =>
+            status switch
+            {
+                OrderBookStatus.PreOpen => book.PreOpenTrading(referencePrice),
+                OrderBookStatus.Open => book.OpenTrading(referencePrice),
+                OrderBookStatus.Closed => book.CloseTrading(),
+                _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+            };
+    }
+}

--- a/Circus/OrderBook/OrderRejectedReason.cs
+++ b/Circus/OrderBook/OrderRejectedReason.cs
@@ -19,7 +19,6 @@ namespace Circus.OrderBook
         NoChange,
         InsufficientLiquidityForFillOrKill,
         InvalidExpireDate,
-        GoodTilDateRequired,
         ClientOrderIdRequired,
         ClientOrderIdTooLong,
         CompanyIdRequired,

--- a/Circus/OrderValidity.cs
+++ b/Circus/OrderValidity.cs
@@ -1,11 +1,18 @@
+using System;
+
 namespace Circus
 {
-    public enum OrderValidity
+    public abstract record OrderValidity
     {
-        Day,
-        GoodTilCanceled,
-        GoodTilDate,
-        FillAndKill,
-        FillOrKill
+        public sealed record Day : OrderValidity;
+        public sealed record GoodTilCanceled : OrderValidity;
+
+        public sealed record GoodTilDate : OrderValidity
+        {
+            public required DateOnly Date { get; init; }
+        }
+
+        public sealed record FillAndKill : OrderValidity;
+        public sealed record FillOrKill : OrderValidity;
     }
 }


### PR DESCRIPTION
## Summary
- Replaces `CreateOrder`'s implicit order-type inference (derived from a matrix of optional `price`/`triggerPrice`/`marketLimit` flags, which silently ignored some combinations rather than rejecting them) with sealed leaf records per order type - `CreateLimitOrder`, `CreateMarketOrder`, `CreateMarketLimitOrder`, `CreateStopLimitOrder`, `CreateStopMarketOrder` - so `OrderType` falls out of which record is constructed instead of being inferred.
- Shrinks `IOrderBook` to `Security`/`Status`/`GetLevels`/`Process`. The old direct `CreateOrder`/`UpdateOrder`/`CancelOrder`/`UpdateStatus` interface methods (and their duplicated optional-parameter lists) are replaced by ergonomic extension methods that build the corresponding action record and call `Process`, so there's one path through the engine instead of two independently-maintained ones. `UpdateStatus` is split the same way into `PreOpenTrading`/`OpenTrading`/`CloseTrading` records, with a bridge extension method for callers (e.g. a session/schedule provider) that only know the target status at runtime.
- Groups self-match-prevention id/instruction and order-validity/expiry fields into their own types (`SelfMatchPrevention`, `OrderValidity`) instead of a shared catch-all options bag. `OrderValidity` itself becomes a record hierarchy so its `GoodTilDate` case carries its own required `Date` - a `GoodTilDate` validity with no date, or a date paired with any other validity, is now a compile error instead of a runtime reject path (removes the now-unreachable `OrderRejectedReason.GoodTilDateRequired`).
- Merges in `main` (`Add auction uncrossing (#25)`), resolving conflicts in `IOrderBook.cs`/`InMemoryOrderBook.cs` by keeping this branch's shrunk interface/`Process` shape and folding in the auction feature's additions (`TryGetIndicativeAuctionPrice`, the volatility-band pause, `VolatilityAuctionBandTicks`) unchanged, and migrating the new auction test file to the new action API.

## Test plan
- [x] `dotnet build Circus.sln` - 0 errors, 0 warnings
- [x] `dotnet test Circus.sln` - 200/200 passing (192 pre-merge + 8 from the merged-in auction test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4xvmUHQF8PaZYi3QHWSAu