### PR TITLE
Add display quantity / iceberg orders

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
@@ -1,0 +1,249 @@
+using System;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    [TestFixture]
+    public class InMemoryOrderBookIcebergTests
+    {
+        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+        private static readonly string CompanyId3 = "Company3";
+
+        private static readonly string OrderId1 = "Order1";
+        private static readonly string OrderId2 = "Order2";
+        private static readonly string OrderId3 = "Order3";
+        private static readonly string OrderId1B = "Order1b";
+
+        private static TestTimeProvider TimeProvider;
+        private static IOrderBook Book;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+            Book = new InMemoryOrderBook(Sec, TimeProvider);
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        [TestCase(6)]
+        public void MaxVisibleQuantity_OutsideValidRange_Rejected(int maxVisibleQuantity)
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100,
+                maxVisibleQuantity: maxVisibleQuantity);
+
+            // assert
+            var rejected = events[0] as CreateOrderRejected;
+            Assert.IsNotNull(rejected);
+            Assert.AreEqual(OrderRejectedReason.MaxVisibleQuantityOutOfRange, rejected.Reason);
+        }
+
+        [Test]
+        public void GetLevels_ReportsDisplayedPeak_NotTrueRemainingSize()
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+
+            // act - total 20, only 5 displayed at a time
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
+                maxVisibleQuantity: 5);
+
+            // assert
+            var levels = Book.GetLevels(Side.Sell, 10);
+            Assert.AreEqual(1, levels.Count);
+            Assert.AreEqual(5, levels[0].Quantity);
+            Assert.AreEqual(1, levels[0].Count);
+        }
+
+        [Test]
+        public void Replenishment_LosesPriority_BystanderMatchedBeforeReplenishedPeak()
+        {
+            // arrange - iceberg (peak 5, total 12) rests first, a plain order arrives right
+            // behind it at the same price
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
+                maxVisibleQuantity: 5);
+            TimeProvider.SetCurrentTime(Now2);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+            TimeProvider.SetCurrentTime(Now3);
+
+            // act - an aggressor larger than the peak
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
+
+            // assert - first fill consumes the iceberg's full peak (5); it still has 7 left, so it
+            // replenishes (to a full peak of 5 again) and is requeued behind Company2
+            Assert.AreEqual(3, events.Count);
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+
+            var firstMatch = events[1] as OrdersMatched;
+            Assert.IsNotNull(firstMatch);
+            Assert.AreEqual(5, firstMatch.Quantity);
+            Assert.AreEqual(OrderId1, firstMatch.Fills[0].ClientOrderId);
+            Assert.AreEqual(OrderStatus.Working, firstMatch.Fills[0].Order.Status);
+            Assert.AreEqual(7, firstMatch.Fills[0].Order.RemainingQuantity);
+            Assert.AreEqual(5, firstMatch.Fills[0].Order.DisplayedQuantity); // already replenished
+
+            // second fill: the aggressor's remaining 3 units match Company2 - not the iceberg's
+            // freshly-replenished peak - proving the iceberg lost its queue position
+            var secondMatch = events[2] as OrdersMatched;
+            Assert.IsNotNull(secondMatch);
+            Assert.AreEqual(3, secondMatch.Quantity);
+            Assert.AreEqual(OrderId2, secondMatch.Fills[0].ClientOrderId);
+            Assert.AreEqual(OrderStatus.Filled, secondMatch.Fills[1].Order.Status); // aggressor done
+
+            // book afterward: iceberg untouched-since (7 remaining, 5 displayed), Company2 down to 2
+            var sellLevels = Book.GetLevels(Side.Sell, 10);
+            Assert.AreEqual(1, sellLevels.Count);
+            Assert.AreEqual(2, sellLevels[0].Count);
+            Assert.AreEqual(7, sellLevels[0].Quantity); // 5 (iceberg's displayed) + 2 (Company2 left)
+            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+        }
+
+        [Test]
+        public void FinalReplenishment_NotMultipleOfPeak_ShowsOnlyWhatsLeft()
+        {
+            // arrange - total 12, peak 5: replenishment cycle is 5, 5, then a final 2
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
+                maxVisibleQuantity: 5);
+            TimeProvider.SetCurrentTime(Now2);
+
+            // act - a single aggressor large enough to consume the whole iceberg
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 12, 100);
+
+            // assert - three separate prints as the peak replenishes: 5, 5, then the 2 left over
+            Assert.AreEqual(4, events.Count);
+            Assert.AreEqual(5, ((OrdersMatched) events[1]).Quantity);
+            Assert.AreEqual(5, ((OrdersMatched) events[2]).Quantity);
+            Assert.AreEqual(2, ((OrdersMatched) events[3]).Quantity);
+
+            var lastFill = ((OrdersMatched) events[3]).Fills[0];
+            Assert.AreEqual(OrderId1, lastFill.ClientOrderId);
+            Assert.AreEqual(OrderStatus.Filled, lastFill.Order.Status);
+            Assert.AreEqual(12, lastFill.Order.FilledQuantity);
+
+            Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
+            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+        }
+
+        [Test]
+        public void HiddenReserve_CountsInFullForMinQuantity_EvenThoughNotDisplayed()
+        {
+            // arrange - only 3 displayed at a time out of a true total of 20
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
+                maxVisibleQuantity: 3);
+            TimeProvider.SetCurrentTime(Now2);
+
+            // act - requires the full 15 to fill immediately or nothing does; GetLevels would only
+            // show 3, but the true available liquidity (20) is what the gate actually checks
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
+                new OrderValidity.ImmediateOrCancel { MinQuantity = 15 }, Side.Buy, 15, 100);
+
+            // assert - accepted and fully filled, replenishing across several peaks (3 each) to do it
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+            var lastMatch = (OrdersMatched) events[^1];
+            Assert.AreEqual(OrderStatus.Filled, lastMatch.Fills[1].Order.Status);
+            Assert.AreEqual(15, lastMatch.Fills[1].Order.FilledQuantity);
+
+            var sellLevels = Book.GetLevels(Side.Sell, 10);
+            Assert.AreEqual(1, sellLevels.Count);
+            Assert.AreEqual(3, sellLevels[0].Quantity); // 20 - 15 = 5 true remaining, displayed capped to peak 3
+        }
+
+        [Test]
+        public void UpdateOrder_IcebergQuantityIncrease_DoesNotLosePriority()
+        {
+            // arrange - iceberg rests first, a plain order arrives behind it
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100,
+                maxVisibleQuantity: 3);
+            TimeProvider.SetCurrentTime(Now2);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+            TimeProvider.SetCurrentTime(Now3);
+
+            // act - grow the iceberg's total size (hidden reserve only, peak is immutable)
+            Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
+            TimeProvider.SetCurrentTime(Now4);
+
+            // a sell should still match the iceberg first - no priority lost
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+            // assert
+            var matched = events[1] as OrdersMatched;
+            Assert.IsNotNull(matched);
+            Assert.AreEqual(OrderId1B, matched.Fills[0].ClientOrderId);
+        }
+
+        [Test]
+        public void UpdateOrder_PlainOrderQuantityIncrease_StillLosesPriority()
+        {
+            // regression - confirms the exception added for icebergs doesn't affect plain orders
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+            TimeProvider.SetCurrentTime(Now2);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+            TimeProvider.SetCurrentTime(Now3);
+
+            // act
+            Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
+            TimeProvider.SetCurrentTime(Now4);
+
+            // a sell should now match Company2 first - Company1 lost priority by growing
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+            // assert
+            var matched = events[1] as OrdersMatched;
+            Assert.IsNotNull(matched);
+            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+        }
+
+        [Test]
+        public void AggressorIsIceberg_OwnDisplayedPortionCapsEachFill()
+        {
+            // arrange - a small resting sell that fully consumes the aggressor's first peak, and
+            // a larger one behind it for the aggressor to keep working through
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+            TimeProvider.SetCurrentTime(Now2);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 100);
+            TimeProvider.SetCurrentTime(Now3);
+
+            // act - the aggressor itself is an iceberg: total 10, peak 3
+            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 10, 100,
+                maxVisibleQuantity: 3);
+
+            // assert - each fill is capped at the aggressor's own displayed peak (3), not its full
+            // remaining size, down to whatever's left at the end (3, 3, 3, then 1)
+            Assert.AreEqual(5, events.Count);
+            Assert.AreEqual(3, ((OrdersMatched) events[1]).Quantity);
+            Assert.AreEqual(3, ((OrdersMatched) events[2]).Quantity);
+            Assert.AreEqual(3, ((OrdersMatched) events[3]).Quantity);
+            Assert.AreEqual(1, ((OrdersMatched) events[4]).Quantity);
+
+            var lastFill = ((OrdersMatched) events[4]).Fills[1];
+            Assert.AreEqual(OrderId3, lastFill.ClientOrderId);
+            Assert.AreEqual(OrderStatus.Filled, lastFill.Order.Status);
+            Assert.AreEqual(10, lastFill.Order.FilledQuantity);
+
+            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+            var sellLevels = Book.GetLevels(Side.Sell, 10);
+            Assert.AreEqual(1, sellLevels.Count);
+            Assert.AreEqual(13, sellLevels[0].Quantity); // Company2's 20 - 7 consumed
+        }
+    }
+}

--- a/Circus/Order.cs
+++ b/Circus/Order.cs
@@ -17,9 +17,11 @@ namespace Circus
         int Quantity,
         int FilledQuantity,
         int RemainingQuantity,
+        int DisplayedQuantity,
         decimal? Price,
         decimal? TriggerPrice,
         string? SelfMatchPreventionId = null,
-        SelfMatchPreventionInstruction? SelfMatchPreventionInstruction = null
+        SelfMatchPreventionInstruction? SelfMatchPreventionInstruction = null,
+        int? MaxVisibleQuantity = null
     );
 }

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -58,7 +58,7 @@ namespace Circus.OrderBook
         public IReadOnlyList<Level> GetLevels(Side side, int maxPrices)
         {
             return _working[side].EnumerateFromBest().Take(maxPrices)
-                .Select(x => new Level(ToDecimal(x.Tick), SumRemaining(x.First), x.Count))
+                .Select(x => new Level(ToDecimal(x.Tick), SumDisplayed(x.First), x.Count))
                 .ToList();
         }
 
@@ -67,6 +67,17 @@ namespace Circus.OrderBook
             var total = 0;
             for (var order = first; order != null; order = order.LevelNext)
                 total += order.RemainingQuantity;
+            return total;
+        }
+
+        // Market data reports what's publicly visible - an iceberg's hidden reserve is
+        // deliberately excluded here even though HasSufficientLiquidity/TryComputeAuctionPrice
+        // (via SumRemaining) still count it in full for liquidity/price-discovery purposes.
+        private static int SumDisplayed(InternalOrder? first)
+        {
+            var total = 0;
+            for (var order = first; order != null; order = order.LevelNext)
+                total += order.DisplayedQuantity;
             return total;
         }
 
@@ -151,15 +162,15 @@ namespace Circus.OrderBook
             return action switch
             {
                 CreateLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
-                    OrderType.Limit, o.Price, null, o.SelfMatchPrevention),
+                    OrderType.Limit, o.Price, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
                 CreateMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
-                    OrderType.Market, null, null, o.SelfMatchPrevention),
+                    OrderType.Market, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
                 CreateMarketLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                    o.Quantity, OrderType.MarketLimit, null, null, o.SelfMatchPrevention),
+                    o.Quantity, OrderType.MarketLimit, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
                 CreateStopLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                    o.Quantity, OrderType.StopLimit, o.Price, o.TriggerPrice, o.SelfMatchPrevention),
+                    o.Quantity, OrderType.StopLimit, o.Price, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
                 CreateStopMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                    o.Quantity, OrderType.StopMarket, null, o.TriggerPrice, o.SelfMatchPrevention),
+                    o.Quantity, OrderType.StopMarket, null, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
                 UpdateOrder update => UpdateOrder(update.CompanyId, update.ClientOrderId,
                     update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice),
                 CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId),
@@ -172,7 +183,7 @@ namespace Circus.OrderBook
 
         private List<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity,
             Side side, int quantity, OrderType type, decimal? price = null, decimal? triggerPrice = null,
-            SelfMatchPrevention? selfMatchPrevention = null)
+            SelfMatchPrevention? selfMatchPrevention = null, int? maxVisibleQuantity = null)
         {
             var selfMatchPreventionId = selfMatchPrevention?.Id;
             var selfMatchPreventionInstruction = selfMatchPrevention?.Instruction;
@@ -212,6 +223,8 @@ namespace Circus.OrderBook
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.PriceOutsideBands);
             if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int minQty } && (minQty < 1 || minQty > quantity))
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MinQuantityOutOfRange);
+            if (maxVisibleQuantity.HasValue && (maxVisibleQuantity < 1 || maxVisibleQuantity > quantity))
+                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MaxVisibleQuantityOutOfRange);
             if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var existingOrder))
             {
                 return existingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
@@ -236,7 +249,7 @@ namespace Circus.OrderBook
             _nextSequenceNumber++;
             var order = new InternalOrder(_nextSequenceNumber, companyId, clientOrderId, _security, Now(), status,
                 type, validity, side, quantity, priceTicks, triggerTicks, selfMatchPreventionId,
-                selfMatchPreventionInstruction);
+                selfMatchPreventionInstruction, maxVisibleQuantity);
 
             _orders.Add(order.ExchangeOrderId, order);
             _clientOrderIndex.Add((companyId, clientOrderId), order);
@@ -438,7 +451,11 @@ namespace Circus.OrderBook
             var sequenceNumber = order.SequenceNumber;
             var isPriceChange = (triggerTicks != null && order.Status == OrderStatus.Hidden && triggerTicks != order.TriggerPrice) ||
                                 (priceTicks != null && order.Status != OrderStatus.Hidden && priceTicks != order.Price);
-            var isQuantityIncrease = (newTotalQuantity != null && newTotalQuantity > order.Quantity);
+            // For an iceberg order, MaxVisibleQuantity (the peak) is immutable, so any quantity
+            // increase here can only be growing the hidden reserve - CME/Eurex don't lose
+            // priority for that, only for a peak increase, which isn't possible in this scope.
+            var isQuantityIncrease = order.MaxVisibleQuantity == null &&
+                (newTotalQuantity != null && newTotalQuantity > order.Quantity);
 
             var orders = (order.Status == OrderStatus.Hidden ? _stops : _working);
 
@@ -557,6 +574,16 @@ namespace Circus.OrderBook
             {
                 CompleteOrder(order);
             }
+            else if (order.DisplayedQuantity == 0 && order.MaxVisibleQuantity.HasValue)
+            {
+                // iceberg peak exhausted with hidden reserve remaining - replenish and requeue to
+                // the back of this price level (PriceLadder.Add always appends to the tail),
+                // losing time priority - matches both CME and Eurex.
+                var priceTicks = order.Price ?? throw new InvalidOperationException("limit order missing price");
+                _working[order.Side].Remove(priceTicks, order);
+                order.Replenish(time);
+                _working[order.Side].Add(priceTicks, order);
+            }
         }
 
         private InternalOrder? BestOrder(Side side) =>
@@ -601,7 +628,7 @@ namespace Circus.OrderBook
                     continue;
                 }
 
-                var quantity = Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
+                var quantity = Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
                 var priceTicks = auctionPriceTicks ?? resting.Price ??
                     throw new InvalidOperationException("limit order requires price");
 

--- a/Circus/OrderBook/InternalOrder.cs
+++ b/Circus/OrderBook/InternalOrder.cs
@@ -27,6 +27,13 @@ namespace Circus.OrderBook
         public long? TriggerPrice { get; private set; }
         public string? SelfMatchPreventionId { get; }
         public SelfMatchPreventionInstruction? SelfMatchPreventionInstruction { get; }
+        public int? MaxVisibleQuantity { get; }
+
+        // The currently-shown portion of an iceberg order, distinct from RemainingQuantity (the
+        // true total including hidden reserve) - equal to RemainingQuantity for a non-iceberg
+        // order (MaxVisibleQuantity null), so nothing elsewhere needs to special-case that. Shrinks
+        // with each fill against it and is replenished (see Fill) once it hits zero.
+        public int DisplayedQuantity { get; private set; }
 
         // intrusive doubly-linked-list pointers used by PriceLadder for the price level currently
         // holding this order (an order only ever rests in one level at a time, so a single pair of
@@ -37,7 +44,7 @@ namespace Circus.OrderBook
         public InternalOrder(long sequenceNumber, string companyId, string clientOrderId, Security security, DateTime time,
             OrderStatus status, OrderType type, OrderValidity validity, Side side, int quantity, long? price,
             long? triggerPrice, string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null)
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null, int? maxVisibleQuantity = null)
         {
             SequenceNumber = sequenceNumber;
             CompanyId = companyId;
@@ -57,6 +64,8 @@ namespace Circus.OrderBook
             TriggerPrice = triggerPrice;
             SelfMatchPreventionId = selfMatchPreventionId;
             SelfMatchPreventionInstruction = selfMatchPreventionInstruction;
+            MaxVisibleQuantity = maxVisibleQuantity;
+            DisplayedQuantity = Math.Min(maxVisibleQuantity ?? quantity, quantity);
         }
 
         public override string ToString() =>
@@ -65,8 +74,9 @@ namespace Circus.OrderBook
         public Order ToOrder()
         {
             return new(CompanyId, ExchangeOrderId, ClientOrderId, Security, CreatedTime, ModifiedTime, CompletedTime,
-                Status, Type, Validity, Side, Quantity, FilledQuantity, RemainingQuantity, ToDecimal(Price),
-                ToDecimal(TriggerPrice), SelfMatchPreventionId, SelfMatchPreventionInstruction);
+                Status, Type, Validity, Side, Quantity, FilledQuantity, RemainingQuantity, DisplayedQuantity,
+                ToDecimal(Price), ToDecimal(TriggerPrice), SelfMatchPreventionId, SelfMatchPreventionInstruction,
+                MaxVisibleQuantity);
         }
 
         private decimal? ToDecimal(long? ticks) => ticks.HasValue ? ticks.Value * Security.TickSize : null;
@@ -101,6 +111,11 @@ namespace Circus.OrderBook
                 // quantity is the new total size, so remaining = new total - already filled
                 RemainingQuantity -= (Quantity - quantity.Value);
                 Quantity = quantity.Value;
+
+                // keep displayed in sync - for a non-iceberg order this just mirrors
+                // RemainingQuantity (no peak to cap it below); for an iceberg it's re-derived the
+                // same way construction does, capped to whatever peak is still configured
+                DisplayedQuantity = Math.Min(MaxVisibleQuantity ?? RemainingQuantity, RemainingQuantity);
             }
 
             if (triggerPrice.HasValue)
@@ -120,12 +135,23 @@ namespace Circus.OrderBook
 
             FilledQuantity += quantity;
             RemainingQuantity -= quantity;
+            DisplayedQuantity -= quantity;
 
             if (RemainingQuantity == 0)
             {
                 Status = OrderStatus.Filled;
                 CompletedTime = time;
             }
+        }
+
+        // Called when an iceberg's displayed peak hits zero with hidden reserve still remaining -
+        // refreshes the display and bumps ModifiedTime, since the caller re-queues this order to
+        // the back of its price level immediately afterward (losing time priority, matching both
+        // CME and Eurex).
+        public void Replenish(DateTime time)
+        {
+            DisplayedQuantity = Math.Min(MaxVisibleQuantity!.Value, RemainingQuantity);
+            ModifiedTime = time;
         }
 
         public void ConvertToLimit(DateTime time, long sequenceNumber, long? price = null)

--- a/Circus/OrderBook/OrderBookAction.cs
+++ b/Circus/OrderBook/OrderBookAction.cs
@@ -39,6 +39,12 @@ namespace Circus.OrderBook
         public required Side Side { get; init; }
         public required int Quantity { get; init; }
         public SelfMatchPrevention? SelfMatchPrevention { get; init; }
+
+        // Iceberg/display quantity - the portion shown to the market at a time, with the rest
+        // held in reserve. Not restricted to CreateLimitOrder: Market/MarketLimit/triggered-Stop
+        // orders can all end up resting as a plain limit order too, so display quantity is
+        // meaningful for any of them.
+        public int? MaxVisibleQuantity { get; init; }
     }
 
     public sealed record CreateLimitOrder : CreateOrder

--- a/Circus/OrderBook/OrderBookExtensions.cs
+++ b/Circus/OrderBook/OrderBookExtensions.cs
@@ -12,58 +12,68 @@ namespace Circus.OrderBook
         public static IReadOnlyList<OrderBookEvent> CreateLimitOrder(this IOrderBook book, string companyId,
             string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
             string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+            int? maxVisibleQuantity = null) =>
             book.Process(new CreateLimitOrder
             {
                 Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
                 OrderValidity = orderValidity, Side = side, Quantity = quantity, Price = price,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+                MaxVisibleQuantity = maxVisibleQuantity
             });
 
         public static IReadOnlyList<OrderBookEvent> CreateMarketOrder(this IOrderBook book, string companyId,
             string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
             string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+            int? maxVisibleQuantity = null) =>
             book.Process(new CreateMarketOrder
             {
                 Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
                 OrderValidity = orderValidity, Side = side, Quantity = quantity,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+                MaxVisibleQuantity = maxVisibleQuantity
             });
 
         public static IReadOnlyList<OrderBookEvent> CreateMarketLimitOrder(this IOrderBook book, string companyId,
             string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
             string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+            int? maxVisibleQuantity = null) =>
             book.Process(new CreateMarketLimitOrder
             {
                 Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
                 OrderValidity = orderValidity, Side = side, Quantity = quantity,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+                MaxVisibleQuantity = maxVisibleQuantity
             });
 
         public static IReadOnlyList<OrderBookEvent> CreateStopLimitOrder(this IOrderBook book, string companyId,
             string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
             decimal triggerPrice, string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+            int? maxVisibleQuantity = null) =>
             book.Process(new CreateStopLimitOrder
             {
                 Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
                 OrderValidity = orderValidity, Side = side, Quantity = quantity,
                 Price = price, TriggerPrice = triggerPrice,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+                MaxVisibleQuantity = maxVisibleQuantity
             });
 
         public static IReadOnlyList<OrderBookEvent> CreateStopMarketOrder(this IOrderBook book, string companyId,
             string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal triggerPrice,
             string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null) =>
+            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+            int? maxVisibleQuantity = null) =>
             book.Process(new CreateStopMarketOrder
             {
                 Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
                 OrderValidity = orderValidity, Side = side, Quantity = quantity,
                 TriggerPrice = triggerPrice,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction)
+                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+                MaxVisibleQuantity = maxVisibleQuantity
             });
 
         public static IReadOnlyList<OrderBookEvent> UpdateOrder(this IOrderBook book, string companyId,

--- a/Circus/OrderBook/OrderRejectedReason.cs
+++ b/Circus/OrderBook/OrderRejectedReason.cs
@@ -26,6 +26,7 @@ namespace Circus.OrderBook
         PriceOutsideBands,
         MinQuantityOutOfRange,
         InsufficientLiquidityForMinQuantity,
+        MaxVisibleQuantityOutOfRange,
         // PendingCancelOrReplace,
         // PriceExceedsCurrentPrice,
         // PriceExceedsCurrentPriceBand,

--- a/Readme.md
+++ b/Readme.md
@@ -16,8 +16,8 @@ Order types
 - [x] Market limit orders
 
 Order properties
-- [ ] Min quantity
-- [ ] Max visible quantity
+- [x] Min quantity
+- [x] Max visible quantity
 
 Time in force/order validity
 - [x] Day orders


### PR DESCRIPTION
## Summary
- `MaxVisibleQuantity` (the displayed peak) added to the shared `CreateOrder` action base - not just `CreateLimitOrder` - since Market/MarketLimit/triggered-Stop orders can all end up resting as a plain limit order too, so display quantity is meaningful for any of them
- New mutable `InternalOrder.DisplayedQuantity`, distinct from `RemainingQuantity` (the true total including hidden reserve) - equal to it for a non-iceberg order, so nothing elsewhere needs to special-case that
- **CME vs Eurex divergence, researched and deliberately resolved one way**: both shrink-then-replenish-on-exhaustion and lose priority on replenishment, but CME sweeps *all* displayed quantity across every order at a price level before touching any hidden reserves (a two-pass-per-level scheme), while Eurex replenishes and requeues **per order, immediately**. Implemented Eurex's model - it's a small, local addition to the existing FIFO matching loop (`Match()` in `InMemoryOrderBook.cs`, which already walks one best-buy/best-sell pair at a time via `PriceLadder`'s intrusive linked list) rather than a structural rewrite into an explicit two-phase level sweep.
- `HasSufficientLiquidity`/`TryComputeAuctionPrice` are untouched and keep summing `RemainingQuantity` - hidden reserve is real, available liquidity for FOK/`MinQuantity`/auction-price-discovery purposes, just not publicly displayed. `GetLevels` gets a parallel `SumDisplayed` helper for market data, which does hide it - a deliberate split, not an inconsistency.
- `MaxVisibleQuantity` is immutable after creation, matching the existing precedent (`SelfMatchPrevention`, `MinQuantity`, `GoodTilDate.Date`) - this also sidesteps needing to distinguish a peak increase (loses priority) from a hidden-reserve increase (doesn't) in `UpdateOrder`: with the peak fixed, any quantity increase can only be the latter, so it's a one-line exception to the existing reprioritization check.
- Deliberately out of scope: Eurex's numeric business rules (peak ≥ 10× lot size, minimum EUR 10,000 notional) and either venue's randomized-peak-size anti-gaming variant - exchange-specific policy, not a generic mechanism.
- **Bug fix along the way**: `InternalOrder.Update()` adjusted `RemainingQuantity`/`Quantity` on a quantity change but never kept `DisplayedQuantity` in sync - for *any* order (not just icebergs), this could desync the two fields and eventually drive `DisplayedQuantity` to 0 while `RemainingQuantity` stayed positive, making `Match()` compute a permanent 0-quantity fill and spin forever. Caught this via an actually-hung test process (85% CPU, 2+ minutes) rather than by inspection - fixed by recomputing `DisplayedQuantity` the same way construction does whenever quantity changes.
- README checklist updated - both `Min quantity` and `Max visible quantity` were still unchecked despite `MinQuantity` already having shipped in #28.

## Test plan
- [x] `dotnet build` across the whole solution
- [x] `dotnet test` - 216/216 passing, including 10 new tests (display-vs-true-size in market data, replenishment losing priority to a bystander order, a final replenishment showing less than a full peak, hidden reserve counting in full for `MinQuantity` despite not being displayed, `UpdateOrder` iceberg-quantity-increase not losing priority vs. a plain order still losing it, and an aggressor that's itself an iceberg being capped by its own displayed portion)
- [x] Re-ran the seeded `OrderFlowSimulator` sanity check (seed 42, 20,000 actions) - identical `confirmed_events=24446 rejected_events=0`, since the simulator never sets `MaxVisibleQuantity`