### PR TITLE
Fix opening-auction allocation ignoring iceberg priority mid-print

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -90,6 +90,72 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
+        public void Opening_IcebergAheadOfLaterOrder_FillsInFullBeforeTheLaterOrderGetsAnything()
+        {
+            // arrange - an iceberg (qty 100, peak 10) rests first at the clearing price; a plain
+            // order (qty 60) arrives second at the same price. Only 100 total sell liquidity is
+            // available - exactly enough to satisfy the iceberg's full size and nothing else.
+            // Price-time priority means the iceberg, having arrived first, must be filled in full
+            // before the later order gets anything - it must not lose its place in the queue just
+            // because its displayed peak needs replenishing mid-print.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
+                maxVisibleQuantity: 10);
+            TimeProvider.SetCurrentTime(Now2);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 60, 100);
+            TimeProvider.SetCurrentTime(Now3);
+            book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 100, 100);
+
+            // act
+            var events = book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert
+            var fills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills).ToList();
+            var icebergFilled = fills.Where(f => f.Order.ClientOrderId == OrderId1).Sum(f => f.Quantity);
+            var laterOrderFilled = fills.Where(f => f.Order.ClientOrderId == OrderId2).Sum(f => f.Quantity);
+
+            Assert.AreEqual(100, icebergFilled, "the earlier-arriving iceberg should be filled in full");
+            Assert.AreEqual(0, laterOrderFilled,
+                "the later order should receive nothing once the earlier iceberg exhausts all available liquidity");
+        }
+
+        [Test]
+        public void Opening_IcebergPartiallyFilled_DisplayedPeakCorrectAfterwardsNotNegative()
+        {
+            // arrange - an iceberg (qty 100, peak 10) is the only buy order at the clearing price;
+            // only 45 units of sell liquidity are available, so it fills for 45 in a single
+            // auction allocation (not five separate peak-sized touches) and is left resting with
+            // 55 remaining. Sizing that single fill against the full remaining quantity rather
+            // than the 10-unit peak must not leave DisplayedQuantity negative or stale - it should
+            // come out re-derived to a fresh full peak, the same as if it had just been entered.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
+                maxVisibleQuantity: 10);
+            TimeProvider.SetCurrentTime(Now2);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100);
+
+            // act
+            var events = book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert - one clean allocation of 45, not several smaller touches
+            var icebergFills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills)
+                .Where(f => f.Order.ClientOrderId == OrderId1).ToList();
+            Assert.AreEqual(1, icebergFills.Count);
+            Assert.AreEqual(45, icebergFills[0].Quantity);
+
+            var buyLevels = book.GetLevels(Side.Buy, 10);
+            Assert.AreEqual(1, buyLevels.Count);
+            Assert.AreEqual(100, buyLevels[0].Price);
+            Assert.AreEqual(10, buyLevels[0].Quantity, "displayed peak should be a fresh full 10, not negative or stale");
+        }
+
+        [Test]
         public void Opening_TiedCandidates_DefaultsToCmeDirectionRule()
         {
             // arrange - 120 and 130 tie for max executable volume (10 each), with the surplus on

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -549,8 +549,8 @@ namespace Circus.OrderBook
                         events.Add(CancelRemainder(aggressor, OrderCancelledReason.SelfMatchPrevention));
                     break;
 
-                case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity):
-                    ApplyTrade(resting, aggressor, priceTicks, quantity, events, time);
+                case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity, var isAuctionAllocation):
+                    ApplyTrade(resting, aggressor, priceTicks, quantity, isAuctionAllocation, events, time);
                     break;
 
                 case TradeRestrictionBreached(_, var action):
@@ -565,15 +565,23 @@ namespace Circus.OrderBook
         }
 
         private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
-            List<OrderBookEvent> events, DateTime time)
+            bool isAuctionAllocation, List<OrderBookEvent> events, DateTime time)
         {
             var price = ToDecimal(priceTicks);
 
-            resting.Fill(time, quantity);
+            void FillOrder(InternalOrder order)
+            {
+                if (isAuctionAllocation)
+                    order.FillFullSize(time, quantity);
+                else
+                    order.Fill(time, quantity);
+            }
+
+            FillOrder(resting);
             var restingSnapshot = resting.ToOrder();
             var restingReplenish = FinishFill(resting, time);
 
-            aggressor.Fill(time, quantity);
+            FillOrder(aggressor);
             var aggressorSnapshot = aggressor.ToOrder();
             var aggressorReplenish = FinishFill(aggressor, time);
 

--- a/Circus/OrderBook/InternalOrder.cs
+++ b/Circus/OrderBook/InternalOrder.cs
@@ -158,6 +158,27 @@ namespace Circus.OrderBook
             }
         }
 
+        // Used only by an auction print, which allocates against an order's full remaining size in
+        // one shot rather than peeling from its displayed peak the way a continuous touch does -
+        // the print is a single atomic event, not a sequence of touches an iceberg needs to ration
+        // its displayed size across. Re-derives DisplayedQuantity from whatever's left afterward
+        // instead of subtracting from it directly (which could take it negative, since quantity
+        // here isn't capped to the current peak), and - unlike Replenish - bumps neither
+        // SequenceNumber nor ModifiedTime: this order isn't losing its place in a queue, only being
+        // sized differently for once.
+        public void FillFullSize(DateTime time, int quantity)
+        {
+            FilledQuantity += quantity;
+            RemainingQuantity -= quantity;
+            DisplayedQuantity = Math.Min(MaxVisibleQuantity ?? RemainingQuantity, RemainingQuantity);
+
+            if (RemainingQuantity == 0)
+            {
+                Status = OrderStatus.Filled;
+                CompletedTime = time;
+            }
+        }
+
         // Called when an iceberg's displayed peak hits zero with hidden reserve still remaining -
         // refreshes the display and bumps SequenceNumber/ModifiedTime, since the caller re-queues
         // this order to the back of its price level immediately afterward (losing time priority,

--- a/Circus/OrderBook/MatchOutcome.cs
+++ b/Circus/OrderBook/MatchOutcome.cs
@@ -9,8 +9,13 @@ namespace Circus.OrderBook
     internal sealed record SelfMatchDetected(InternalOrder Resting, InternalOrder Aggressor,
         SelfMatchPreventionInstruction Instruction) : MatchOutcome;
 
+    // IsAuctionAllocation is true only for a trade priced and sized during an auction print
+    // (as opposed to one after a stop has switched the rest of that print to continuous pricing) -
+    // it tells Apply to size the fill against the order's full remaining quantity instead of its
+    // displayed peak, since the print is one atomic allocation, not a sequence of continuous
+    // touches an iceberg needs to ration its displayed size across.
     internal sealed record TradeExecuted(InternalOrder Resting, InternalOrder Aggressor, long PriceTicks,
-        int Quantity) : MatchOutcome;
+        int Quantity, bool IsAuctionAllocation) : MatchOutcome;
 
     // Terminal for the Run this came from - Matcher stops yielding after this, matching Match()'s
     // previous early-return on a trade-restriction breach.

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -69,7 +69,16 @@ namespace Circus.OrderBook
                     continue;
                 }
 
-                var quantity = Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
+                // An auction print allocates against each side's full remaining size, not its
+                // displayed peak - it's one atomic clearing event, not a sequence of continuous
+                // touches an iceberg needs to ration its displayed size across. Sizing off the
+                // displayed peak here (as continuous matching correctly does) is what let a
+                // later-arriving order leapfrog an iceberg mid-print, every time the iceberg's
+                // peak needed replenishing.
+                var isAuctionAllocation = effectiveAuctionPriceTicks.HasValue;
+                var quantity = isAuctionAllocation
+                    ? Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity)
+                    : Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
                 var priceTicks = effectiveAuctionPriceTicks ?? resting.Price ??
                     throw new InvalidOperationException("limit order requires price");
 
@@ -78,7 +87,7 @@ namespace Circus.OrderBook
                 // actual price movement, only an executed trade at an extreme price does. Doesn't
                 // apply to an auction uncrossing pass itself (auctionPriceTicks set) - the auction
                 // print is already the resolution mechanism, not something to interrupt.
-                if (effectiveAuctionPriceTicks == null)
+                if (!isAuctionAllocation)
                 {
                     var breachAction = checkTradeRestrictionBreach(priceTicks);
                     if (breachAction.HasValue)
@@ -88,7 +97,7 @@ namespace Circus.OrderBook
                     }
                 }
 
-                yield return new TradeExecuted(resting, aggressor, priceTicks, quantity);
+                yield return new TradeExecuted(resting, aggressor, priceTicks, quantity, isAuctionAllocation);
 
                 var triggeredStops = GatherTriggeredStops(priceTicks);
                 if (triggeredStops != null)


### PR DESCRIPTION
## Summary

Addresses Proposal D from the matching-logic architecture review (the divergence named in "auction prices on full size... but the loop fills only the displayed peak"), confirmed as a real allocation bug via a hand-traced scenario before writing any fix.

**The bug:** `Matcher.Run` sized every auction-priced trade off `DisplayedQuantity`, exactly like a continuous touch. When an iceberg's displayed peak needed replenishing mid-print, `FinishFill` requeued it to the back of its price level - so a later-arriving order at the same clearing price could leapfrog an iceberg that arrived first, even though the auction's own executable-volume calculation (`TryComputeAuctionPrice`, via `SumRemaining`) already counts the iceberg's full remaining size. Concretely: an iceberg (qty 100, peak 10) arriving before a plain order (qty 60), with exactly 100 units of opposing liquidity, ended up giving the *later* order 60 filled and the iceberg only 40 - backwards from price-time priority.

**The fix** turned out much smaller than the originating design doc anticipated, since `Matcher.Run`/`Apply` (from the already-merged C0-C2 work) let the existing pairwise loop reproduce correct priority allocation once fed the right quantities - no separate auction algorithm or new interface needed:
- `Matcher.Run` now sizes a trade off each side's full `RemainingQuantity` while `effectiveAuctionPriceTicks` is set (i.e. during an auction print, before any stop switches the rest of it to continuous pricing), instead of `DisplayedQuantity`.
- `InternalOrder.FillFullSize` fills against that full amount in one shot and re-derives `DisplayedQuantity` from what's left afterward, rather than subtracting from it directly (which could otherwise go negative, since the fill is no longer capped to the current peak).
- `TradeExecuted` carries a new `IsAuctionAllocation` flag so `Apply` knows which fill method to use.
- Continuous matching is untouched, and this is a no-op for every existing non-iceberg scenario: `DisplayedQuantity == RemainingQuantity` whenever `MaxVisibleQuantity` is null.

## Test plan

- [x] Added `Opening_IcebergAheadOfLaterOrder_FillsInFullBeforeTheLaterOrderGetsAnything` - hand-traced against both the old and new code; fails on the old code (iceberg 40, later order 60) and passes on the new one (iceberg 100, later order 0).
- [x] Added `Opening_IcebergPartiallyFilled_DisplayedPeakCorrectAfterwardsNotNegative` - covers the partial-fill path where the negative-`DisplayedQuantity` risk in a naive fix would have shown up; asserts a single 45-unit allocation (not five 10-unit touches) and a correctly re-derived peak of 10 afterward.
- [x] Confirmed no existing test in `InMemoryOrderBookAuctionTests.cs` uses icebergs, and manually verified the fix is mathematically a no-op for non-iceberg orders (`DisplayedQuantity == RemainingQuantity` always holds when `MaxVisibleQuantity` is null), so no other test's behavior changes.
- [ ] CI (`dotnet build` + `dotnet test`) - no local .NET SDK available in this sandbox, so this PR relies on CI to confirm the full `Circus.Tests` suite is still green.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PqcnfvPNmBnm2xthgwgED)_