### PR TITLE
Bump PackageVersion to 0.6.0

### DIFF
--- a/Circus/Circus.csproj
+++ b/Circus/Circus.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.5.0</PackageVersion>
+        <PackageVersion>0.6.0</PackageVersion>
         <Title>Circus</Title>
         <Authors>seanoflynn</Authors>
         <Description>Financial exchange simulator.</Description>


### PR DESCRIPTION
## Summary
- Bumps `PackageVersion` from 0.5.0 to 0.6.0 to cover the 16 commits merged since the last version bump.
- Warrants a minor bump (not patch) because `IOrderBook` had a breaking API redesign (`CreateOrder`/`UpdateOrder`/`CancelOrder`/`UpdateStatus` collapsed into `Process()`, `IList` → `IReadOnlyList`), plus several additive features (market-limit orders, GTD validity, price bands, auction uncrossing, self-trade prevention, iceberg/display quantity).

## Test plan
- [ ] CI build/test suite passes