### PR TITLE
C1: move the Match loop into Matcher.Run, introduce Apply

### DIFF
--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -509,104 +509,82 @@ namespace Circus.OrderBook
 
             var time = Now();
 
-            var buy = _matcher.BestOrder(Side.Buy);
-            var sell = _matcher.BestOrder(Side.Sell);
+            foreach (var outcome in _matcher.Run(auctionPriceTicks, CheckTradeRestrictionBreach))
+                Apply(outcome, events, time);
+        }
 
-            if (buy != null && !buy.Price.HasValue)
+        // On the first Trade-scoped restriction that disallows priceTicks, returns its OnBreach
+        // consequence (Pause -> PreOpen, Halt -> Closed); a pure query, consulted by Matcher.Run
+        // only outside an auction uncrossing pass.
+        private RestrictionBreachAction? CheckTradeRestrictionBreach(long priceTicks)
+        {
+            foreach (var restriction in _priceRestrictions)
             {
-                throw new InvalidOperationException("buy limit order requires price");
+                if (restriction.Scope == RestrictionScope.Trade && !restriction.Allows(priceTicks))
+                    return restriction.OnBreach;
             }
 
-            if (sell != null && !sell.Price.HasValue)
-            {
-                throw new InvalidOperationException("sell limit order requires price");
-            }
+            return null;
+        }
 
-            while (buy != null && sell != null && buy.Price >= sell.Price)
+        private void Apply(MatchOutcome outcome, List<OrderBookEvent> events, DateTime time)
+        {
+            switch (outcome)
             {
-                var resting = buy.ModifiedTime < sell.ModifiedTime ? buy : sell;
-                var aggressor = buy == resting ? sell : buy;
-
-                if (Matcher.IsSelfMatch(resting, aggressor, out var instruction))
-                {
+                case SelfMatchDetected(var resting, var aggressor, var instruction):
                     if (instruction != SelfMatchPreventionInstruction.CancelAggressor)
                         events.Add(CancelRemainder(resting, OrderCancelledReason.SelfMatchPrevention));
                     if (instruction != SelfMatchPreventionInstruction.CancelResting)
                         events.Add(CancelRemainder(aggressor, OrderCancelledReason.SelfMatchPrevention));
+                    break;
 
-                    buy = _matcher.BestOrder(Side.Buy);
-                    sell = _matcher.BestOrder(Side.Sell);
-                    continue;
-                }
+                case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity):
+                    ApplyTrade(resting, aggressor, priceTicks, quantity, events, time);
+                    break;
 
-                var quantity = Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
-                var priceTicks = auctionPriceTicks ?? resting.Price ??
-                    throw new InvalidOperationException("limit order requires price");
-
-                // Checked against the prospective trade price, not either order's own submitted
-                // limit price - a resting order sitting far from the market doesn't represent any
-                // actual price movement, only an executed trade at an extreme price does. Doesn't
-                // apply to an auction uncrossing pass itself (auctionPriceTicks set) - the auction
-                // print is already the resolution mechanism, not something to interrupt.
-                if (auctionPriceTicks == null && BreachesTradeRestriction(priceTicks, events))
-                    return;
-
-                var price = ToDecimal(priceTicks);
-
-                resting.Fill(time, quantity);
-                var restingSnapshot = resting.ToOrder();
-                var restingReplenish = FinishFill(resting, time);
-
-                aggressor.Fill(time, quantity);
-                var aggressorSnapshot = aggressor.ToOrder();
-                var aggressorReplenish = FinishFill(aggressor, time);
-
-                events.Add(new OrdersMatched(_security, time, price, quantity,
-                    new[]
-                    {
-                        new FillOrderConfirmed(_security, time, resting.CompanyId, restingSnapshot, price, quantity,
-                            true),
-                        new FillOrderConfirmed(_security, time, aggressor.CompanyId, aggressorSnapshot, price,
-                            quantity, false)
-                    }
-                ));
-
-                if (restingReplenish != null)
-                    events.Add(restingReplenish);
-                if (aggressorReplenish != null)
-                    events.Add(aggressorReplenish);
-
-                if (_lastTradedPrice != priceTicks)
-                {
-                    _lastTradedPrice = priceTicks;
-                    _auctionReferencePriceTicks = priceTicks;
-                    foreach (var restriction in _priceRestrictions)
-                        restriction.OnTrade(priceTicks, time);
-                    CheckStops(events);
-                }
-
-                buy = _matcher.BestOrder(Side.Buy);
-                sell = _matcher.BestOrder(Side.Sell);
+                case TradeRestrictionBreached(_, var action):
+                    _status = action == RestrictionBreachAction.Halt ? OrderBookStatus.Closed : OrderBookStatus.PreOpen;
+                    events.Add(new StatusChanged(_security, Now(), _status));
+                    break;
             }
         }
 
-        // On the first Trade-scoped restriction that disallows priceTicks, applies its OnBreach
-        // consequence (Pause -> PreOpen, Halt -> Closed) and reports it as a StatusChanged event.
-        private bool BreachesTradeRestriction(long priceTicks, List<OrderBookEvent> events)
+        private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
+            List<OrderBookEvent> events, DateTime time)
         {
-            foreach (var restriction in _priceRestrictions)
+            var price = ToDecimal(priceTicks);
+
+            resting.Fill(time, quantity);
+            var restingSnapshot = resting.ToOrder();
+            var restingReplenish = FinishFill(resting, time);
+
+            aggressor.Fill(time, quantity);
+            var aggressorSnapshot = aggressor.ToOrder();
+            var aggressorReplenish = FinishFill(aggressor, time);
+
+            events.Add(new OrdersMatched(_security, time, price, quantity,
+                new[]
+                {
+                    new FillOrderConfirmed(_security, time, resting.CompanyId, restingSnapshot, price, quantity,
+                        true),
+                    new FillOrderConfirmed(_security, time, aggressor.CompanyId, aggressorSnapshot, price,
+                        quantity, false)
+                }
+            ));
+
+            if (restingReplenish != null)
+                events.Add(restingReplenish);
+            if (aggressorReplenish != null)
+                events.Add(aggressorReplenish);
+
+            if (_lastTradedPrice != priceTicks)
             {
-                if (restriction.Scope != RestrictionScope.Trade || restriction.Allows(priceTicks))
-                    continue;
-
-                _status = restriction.OnBreach == RestrictionBreachAction.Halt
-                    ? OrderBookStatus.Closed
-                    : OrderBookStatus.PreOpen;
-                events.Add(new StatusChanged(_security, Now(), _status));
-                return true;
+                _lastTradedPrice = priceTicks;
+                _auctionReferencePriceTicks = priceTicks;
+                foreach (var restriction in _priceRestrictions)
+                    restriction.OnTrade(priceTicks, time);
+                CheckStops(events);
             }
-
-            return false;
         }
 
         private void CheckStops(List<OrderBookEvent> events)

--- a/Circus/OrderBook/MatchOutcome.cs
+++ b/Circus/OrderBook/MatchOutcome.cs
@@ -1,0 +1,16 @@
+namespace Circus.OrderBook
+{
+    // What Matcher.Run decided should happen next, without having mutated anything or emitted any
+    // events itself - InMemoryOrderBook.Apply is what actually does that.
+    internal abstract record MatchOutcome;
+
+    internal sealed record SelfMatchDetected(InternalOrder Resting, InternalOrder Aggressor,
+        SelfMatchPreventionInstruction Instruction) : MatchOutcome;
+
+    internal sealed record TradeExecuted(InternalOrder Resting, InternalOrder Aggressor, long PriceTicks,
+        int Quantity) : MatchOutcome;
+
+    // Terminal for the Run this came from - Matcher stops yielding after this, matching Match()'s
+    // previous early-return on a trade-restriction breach.
+    internal sealed record TradeRestrictionBreached(long PriceTicks, RestrictionBreachAction Action) : MatchOutcome;
+}

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -4,10 +4,11 @@ using System.Linq;
 
 namespace Circus.OrderBook
 {
-    // Owns the resting-order state (working + stop ladders) and the pure, state-reading
-    // decision helpers used around Match(). Match's control flow - the loop, event emission,
-    // fills, stop-checking - stays on InMemoryOrderBook for now; this only proves the seam
-    // ahead of moving the loop itself.
+    // Owns the resting-order state (working + stop ladders), decides what should happen against
+    // that state via Run, and hosts the pure, state-reading decision helpers Run and
+    // InMemoryOrderBook both need. Run only ever decides - it never mutates state or emits
+    // events; InMemoryOrderBook.Apply does that, order by order, between calls into Run's
+    // enumerator, so Run always resumes against state Apply has already caught up to.
     internal sealed class Matcher
     {
         // Array-backed, indexed by tick count (price / Security.TickSize) rather than decimal —
@@ -27,8 +28,65 @@ namespace Circus.OrderBook
         public IReadOnlyDictionary<Side, PriceLadder> Working => _working;
         public IReadOnlyDictionary<Side, PriceLadder> Stops => _stops;
 
-        public InternalOrder? BestOrder(Side side) =>
+        private InternalOrder? BestOrder(Side side) =>
             _working[side].TryGetBest(out _, out var order) ? order : null;
+
+        // Decides, one step at a time, what Match should do next against the current book state -
+        // self-match cancellations, trades, and trade-restriction breaches - without mutating
+        // anything or emitting events. checkTradeRestrictionBreach is a pure query (not consulted
+        // during an auction uncrossing pass, same as before) returning the breach action of the
+        // first Trade-scoped restriction that disallows the prospective trade price, if any.
+        // Re-reads the book fresh on every iteration, so the caller must fully apply each yielded
+        // outcome - including any ladder mutation - before asking for the next one.
+        public IEnumerable<MatchOutcome> Run(long? auctionPriceTicks,
+            Func<long, RestrictionBreachAction?> checkTradeRestrictionBreach)
+        {
+            var buy = BestOrder(Side.Buy);
+            var sell = BestOrder(Side.Sell);
+
+            if (buy != null && !buy.Price.HasValue)
+                throw new InvalidOperationException("buy limit order requires price");
+            if (sell != null && !sell.Price.HasValue)
+                throw new InvalidOperationException("sell limit order requires price");
+
+            while (buy != null && sell != null && buy.Price >= sell.Price)
+            {
+                var resting = buy.ModifiedTime < sell.ModifiedTime ? buy : sell;
+                var aggressor = buy == resting ? sell : buy;
+
+                if (IsSelfMatch(resting, aggressor, out var instruction))
+                {
+                    yield return new SelfMatchDetected(resting, aggressor, instruction);
+                    buy = BestOrder(Side.Buy);
+                    sell = BestOrder(Side.Sell);
+                    continue;
+                }
+
+                var quantity = Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
+                var priceTicks = auctionPriceTicks ?? resting.Price ??
+                    throw new InvalidOperationException("limit order requires price");
+
+                // Checked against the prospective trade price, not either order's own submitted
+                // limit price - a resting order sitting far from the market doesn't represent any
+                // actual price movement, only an executed trade at an extreme price does. Doesn't
+                // apply to an auction uncrossing pass itself (auctionPriceTicks set) - the auction
+                // print is already the resolution mechanism, not something to interrupt.
+                if (auctionPriceTicks == null)
+                {
+                    var breachAction = checkTradeRestrictionBreach(priceTicks);
+                    if (breachAction.HasValue)
+                    {
+                        yield return new TradeRestrictionBreached(priceTicks, breachAction.Value);
+                        yield break;
+                    }
+                }
+
+                yield return new TradeExecuted(resting, aggressor, priceTicks, quantity);
+
+                buy = BestOrder(Side.Buy);
+                sell = BestOrder(Side.Sell);
+            }
+        }
 
         private static int SumRemaining(InternalOrder? first)
         {
@@ -147,12 +205,12 @@ namespace Circus.OrderBook
         // SelfMatchPreventionId - matches CME/Eurex, where this is a dedicated opt-in id
         // distinct from the firm/company identifier (so unrelated desks under one company
         // aren't blocked from trading each other).
-        public static bool IsSelfMatch(InternalOrder resting, InternalOrder aggressor,
+        private static bool IsSelfMatch(InternalOrder resting, InternalOrder aggressor,
             out SelfMatchPreventionInstruction instruction) =>
             TryGetSelfMatchInstruction(resting, aggressor.SelfMatchPreventionId,
                 aggressor.SelfMatchPreventionInstruction, out instruction);
 
-        public static bool TryGetSelfMatchInstruction(InternalOrder resting, string? incomingSelfMatchPreventionId,
+        private static bool TryGetSelfMatchInstruction(InternalOrder resting, string? incomingSelfMatchPreventionId,
             SelfMatchPreventionInstruction? incomingInstruction, out SelfMatchPreventionInstruction instruction)
         {
             if (incomingSelfMatchPreventionId == null ||


### PR DESCRIPTION
## Summary

Second step (C1) of the matching-logic decomposition plan, building on the merged C0 (#35): move `Match()`'s while-loop itself into `Matcher`, split into a pure decision stream (`Run`) and a mutation/event-emission consumer (`Apply`).

- New `Circus/OrderBook/MatchOutcome.cs`: `MatchOutcome` and its three cases — `SelfMatchDetected`, `TradeExecuted`, `TradeRestrictionBreached`.
- `Matcher.Run`: an iterator that replays the old loop's *decisions* (self-match check, quantity/price computation, trade-restriction check) against its own ladders, yielding a `MatchOutcome` per step — it never mutates state or emits events itself.
- `InMemoryOrderBook.Apply`/`ApplyTrade`: do the actual work per outcome — cancellations, fills, `FinishFill` ladder mutation/replenish, event construction, `_lastTradedPrice`/`_auctionReferencePriceTicks` bookkeeping, and the `CheckStops` call. `Match()` is now just a `foreach` over `_matcher.Run(...)` calling `Apply`.
- Continuous matching and the auction uncrossing pass both go through the same seam (`auctionPriceTicks` parameter), same as before.

`CheckStops`/`TriggerStops` and their recursive call back into `Match` are untouched — that's C2.

## Test plan

- [x] Manual line-by-line diff review: `Run` reproduces the original loop's control flow and conditions verbatim, just yielding instead of acting; `Apply`/`ApplyTrade` reproduce the original mutation/event-emission verbatim.
- [x] Confirmed no other file in the repo (tests, benchmarks) references the moved/renamed internals.
- [ ] CI (`dotnet build` + `dotnet test`) — no local .NET SDK available in this sandbox, so this PR relies on CI to confirm the full `Circus.Tests` suite is still green.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PqcnfvPNmBnm2xthgwgED)_