### PR TITLE
C2: fold stop-triggering into the outcome stream, delete the recursion

### DIFF
--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -508,9 +508,19 @@ namespace Circus.OrderBook
             }
 
             var time = Now();
+            var pendingImmediateOrCancelStops = new List<InternalOrder>();
 
             foreach (var outcome in _matcher.Run(auctionPriceTicks, CheckTradeRestrictionBreach))
-                Apply(outcome, events, time);
+                Apply(outcome, events, time, pendingImmediateOrCancelStops);
+
+            // Deferred until the whole sweep is done, not checked right after each stop's own
+            // conversion: since this loop only ever exits once no crosses remain anywhere in the
+            // book, "did it fill" can't be answered any earlier than right here.
+            foreach (var order in pendingImmediateOrCancelStops)
+            {
+                if (order.RemainingQuantity > 0)
+                    events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
+            }
         }
 
         // On the first Trade-scoped restriction that disallows priceTicks, returns its OnBreach
@@ -527,7 +537,8 @@ namespace Circus.OrderBook
             return null;
         }
 
-        private void Apply(MatchOutcome outcome, List<OrderBookEvent> events, DateTime time)
+        private void Apply(MatchOutcome outcome, List<OrderBookEvent> events, DateTime time,
+            List<InternalOrder> pendingImmediateOrCancelStops)
         {
             switch (outcome)
             {
@@ -545,6 +556,10 @@ namespace Circus.OrderBook
                 case TradeRestrictionBreached(_, var action):
                     _status = action == RestrictionBreachAction.Halt ? OrderBookStatus.Closed : OrderBookStatus.PreOpen;
                     events.Add(new StatusChanged(_security, Now(), _status));
+                    break;
+
+                case StopsTriggered(var orders):
+                    TriggerStops(orders, time, events, pendingImmediateOrCancelStops);
                     break;
             }
         }
@@ -583,47 +598,21 @@ namespace Circus.OrderBook
                 _auctionReferencePriceTicks = priceTicks;
                 foreach (var restriction in _priceRestrictions)
                     restriction.OnTrade(priceTicks, time);
-                CheckStops(events);
             }
         }
 
-        private void CheckStops(List<OrderBookEvent> events)
+        private void TriggerStops(IReadOnlyList<InternalOrder> orders, DateTime time, List<OrderBookEvent> events,
+            List<InternalOrder> pendingImmediateOrCancelStops)
         {
-            var time = Now();
-            var triggered = new SortedDictionary<long, InternalOrder>();
-
-            while (_matcher.Stops[Side.Buy].TryGetBest(out var buyTick, out var buyFirst) && buyTick <= _lastTradedPrice)
+            foreach (var order in orders)
             {
-                for (var order = buyFirst; order != null; order = order.LevelNext)
-                    triggered.Add(order.SequenceNumber, order);
-                _matcher.Stops[Side.Buy].RemoveLevel(buyTick);
-            }
+                var triggerPriceTicks = order.TriggerPrice ??
+                    throw new InvalidOperationException("stop order missing stop price");
+                _matcher.Stops[order.Side].Remove(triggerPriceTicks, order);
 
-            while (_matcher.Stops[Side.Sell].TryGetBest(out var sellTick, out var sellFirst) && sellTick >= _lastTradedPrice)
-            {
-                for (var order = sellFirst; order != null; order = order.LevelNext)
-                    triggered.Add(order.SequenceNumber, order);
-                _matcher.Stops[Side.Sell].RemoveLevel(sellTick);
-            }
+                if (order.Validity is OrderValidity.ImmediateOrCancel)
+                    pendingImmediateOrCancelStops.Add(order);
 
-            if (triggered.Any())
-            {
-                TriggerStops(triggered, time, events);
-                Match(events);
-
-                foreach (var order in triggered.Values)
-                {
-                    if (order.Validity is OrderValidity.ImmediateOrCancel && order.RemainingQuantity > 0)
-                        events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
-                }
-            }
-        }
-
-        private void TriggerStops(SortedDictionary<long, InternalOrder> orders, DateTime time,
-            List<OrderBookEvent> events)
-        {
-            foreach (var (_, order) in orders)
-            {
                 // calculate price for stop market orders
                 long? newPriceTicks = order.Price;
                 if (order.Type == OrderType.StopMarket &&

--- a/Circus/OrderBook/MatchOutcome.cs
+++ b/Circus/OrderBook/MatchOutcome.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Circus.OrderBook
 {
     // What Matcher.Run decided should happen next, without having mutated anything or emitted any
@@ -13,4 +15,8 @@ namespace Circus.OrderBook
     // Terminal for the Run this came from - Matcher stops yielding after this, matching Match()'s
     // previous early-return on a trade-restriction breach.
     internal sealed record TradeRestrictionBreached(long PriceTicks, RestrictionBreachAction Action) : MatchOutcome;
+
+    // Orders pulled from Stops by the trade that just printed, in trigger order (FIFO by
+    // SequenceNumber across both sides) - still resting in Stops until Apply removes them.
+    internal sealed record StopsTriggered(IReadOnlyList<InternalOrder> Orders) : MatchOutcome;
 }

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -32,15 +32,22 @@ namespace Circus.OrderBook
             _working[side].TryGetBest(out _, out var order) ? order : null;
 
         // Decides, one step at a time, what Match should do next against the current book state -
-        // self-match cancellations, trades, and trade-restriction breaches - without mutating
-        // anything or emitting events. checkTradeRestrictionBreach is a pure query (not consulted
-        // during an auction uncrossing pass, same as before) returning the breach action of the
-        // first Trade-scoped restriction that disallows the prospective trade price, if any.
-        // Re-reads the book fresh on every iteration, so the caller must fully apply each yielded
-        // outcome - including any ladder mutation - before asking for the next one.
+        // self-match cancellations, trades, trade-restriction breaches, and stop triggers -
+        // without mutating anything or emitting events. checkTradeRestrictionBreach is a pure
+        // query (not consulted during an auction uncrossing pass, same as before) returning the
+        // breach action of the first Trade-scoped restriction that disallows the prospective trade
+        // price, if any. Re-reads the book fresh on every iteration, so the caller must fully
+        // apply each yielded outcome - including any ladder mutation - before asking for the next
+        // one; a converted stop landing in Working is exactly what lets this same loop pick it up
+        // and keep matching, with no separate recursive pass needed.
         public IEnumerable<MatchOutcome> Run(long? auctionPriceTicks,
             Func<long, RestrictionBreachAction?> checkTradeRestrictionBreach)
         {
+            // Once a stop fires mid-sweep, everything after it prices continuously - an auction
+            // print is the resolution mechanism for the book as it stood at open, not for orders
+            // that have just newly arrived because of it.
+            var effectiveAuctionPriceTicks = auctionPriceTicks;
+
             var buy = BestOrder(Side.Buy);
             var sell = BestOrder(Side.Sell);
 
@@ -63,7 +70,7 @@ namespace Circus.OrderBook
                 }
 
                 var quantity = Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
-                var priceTicks = auctionPriceTicks ?? resting.Price ??
+                var priceTicks = effectiveAuctionPriceTicks ?? resting.Price ??
                     throw new InvalidOperationException("limit order requires price");
 
                 // Checked against the prospective trade price, not either order's own submitted
@@ -71,7 +78,7 @@ namespace Circus.OrderBook
                 // actual price movement, only an executed trade at an extreme price does. Doesn't
                 // apply to an auction uncrossing pass itself (auctionPriceTicks set) - the auction
                 // print is already the resolution mechanism, not something to interrupt.
-                if (auctionPriceTicks == null)
+                if (effectiveAuctionPriceTicks == null)
                 {
                     var breachAction = checkTradeRestrictionBreach(priceTicks);
                     if (breachAction.HasValue)
@@ -83,9 +90,50 @@ namespace Circus.OrderBook
 
                 yield return new TradeExecuted(resting, aggressor, priceTicks, quantity);
 
+                var triggeredStops = GatherTriggeredStops(priceTicks);
+                if (triggeredStops != null)
+                {
+                    yield return new StopsTriggered(triggeredStops);
+                    effectiveAuctionPriceTicks = null;
+                }
+
                 buy = BestOrder(Side.Buy);
                 sell = BestOrder(Side.Sell);
             }
+        }
+
+        // Non-mutating: only identifies which resting stop orders now qualify to trigger at
+        // priceTicks - removing them from Stops, and converting or cancelling them, is Apply's
+        // job. Safe to call after every trade, even repeatedly at the same price: an order already
+        // removed from Stops by an earlier StopsTriggered within this same Run simply isn't found
+        // again. Buy stops trigger as price rises to/through their level, sell stops as it falls
+        // to/through theirs - same direction each ladder is already ordered in, so EnumerateFromBest
+        // can stop at the first level that no longer qualifies.
+        private List<InternalOrder>? GatherTriggeredStops(long priceTicks)
+        {
+            SortedDictionary<long, InternalOrder>? triggered = null;
+
+            foreach (var (tick, first, _) in _stops[Side.Buy].EnumerateFromBest())
+            {
+                if (tick > priceTicks)
+                    break;
+
+                triggered ??= new SortedDictionary<long, InternalOrder>();
+                for (var order = first; order != null; order = order.LevelNext)
+                    triggered.Add(order.SequenceNumber, order);
+            }
+
+            foreach (var (tick, first, _) in _stops[Side.Sell].EnumerateFromBest())
+            {
+                if (tick < priceTicks)
+                    break;
+
+                triggered ??= new SortedDictionary<long, InternalOrder>();
+                for (var order = first; order != null; order = order.LevelNext)
+                    triggered.Add(order.SequenceNumber, order);
+            }
+
+            return triggered?.Values.ToList();
         }
 
         private static int SumRemaining(InternalOrder? first)
@@ -102,7 +150,7 @@ namespace Circus.OrderBook
         // auctionReferencePriceTicks, since neither venue's public docs cover a case this granular,
         // (3) CME's final rule: highest price if the surplus is on the buy side, lowest if on the
         // sell side. Stops are deliberately not folded into this search (unlike CME's iterative
-        // stop-election loop) - they're picked up afterward by the existing CheckStops() pass,
+        // stop-election loop) - they're picked up afterward by Run's own stop-triggering check,
         // same as any other trade.
         public bool TryComputeAuctionPrice(long? auctionReferencePriceTicks, out long priceTicks, out int quantity)
         {


### PR DESCRIPTION
## Summary

Third and final step (C2) of the matching-logic decomposition plan, building on the merged C0 (#35) and C1 (#36): flatten stop-triggering into `Matcher.Run`'s outcome stream and delete the `CheckStops` → `Match` recursion.

- `Matcher.Run` now checks the stops ladders itself right after each `TradeExecuted` (using that trade's own price), yielding a new `StopsTriggered` outcome when any qualify. It never mutates `Stops`/`Working` itself — `InMemoryOrderBook.Apply`'s `TriggerStops` does the removal, conversion-to-limit (or cancellation, for a stop-market with no liquidity or an IOC gate that fails), and event emission, same logic as before.
- The key change: a converted stop lands in `Working`, which the *same* `Run` while-loop already reads from on its next iteration — so newly triggered stops get matched by the loop continuing, not by a nested recursive `Match()` call. `ApplyTrade` no longer calls back into `CheckStops`/`Match` at all; `CheckStops` is deleted.
- The IOC-not-filled cancellation check for triggered stops is now deferred to once `Run`'s enumeration is fully exhausted (in `InMemoryOrderBook.Match`'s outer loop), rather than right after each stop's own nested cascade. This is equivalent because `Run`'s loop only ever terminates once no crosses remain anywhere in the book, so "did it fill" can't be answered any earlier than that in either version.

## Test plan

- [x] Manual trace of every stop-related test across `InMemoryOrderBookStopTriggerTests.cs`, the stop test in `InMemoryOrderBookImmediateOrCancelTests.cs`, and the stop+volatility-pause test in `InMemoryOrderBookAuctionTests.cs`, confirming identical event sequences to the original recursive implementation.
- [x] Traced a more complex case found via review — a stop that triggers mid-sweep and then itself produces a *second*, differently-priced trade (`LevelDataProducerTests.StopOrderActivation_ReportedAsArrival_NotDoubleCounted` / `FullBookDataProducerTests.StopOrderActivation_ProducesAddedDelta_NotModified`) — through the new `Matcher.Run` loop by hand; event ordering (arrival before fill, never observable as a resting level) matches.
- [x] Confirmed no other test combines a stop trigger with auction uncrossing, self-match prevention, or a price-restriction breach, or asserts exact `events[N]` ordering around a trigger beyond what was checked above.
- [ ] CI (`dotnet build` + `dotnet test`) — no local .NET SDK available in this sandbox, so this PR relies on CI to confirm the full `Circus.Tests` suite is still green.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PqcnfvPNmBnm2xthgwgED)_