### PR TITLE
Extract matching algorithms behind IMatchingAlgorithm

### DIFF
--- a/Circus.Tests/OrderBook/MatcherTests.cs
+++ b/Circus.Tests/OrderBook/MatcherTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Circus.OrderBook;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // Drives Matcher directly rather than through InMemoryOrderBook, which is the only way to run
+    // it against a matching algorithm the book doesn't itself construct. Covers the seam
+    // IMatchingAlgorithm.SelectNext opens up: an algorithm choosing a counterparty other than the
+    // FIFO-earliest order at the level, which is what any non-price-time algorithm (pro-rata and
+    // friends) needs and what the loop used to decide for itself.
+    [TestFixture]
+    public class MatcherTests
+    {
+        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+        private static readonly DateTime Early = new(2000, 1, 1, 12, 0, 0);
+        private static readonly DateTime Late = new(2000, 1, 1, 12, 1, 0);
+
+        private const long Tick = 100;
+
+        // Nothing yielded by Run is applied here, so the book is never mutated and the loop would
+        // re-offer the same crossing forever. Every test below takes only as many outcomes as the
+        // lazy iterator has to produce, which is safe precisely because Run yields.
+        private static MatchOutcome? FirstOutcome(Matcher matcher, IMatchingAlgorithm algorithm) =>
+            matcher.Run(algorithm, algorithm, _ => null).FirstOrDefault();
+
+        private static InternalOrder Order(long sequenceNumber, Side side, int quantity, DateTime time) =>
+            new(sequenceNumber, $"Company{sequenceNumber}", $"Order{sequenceNumber}", Sec, time,
+                OrderStatus.Working, OrderType.Limit, new OrderValidity.Day(), side, quantity, Tick, null);
+
+        // Three resting buys at one price, then a later sell that crosses all of them - the shape
+        // every allocation algorithm differs over.
+        private static Matcher BookWithThreeRestingBuys(out InternalOrder first, out InternalOrder second,
+            out InternalOrder third, int aggressorQuantity = 50)
+        {
+            var matcher = new Matcher();
+
+            first = Order(1, Side.Buy, 60, Early);
+            second = Order(2, Side.Buy, 30, Early);
+            third = Order(3, Side.Buy, 10, Early);
+
+            matcher.Working[Side.Buy].Add(Tick, first);
+            matcher.Working[Side.Buy].Add(Tick, second);
+            matcher.Working[Side.Buy].Add(Tick, third);
+            matcher.Working[Side.Sell].Add(Tick, Order(4, Side.Sell, aggressorQuantity, Late));
+
+            return matcher;
+        }
+
+        [Test]
+        public void SelectNext_ChoosingBehindTheHead_IsHonoured()
+        {
+            // arrange - the head is offered, as always, but this algorithm allocates to the order
+            // behind it. Under the old shape the loop picked the counterparty itself and this was
+            // simply not expressible.
+            var matcher = BookWithThreeRestingBuys(out var first, out var second, out _);
+
+            // act
+            var outcome = FirstOutcome(matcher, new SelectsBehindTheHead());
+
+            // assert
+            var trade = outcome as TradeExecuted;
+            Assert.IsNotNull(trade);
+            Assert.AreSame(second, trade.Resting, "the algorithm's choice should decide the counterparty");
+            Assert.AreNotSame(first, trade.Resting, "the FIFO-earliest order should have been passed over");
+            Assert.AreEqual(30, trade.Quantity);
+        }
+
+        [Test]
+        public void PriceTime_TakesTheHeadOfTheLevel()
+        {
+            // arrange - the default algorithm must still be strict price-time: head first, sized
+            // off displayed quantity, printed at the resting order's own limit.
+            var matcher = BookWithThreeRestingBuys(out var first, out _, out _);
+
+            // act
+            var outcome = FirstOutcome(matcher, new PriceTime());
+
+            // assert
+            var trade = outcome as TradeExecuted;
+            Assert.IsNotNull(trade);
+            Assert.AreSame(first, trade.Resting);
+            Assert.AreEqual(50, trade.Quantity, "capped by the aggressor's 50, not the head's 60");
+            Assert.AreEqual(Tick, trade.PriceTicks);
+            Assert.IsFalse(trade.UsesFullRemainingQuantity);
+        }
+
+        [Test]
+        public void SelectNext_DecliningToMatch_EndsTheRunWithoutTrading()
+        {
+            // arrange - a crossed book an algorithm refuses to act on should terminate rather than
+            // spin, since the loop would otherwise keep re-offering the same crossing.
+            var matcher = BookWithThreeRestingBuys(out _, out _, out _);
+
+            // act
+            var outcomes = matcher.Run(new DeclinesToMatch(), new PriceTime(), _ => null).ToList();
+
+            // assert
+            Assert.IsEmpty(outcomes);
+        }
+
+        [Test]
+        public void TryBegin_ReturningFalse_YieldsNothing()
+        {
+            // arrange - how an uncrossing pass over an uncrossed book stays a no-op.
+            var matcher = BookWithThreeRestingBuys(out _, out _, out _);
+
+            // act
+            var outcomes = matcher.Run(new DeclinesToBegin(), new PriceTime(), _ => null).ToList();
+
+            // assert
+            Assert.IsEmpty(outcomes);
+        }
+
+        private sealed class SelectsBehindTheHead : IMatchingAlgorithm
+        {
+            public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => true;
+
+            public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor)
+            {
+                var behind = restingHead.LevelNext ?? restingHead;
+                return new Allocation(behind, Math.Min(behind.RemainingQuantity, aggressor.RemainingQuantity),
+                    behind.Price!.Value);
+            }
+
+            public bool UsesFullRemainingQuantity => true;
+            public bool ChecksTradeRestrictions => false;
+        }
+
+        private sealed class DeclinesToMatch : IMatchingAlgorithm
+        {
+            public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => true;
+            public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) => null;
+            public bool UsesFullRemainingQuantity => false;
+            public bool ChecksTradeRestrictions => false;
+        }
+
+        private sealed class DeclinesToBegin : IMatchingAlgorithm
+        {
+            public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => false;
+            public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
+                throw new InvalidOperationException("must not be consulted once TryBegin declines");
+            public bool UsesFullRemainingQuantity => false;
+            public bool ChecksTradeRestrictions => false;
+        }
+    }
+}

--- a/Circus/OrderBook/Auction.cs
+++ b/Circus/OrderBook/Auction.cs
@@ -1,23 +1,38 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Circus.OrderBook
 {
-    // A call-auction print. Every trade clears at one price - computed beforehand by
-    // Matcher.TryComputeAuctionPrice as the price maximizing executable volume across the resting
-    // book - and is sized off each side's full remaining quantity rather than its displayed peak:
-    // the print is a single atomic allocation, not a sequence of continuous touches an iceberg
-    // would need to ration its displayed size across.
-    //
-    // Constructed per print, since the clearing price belongs to the particular book state being
-    // uncrossed.
+    // A call-auction print. Every trade clears at one price - the price maximizing executable
+    // volume across the resting book, computed here - and is sized off each side's full remaining
+    // quantity rather than its displayed peak: the print is a single atomic allocation, not a
+    // sequence of continuous touches an iceberg would need to ration its displayed size across.
     internal sealed class Auction : IMatchingAlgorithm
     {
-        private readonly long _clearingPriceTicks;
+        // Reference anchor for the tie-break below, and nothing else: seeded from an explicit
+        // reference price (mirroring CME's settlement price pre-open) before any trade, then
+        // tracking the trade price. Owned here rather than by the book for the same reason each
+        // IPriceRestriction owns its own anchor - no other concern reads it. Deliberately distinct
+        // from the book's _lastTradedPrice, which being null specifically means "no trade yet" for
+        // the stop-trigger checks.
+        private long? _referencePriceTicks;
 
-        public Auction(long clearingPriceTicks)
-        {
-            _clearingPriceTicks = clearingPriceTicks;
-        }
+        // Fixed by TryBegin for the duration of one print, so the trades that print are allocated
+        // against the book as it stood when the price was struck - not re-derived per trade from a
+        // book those very trades are consuming.
+        private long _clearingPriceTicks;
+
+        // Lifecycle hooks mirroring IPriceRestriction.OnTrade / OnSessionChange, called by the
+        // book to keep the anchor above current.
+        public void OnTrade(long priceTicks) => _referencePriceTicks = priceTicks;
+
+        public void OnSessionChange(long? referencePriceTicks) => _referencePriceTicks = referencePriceTicks;
+
+        // False when the book isn't crossed, which is what makes an uncrossing pass over an
+        // uncrossed book a no-op rather than something the caller has to check for first.
+        public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) =>
+            TryComputeClearingPrice(working, out _clearingPriceTicks, out _);
 
         public long PriceTicks(InternalOrder resting) => _clearingPriceTicks;
 
@@ -29,5 +44,83 @@ namespace Circus.OrderBook
         // The print is itself the resolution mechanism for a crossed book - not something a
         // volatility pause should interrupt partway through.
         public bool ChecksTradeRestrictions => false;
+
+        // The uncrossing price: the price that maximizes executable volume across the resting
+        // book, i.e. min(cumulative bid quantity at/above p, cumulative ask quantity at/below p).
+        // Ties break by (1) minimum surplus - CME's rule, (2) closest to _referencePriceTicks,
+        // since neither venue's public docs cover a case this granular, (3) CME's final rule:
+        // highest price if the surplus is on the buy side, lowest if on the sell side. Stops are
+        // deliberately not folded into this search (unlike CME's iterative stop-election loop) -
+        // they're picked up afterward by Matcher.Run's own stop-triggering check, same as any
+        // other trade.
+        //
+        // Public and side-effect-free so the book can also publish it as a live indicative price
+        // during pre-open, without committing to a print.
+        public bool TryComputeClearingPrice(IReadOnlyDictionary<Side, PriceLadder> working, out long priceTicks,
+            out int quantity)
+        {
+            priceTicks = 0;
+            quantity = 0;
+
+            var buyLevels = working[Side.Buy].EnumerateFromBest()
+                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
+            var sellLevels = working[Side.Sell].EnumerateFromBest()
+                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
+
+            if (buyLevels.Count == 0 || sellLevels.Count == 0 || buyLevels[0].Tick < sellLevels[0].Tick)
+                return false;
+
+            var candidates = buyLevels.Select(l => l.Tick).Concat(sellLevels.Select(l => l.Tick)).Distinct();
+
+            (long Price, int Executable, long Surplus)? best = null;
+            foreach (var p in candidates)
+            {
+                var cumBid = buyLevels.Where(l => l.Tick >= p).Sum(l => l.Qty);
+                var cumAsk = sellLevels.Where(l => l.Tick <= p).Sum(l => l.Qty);
+                var executable = Math.Min(cumBid, cumAsk);
+                var surplus = cumBid - cumAsk;
+
+                if (best == null || executable > best.Value.Executable ||
+                    (executable == best.Value.Executable &&
+                     IsBetterTieBreak(p, surplus, best.Value.Price, best.Value.Surplus)))
+                {
+                    best = (p, executable, surplus);
+                }
+            }
+
+            priceTicks = best!.Value.Price;
+            quantity = best.Value.Executable;
+            return quantity > 0;
+        }
+
+        private bool IsBetterTieBreak(long candidatePrice, long candidateSurplus, long currentPrice,
+            long currentSurplus)
+        {
+            var candidateAbsSurplus = Math.Abs(candidateSurplus);
+            var currentAbsSurplus = Math.Abs(currentSurplus);
+            if (candidateAbsSurplus != currentAbsSurplus)
+                return candidateAbsSurplus < currentAbsSurplus;
+
+            if (_referencePriceTicks.HasValue)
+            {
+                var candidateDistance = Math.Abs(candidatePrice - _referencePriceTicks.Value);
+                var currentDistance = Math.Abs(currentPrice - _referencePriceTicks.Value);
+                if (candidateDistance != currentDistance)
+                    return candidateDistance < currentDistance;
+            }
+
+            // surplus on the buy side (positive) -> prefer the higher price; sell side -> lower
+            return candidateSurplus > 0 ? candidatePrice > currentPrice : candidatePrice < currentPrice;
+        }
+
+        // Counts an iceberg's hidden reserve in full - price discovery is on true size, unlike the
+        // displayed-only aggregates the book publishes as market data.
+        private static int SumRemaining(InternalOrder? first)
+        {
+            var total = 0;
+            for (var order = first; order != null; order = order.LevelNext)
+                total += order.RemainingQuantity;
+            return total;
+        }
     }
 }

--- a/Circus/OrderBook/Auction.cs
+++ b/Circus/OrderBook/Auction.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Circus.OrderBook
+{
+    // A call-auction print. Every trade clears at one price - computed beforehand by
+    // Matcher.TryComputeAuctionPrice as the price maximizing executable volume across the resting
+    // book - and is sized off each side's full remaining quantity rather than its displayed peak:
+    // the print is a single atomic allocation, not a sequence of continuous touches an iceberg
+    // would need to ration its displayed size across.
+    //
+    // Constructed per print, since the clearing price belongs to the particular book state being
+    // uncrossed.
+    internal sealed class Auction : IMatchingAlgorithm
+    {
+        private readonly long _clearingPriceTicks;
+
+        public Auction(long clearingPriceTicks)
+        {
+            _clearingPriceTicks = clearingPriceTicks;
+        }
+
+        public long PriceTicks(InternalOrder resting) => _clearingPriceTicks;
+
+        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
+            Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
+
+        public bool UsesFullRemainingQuantity => true;
+
+        // The print is itself the resolution mechanism for a crossed book - not something a
+        // volatility pause should interrupt partway through.
+        public bool ChecksTradeRestrictions => false;
+    }
+}

--- a/Circus/OrderBook/Auction.cs
+++ b/Circus/OrderBook/Auction.cs
@@ -34,10 +34,13 @@ namespace Circus.OrderBook
         public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) =>
             TryComputeClearingPrice(working, out _clearingPriceTicks, out _);
 
-        public long PriceTicks(InternalOrder resting) => _clearingPriceTicks;
-
-        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
-            Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
+        // Time priority at the clearing price: the FIFO-earliest order at the level fills first,
+        // same order the continuous algorithm would take them in - what differs is the price they
+        // all print at and the full-size allocation below.
+        public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
+            new Allocation(restingHead,
+                Math.Min(restingHead.RemainingQuantity, aggressor.RemainingQuantity),
+                _clearingPriceTicks);
 
         public bool UsesFullRemainingQuantity => true;
 

--- a/Circus/OrderBook/IMatchingAlgorithm.cs
+++ b/Circus/OrderBook/IMatchingAlgorithm.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Circus.OrderBook
+{
+    // Selected by InMemoryOrderBook per phase (continuous vs. an auction print) and consulted by
+    // Matcher.Run for how to price and size the next trade. The loop itself - self-match
+    // detection, the crossing condition, stop-triggering - is identical either way and stays owned
+    // by Matcher; only these decisions vary between algorithms.
+    internal interface IMatchingAlgorithm
+    {
+        // The price a trade between these two orders should print at.
+        long PriceTicks(InternalOrder resting);
+
+        // How much of that trade should execute.
+        int Quantity(InternalOrder resting, InternalOrder aggressor);
+
+        // Whether a fill under this algorithm allocates against an order's full remaining quantity
+        // (one atomic auction allocation) rather than its displayed peak (a continuous touch, which
+        // an iceberg needs to ration across several) - tells Apply which InternalOrder fill method
+        // to use.
+        bool UsesFullRemainingQuantity { get; }
+
+        // Whether a fill under this algorithm is checked against Trade-scoped price restrictions -
+        // true for continuous matching; false for an auction print, which is already the
+        // resolution mechanism, not something to interrupt.
+        bool ChecksTradeRestrictions { get; }
+    }
+
+    // Price-time priority against each order's own resting limit price, sized off its displayed
+    // peak - an iceberg only ever shows one peak's worth to the rest of the book at a time.
+    internal sealed class ContinuousMatch : IMatchingAlgorithm
+    {
+        // Stateless - safe to share, including as the algorithm Run switches back to mid-sweep
+        // once a stop triggers during an otherwise-Uncross print.
+        public static readonly ContinuousMatch Instance = new();
+
+        public long PriceTicks(InternalOrder resting) =>
+            resting.Price ?? throw new InvalidOperationException("limit order requires price");
+
+        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
+            Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
+
+        public bool UsesFullRemainingQuantity => false;
+        public bool ChecksTradeRestrictions => true;
+    }
+
+    // The call-auction uncrossing pass: every trade prints at the single pre-computed clearing
+    // price, sized off each side's full remaining quantity - the print is one atomic allocation,
+    // not a sequence of continuous touches an iceberg would otherwise need to ration its displayed
+    // size across.
+    internal sealed class Uncross : IMatchingAlgorithm
+    {
+        private readonly long _priceTicks;
+
+        public Uncross(long priceTicks)
+        {
+            _priceTicks = priceTicks;
+        }
+
+        public long PriceTicks(InternalOrder resting) => _priceTicks;
+
+        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
+            Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
+
+        public bool UsesFullRemainingQuantity => true;
+        public bool ChecksTradeRestrictions => false;
+    }
+}

--- a/Circus/OrderBook/IMatchingAlgorithm.cs
+++ b/Circus/OrderBook/IMatchingAlgorithm.cs
@@ -2,10 +2,13 @@ using System.Collections.Generic;
 
 namespace Circus.OrderBook
 {
-    // How to price and size the next trade. Selected per phase by InMemoryOrderBook and consulted
-    // by Matcher.Run; the loop itself - the crossing condition, self-match detection,
-    // stop-triggering - is identical whichever algorithm is active and stays owned by Matcher.
-    // Only the decisions below vary.
+    // Which resting order an aggressor trades against next, for how much, and at what price.
+    internal readonly record struct Allocation(InternalOrder Resting, int Quantity, long PriceTicks);
+
+    // How the next trade is allocated and priced. Selected per phase by InMemoryOrderBook and
+    // consulted by Matcher.Run; the loop itself - the crossing condition, which side is the
+    // aggressor, self-match detection, stop-triggering - is identical whichever algorithm is
+    // active and stays owned by Matcher. Only the decisions below vary.
     //
     // Implementations are instances rather than shared singletons, so a security can eventually
     // carry its own configured set: a dry-run auction publishing an indicative price during
@@ -18,11 +21,23 @@ namespace Circus.OrderBook
         // there is nothing for this algorithm to match, so the run yields no outcomes at all.
         bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working);
 
-        // The price a trade against this resting order should print at.
-        long PriceTicks(InternalOrder resting);
-
-        // How much of that trade should execute.
-        int Quantity(InternalOrder resting, InternalOrder aggressor);
+        // Picks the counterparty for the next trade. This is the decision that actually separates
+        // one matching algorithm from another - price-time takes the head of the level, pro-rata
+        // divides the aggressor across the whole level in proportion to size - so it belongs here
+        // rather than in the loop.
+        //
+        // restingHead is the FIFO-earliest order at the resting side's best level; walk LevelNext
+        // for the rest of that level. The order returned must come from that level, but need not
+        // be the head: PriceLadder unlinks from any position, so allocating out of FIFO order is
+        // safe. Null declines to match any further and ends the run - a crossed book normally
+        // must not decline, and neither algorithm here ever does.
+        //
+        // An algorithm caching per-level state across calls should key it on the level's price
+        // tick and recompute when the level's composition changes: a selection can still be
+        // dropped before it trades if self-match prevention cancels the pair, which would leave
+        // pre-computed shares stale. Neither algorithm here is stateful, so nothing today relies
+        // on this.
+        Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor);
 
         // Whether a fill allocates against an order's full remaining quantity rather than its
         // displayed peak - tells InMemoryOrderBook.Apply which InternalOrder fill method to use.

--- a/Circus/OrderBook/IMatchingAlgorithm.cs
+++ b/Circus/OrderBook/IMatchingAlgorithm.cs
@@ -1,68 +1,28 @@
-using System;
-
 namespace Circus.OrderBook
 {
-    // Selected by InMemoryOrderBook per phase (continuous vs. an auction print) and consulted by
-    // Matcher.Run for how to price and size the next trade. The loop itself - self-match
-    // detection, the crossing condition, stop-triggering - is identical either way and stays owned
-    // by Matcher; only these decisions vary between algorithms.
+    // How to price and size the next trade. Selected per phase by InMemoryOrderBook and consulted
+    // by Matcher.Run; the loop itself - the crossing condition, self-match detection,
+    // stop-triggering - is identical whichever algorithm is active and stays owned by Matcher.
+    // Only the decisions below vary.
+    //
+    // Implementations are instances rather than shared singletons, so a security can eventually
+    // carry its own configured set: a dry-run auction publishing an indicative price during
+    // pre-open, a committing auction for the opening print, price-time (or a pro-rata variant of
+    // it) once continuous trading starts.
     internal interface IMatchingAlgorithm
     {
-        // The price a trade between these two orders should print at.
+        // The price a trade against this resting order should print at.
         long PriceTicks(InternalOrder resting);
 
         // How much of that trade should execute.
         int Quantity(InternalOrder resting, InternalOrder aggressor);
 
-        // Whether a fill under this algorithm allocates against an order's full remaining quantity
-        // (one atomic auction allocation) rather than its displayed peak (a continuous touch, which
-        // an iceberg needs to ration across several) - tells Apply which InternalOrder fill method
-        // to use.
+        // Whether a fill allocates against an order's full remaining quantity rather than its
+        // displayed peak - tells InMemoryOrderBook.Apply which InternalOrder fill method to use.
         bool UsesFullRemainingQuantity { get; }
 
-        // Whether a fill under this algorithm is checked against Trade-scoped price restrictions -
-        // true for continuous matching; false for an auction print, which is already the
-        // resolution mechanism, not something to interrupt.
+        // Whether a prospective trade price is checked against Trade-scoped price restrictions
+        // (a volatility band pausing the book, say) before it executes.
         bool ChecksTradeRestrictions { get; }
-    }
-
-    // Price-time priority against each order's own resting limit price, sized off its displayed
-    // peak - an iceberg only ever shows one peak's worth to the rest of the book at a time.
-    internal sealed class ContinuousMatch : IMatchingAlgorithm
-    {
-        // Stateless - safe to share, including as the algorithm Run switches back to mid-sweep
-        // once a stop triggers during an otherwise-Uncross print.
-        public static readonly ContinuousMatch Instance = new();
-
-        public long PriceTicks(InternalOrder resting) =>
-            resting.Price ?? throw new InvalidOperationException("limit order requires price");
-
-        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
-            Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
-
-        public bool UsesFullRemainingQuantity => false;
-        public bool ChecksTradeRestrictions => true;
-    }
-
-    // The call-auction uncrossing pass: every trade prints at the single pre-computed clearing
-    // price, sized off each side's full remaining quantity - the print is one atomic allocation,
-    // not a sequence of continuous touches an iceberg would otherwise need to ration its displayed
-    // size across.
-    internal sealed class Uncross : IMatchingAlgorithm
-    {
-        private readonly long _priceTicks;
-
-        public Uncross(long priceTicks)
-        {
-            _priceTicks = priceTicks;
-        }
-
-        public long PriceTicks(InternalOrder resting) => _priceTicks;
-
-        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
-            Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity);
-
-        public bool UsesFullRemainingQuantity => true;
-        public bool ChecksTradeRestrictions => false;
     }
 }

--- a/Circus/OrderBook/IMatchingAlgorithm.cs
+++ b/Circus/OrderBook/IMatchingAlgorithm.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Circus.OrderBook
 {
     // How to price and size the next trade. Selected per phase by InMemoryOrderBook and consulted
@@ -11,6 +13,11 @@ namespace Circus.OrderBook
     // it) once continuous trading starts.
     internal interface IMatchingAlgorithm
     {
+        // Prepare for a run against the current working book, deriving whatever run-scoped state
+        // this algorithm needs from it - an auction strikes its clearing price here. False means
+        // there is nothing for this algorithm to match, so the run yields no outcomes at all.
+        bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working);
+
         // The price a trade against this resting order should print at.
         long PriceTicks(InternalOrder resting);
 

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -14,27 +14,21 @@ namespace Circus.OrderBook
         private long _nextSequenceNumber;
         private long? _lastTradedPrice;
 
-        // Reference anchor for the call-auction tie-break only (IsBetterAuctionPriceTieBreak):
-        // seeded from an explicit reference price (mirroring CME's settlement price pre-open)
-        // before any trade, then tracks the trade price. Kept separate from _lastTradedPrice,
-        // which being null specifically means "no trade yet" for the stop-trigger checks. The
-        // price restrictions no longer read this - each restriction owns its own anchor (see
-        // IPriceRestriction.OnTrade / OnSessionChange), so nothing here is shared with them.
-        private long? _auctionReferencePriceTicks;
-
         // Order-entry and trade-time price bands, each maintaining its own reference anchor.
         // A future velocity limit or circuit breaker is a new entry here, not a redesign.
         private readonly IReadOnlyList<IPriceRestriction> _priceRestrictions;
 
-        // Owns the working/stop ladders and the pure decision helpers (auction pricing,
-        // liquidity checks, self-match verdicts) that read them.
+        // Owns the working/stop ladders and the pure decision helpers (liquidity checks,
+        // self-match verdicts) that read them.
         private readonly Matcher _matcher = new();
 
-        // The algorithm continuous trading runs under, and the one an interrupted auction print
-        // hands the rest of its sweep to. Held as an instance rather than reached for statically
-        // so a security can eventually supply its own (a pro-rata variant, say) alongside the
-        // auction algorithms its pre-open and opening phases use.
+        // The algorithms this book matches under: one for continuous trading - also what an
+        // interrupted auction print hands the rest of its sweep to - and one for the auction
+        // print itself, which owns its own clearing-price computation and reference anchor.
+        // Held as instances rather than reached for statically so a security can eventually
+        // supply its own set, differing by phase.
         private readonly IMatchingAlgorithm _continuous = new PriceTime();
+        private readonly Auction _auction = new();
 
         // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
         private readonly Dictionary<long, InternalOrder> _orders = new();
@@ -70,8 +64,9 @@ namespace Circus.OrderBook
         }
 
         // Market data reports what's publicly visible - an iceberg's hidden reserve is
-        // deliberately excluded here even though HasSufficientLiquidity/TryComputeAuctionPrice
-        // (via SumRemaining) still count it in full for liquidity/price-discovery purposes.
+        // deliberately excluded here even though Matcher.HasSufficientLiquidity and
+        // Auction.TryComputeClearingPrice still count it in full for liquidity/price-discovery
+        // purposes.
         private static int SumDisplayed(InternalOrder? first)
         {
             var total = 0;
@@ -82,7 +77,7 @@ namespace Circus.OrderBook
 
         public bool TryGetIndicativeAuctionPrice(out decimal price, out int quantity)
         {
-            if (!_matcher.TryComputeAuctionPrice(_auctionReferencePriceTicks, out var priceTicks, out quantity))
+            if (!_auction.TryComputeClearingPrice(_matcher.Working, out var priceTicks, out quantity))
             {
                 price = 0;
                 return false;
@@ -610,7 +605,7 @@ namespace Circus.OrderBook
             if (_lastTradedPrice != priceTicks)
             {
                 _lastTradedPrice = priceTicks;
-                _auctionReferencePriceTicks = priceTicks;
+                _auction.OnTrade(priceTicks);
                 foreach (var restriction in _priceRestrictions)
                     restriction.OnTrade(priceTicks, time);
             }
@@ -679,7 +674,7 @@ namespace Circus.OrderBook
         {
             if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
             {
-                _auctionReferencePriceTicks = referenceTicks;
+                _auction.OnSessionChange(referenceTicks);
                 foreach (var restriction in _priceRestrictions)
                     restriction.OnSessionChange(referenceTicks);
             }
@@ -708,9 +703,9 @@ namespace Circus.OrderBook
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
 
             // Runs whether the prior status was the real start-of-day PreOpen or PreOpen
-            // re-entered mid-session for a volatility pause - same uncrossing either way.
-            if (_matcher.TryComputeAuctionPrice(_auctionReferencePriceTicks, out var auctionPriceTicks, out _))
-                Match(events, new Auction(auctionPriceTicks));
+            // re-entered mid-session for a volatility pause - same uncrossing either way, and a
+            // no-op when the book isn't crossed, since the auction declines to begin.
+            Match(events, _auction);
 
             Match(events);
             return events;

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -509,8 +509,11 @@ namespace Circus.OrderBook
 
             var time = Now();
             var pendingImmediateOrCancelStops = new List<InternalOrder>();
+            IMatchingAlgorithm algorithm = auctionPriceTicks.HasValue
+                ? new Uncross(auctionPriceTicks.Value)
+                : ContinuousMatch.Instance;
 
-            foreach (var outcome in _matcher.Run(auctionPriceTicks, CheckTradeRestrictionBreach))
+            foreach (var outcome in _matcher.Run(algorithm, CheckTradeRestrictionBreach))
                 Apply(outcome, events, time, pendingImmediateOrCancelStops);
 
             // Deferred until the whole sweep is done, not checked right after each stop's own
@@ -549,8 +552,8 @@ namespace Circus.OrderBook
                         events.Add(CancelRemainder(aggressor, OrderCancelledReason.SelfMatchPrevention));
                     break;
 
-                case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity, var isAuctionAllocation):
-                    ApplyTrade(resting, aggressor, priceTicks, quantity, isAuctionAllocation, events, time);
+                case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity, var usesFullRemainingQuantity):
+                    ApplyTrade(resting, aggressor, priceTicks, quantity, usesFullRemainingQuantity, events, time);
                     break;
 
                 case TradeRestrictionBreached(_, var action):
@@ -565,13 +568,13 @@ namespace Circus.OrderBook
         }
 
         private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
-            bool isAuctionAllocation, List<OrderBookEvent> events, DateTime time)
+            bool usesFullRemainingQuantity, List<OrderBookEvent> events, DateTime time)
         {
             var price = ToDecimal(priceTicks);
 
             void FillOrder(InternalOrder order)
             {
-                if (isAuctionAllocation)
+                if (usesFullRemainingQuantity)
                     order.FillFullSize(time, quantity);
                 else
                     order.Fill(time, quantity);

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -30,6 +30,12 @@ namespace Circus.OrderBook
         // liquidity checks, self-match verdicts) that read them.
         private readonly Matcher _matcher = new();
 
+        // The algorithm continuous trading runs under, and the one an interrupted auction print
+        // hands the rest of its sweep to. Held as an instance rather than reached for statically
+        // so a security can eventually supply its own (a pro-rata variant, say) alongside the
+        // auction algorithms its pre-open and opening phases use.
+        private readonly IMatchingAlgorithm _continuous = new PriceTime();
+
         // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
         private readonly Dictionary<long, InternalOrder> _orders = new();
         private readonly Dictionary<long, InternalOrder> _completedOrders = new();
@@ -500,7 +506,8 @@ namespace Circus.OrderBook
             return null;
         }
 
-        private void Match(List<OrderBookEvent> events, long? auctionPriceTicks = null)
+        // algorithm defaults to continuous trading; the opening print passes an Auction instead.
+        private void Match(List<OrderBookEvent> events, IMatchingAlgorithm? algorithm = null)
         {
             if (_status != OrderBookStatus.Open)
             {
@@ -509,11 +516,8 @@ namespace Circus.OrderBook
 
             var time = Now();
             var pendingImmediateOrCancelStops = new List<InternalOrder>();
-            IMatchingAlgorithm algorithm = auctionPriceTicks.HasValue
-                ? new Uncross(auctionPriceTicks.Value)
-                : ContinuousMatch.Instance;
 
-            foreach (var outcome in _matcher.Run(algorithm, CheckTradeRestrictionBreach))
+            foreach (var outcome in _matcher.Run(algorithm ?? _continuous, _continuous, CheckTradeRestrictionBreach))
                 Apply(outcome, events, time, pendingImmediateOrCancelStops);
 
             // Deferred until the whole sweep is done, not checked right after each stop's own
@@ -706,7 +710,7 @@ namespace Circus.OrderBook
             // Runs whether the prior status was the real start-of-day PreOpen or PreOpen
             // re-entered mid-session for a volatility pause - same uncrossing either way.
             if (_matcher.TryComputeAuctionPrice(_auctionReferencePriceTicks, out var auctionPriceTicks, out _))
-                Match(events, auctionPriceTicks);
+                Match(events, new Auction(auctionPriceTicks));
 
             Match(events);
             return events;

--- a/Circus/OrderBook/MatchOutcome.cs
+++ b/Circus/OrderBook/MatchOutcome.cs
@@ -9,13 +9,10 @@ namespace Circus.OrderBook
     internal sealed record SelfMatchDetected(InternalOrder Resting, InternalOrder Aggressor,
         SelfMatchPreventionInstruction Instruction) : MatchOutcome;
 
-    // IsAuctionAllocation is true only for a trade priced and sized during an auction print
-    // (as opposed to one after a stop has switched the rest of that print to continuous pricing) -
-    // it tells Apply to size the fill against the order's full remaining quantity instead of its
-    // displayed peak, since the print is one atomic allocation, not a sequence of continuous
-    // touches an iceberg needs to ration its displayed size across.
+    // UsesFullRemainingQuantity mirrors the IMatchingAlgorithm that decided this trade (see
+    // IMatchingAlgorithm.cs) - it tells Apply which InternalOrder fill method to use.
     internal sealed record TradeExecuted(InternalOrder Resting, InternalOrder Aggressor, long PriceTicks,
-        int Quantity, bool IsAuctionAllocation) : MatchOutcome;
+        int Quantity, bool UsesFullRemainingQuantity) : MatchOutcome;
 
     // Terminal for the Run this came from - Matcher stops yielding after this, matching Match()'s
     // previous early-return on a trade-restriction breach.

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -33,10 +33,12 @@ namespace Circus.OrderBook
 
         // Decides, one step at a time, what Match should do next against the current book state -
         // self-match cancellations, trades, trade-restriction breaches, and stop triggers -
-        // without mutating anything or emitting events. algorithm supplies the pricing/sizing
-        // policy (see IMatchingAlgorithm.cs); everything else here - the crossing condition,
-        // self-match detection, stop-triggering - is identical regardless of which algorithm is
-        // active. afterStopTrigger is the algorithm the remainder of this run switches to once a
+        // without mutating anything or emitting events. algorithm picks the counterparty for each
+        // trade and prices it (see IMatchingAlgorithm.cs); everything else here - the crossing
+        // condition, which side is the aggressor, self-match detection, stop-triggering - is
+        // identical regardless of which algorithm is active and stays here rather than being
+        // reimplemented per algorithm.
+        // afterStopTrigger is the algorithm the remainder of this run switches to once a
         // stop fires (see below) - the security's continuous algorithm, which for a run that was
         // already continuous is simply the same instance again; it is taken as already prepared,
         // never TryBegin'd mid-run.
@@ -63,9 +65,20 @@ namespace Circus.OrderBook
 
             while (buy != null && sell != null && buy.Price >= sell.Price)
             {
-                var resting = buy.ModifiedTime < sell.ModifiedTime ? buy : sell;
-                var aggressor = buy == resting ? sell : buy;
+                // Which side is passive is the loop's call, not the algorithm's - the older of the
+                // two orders at the touch is resting by definition, whatever the algorithm then
+                // does with its level.
+                var restingHead = buy.ModifiedTime < sell.ModifiedTime ? buy : sell;
+                var aggressor = buy == restingHead ? sell : buy;
 
+                var selection = algorithm.SelectNext(restingHead, aggressor);
+                if (selection == null)
+                    yield break;
+
+                var (resting, quantity, priceTicks) = selection.Value;
+
+                // Checked against the order the algorithm actually picked, which for anything
+                // other than price-time need not be the head it was offered.
                 if (IsSelfMatch(resting, aggressor, out var instruction))
                 {
                     yield return new SelfMatchDetected(resting, aggressor, instruction);
@@ -73,9 +86,6 @@ namespace Circus.OrderBook
                     sell = BestOrder(Side.Sell);
                     continue;
                 }
-
-                var priceTicks = algorithm.PriceTicks(resting);
-                var quantity = algorithm.Quantity(resting, aggressor);
 
                 if (algorithm.ChecksTradeRestrictions)
                 {

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -33,21 +33,19 @@ namespace Circus.OrderBook
 
         // Decides, one step at a time, what Match should do next against the current book state -
         // self-match cancellations, trades, trade-restriction breaches, and stop triggers -
-        // without mutating anything or emitting events. checkTradeRestrictionBreach is a pure
-        // query (not consulted during an auction uncrossing pass, same as before) returning the
-        // breach action of the first Trade-scoped restriction that disallows the prospective trade
-        // price, if any. Re-reads the book fresh on every iteration, so the caller must fully
-        // apply each yielded outcome - including any ladder mutation - before asking for the next
-        // one; a converted stop landing in Working is exactly what lets this same loop pick it up
-        // and keep matching, with no separate recursive pass needed.
-        public IEnumerable<MatchOutcome> Run(long? auctionPriceTicks,
+        // without mutating anything or emitting events. algorithm supplies the pricing/sizing
+        // policy (see IMatchingAlgorithm.cs); everything else here - the crossing condition,
+        // self-match detection, stop-triggering - is identical regardless of which algorithm is
+        // active. checkTradeRestrictionBreach is a pure query (consulted only when
+        // algorithm.ChecksTradeRestrictions) returning the breach action of the first Trade-scoped
+        // restriction that disallows the prospective trade price, if any. Re-reads the book fresh
+        // on every iteration, so the caller must fully apply each yielded outcome - including any
+        // ladder mutation - before asking for the next one; a converted stop landing in Working is
+        // exactly what lets this same loop pick it up and keep matching, with no separate
+        // recursive pass needed.
+        public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm,
             Func<long, RestrictionBreachAction?> checkTradeRestrictionBreach)
         {
-            // Once a stop fires mid-sweep, everything after it prices continuously - an auction
-            // print is the resolution mechanism for the book as it stood at open, not for orders
-            // that have just newly arrived because of it.
-            var effectiveAuctionPriceTicks = auctionPriceTicks;
-
             var buy = BestOrder(Side.Buy);
             var sell = BestOrder(Side.Sell);
 
@@ -69,25 +67,10 @@ namespace Circus.OrderBook
                     continue;
                 }
 
-                // An auction print allocates against each side's full remaining size, not its
-                // displayed peak - it's one atomic clearing event, not a sequence of continuous
-                // touches an iceberg needs to ration its displayed size across. Sizing off the
-                // displayed peak here (as continuous matching correctly does) is what let a
-                // later-arriving order leapfrog an iceberg mid-print, every time the iceberg's
-                // peak needed replenishing.
-                var isAuctionAllocation = effectiveAuctionPriceTicks.HasValue;
-                var quantity = isAuctionAllocation
-                    ? Math.Min(resting.RemainingQuantity, aggressor.RemainingQuantity)
-                    : Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
-                var priceTicks = effectiveAuctionPriceTicks ?? resting.Price ??
-                    throw new InvalidOperationException("limit order requires price");
+                var priceTicks = algorithm.PriceTicks(resting);
+                var quantity = algorithm.Quantity(resting, aggressor);
 
-                // Checked against the prospective trade price, not either order's own submitted
-                // limit price - a resting order sitting far from the market doesn't represent any
-                // actual price movement, only an executed trade at an extreme price does. Doesn't
-                // apply to an auction uncrossing pass itself (auctionPriceTicks set) - the auction
-                // print is already the resolution mechanism, not something to interrupt.
-                if (!isAuctionAllocation)
+                if (algorithm.ChecksTradeRestrictions)
                 {
                     var breachAction = checkTradeRestrictionBreach(priceTicks);
                     if (breachAction.HasValue)
@@ -97,13 +80,18 @@ namespace Circus.OrderBook
                     }
                 }
 
-                yield return new TradeExecuted(resting, aggressor, priceTicks, quantity, isAuctionAllocation);
+                yield return new TradeExecuted(resting, aggressor, priceTicks, quantity,
+                    algorithm.UsesFullRemainingQuantity);
 
                 var triggeredStops = GatherTriggeredStops(priceTicks);
                 if (triggeredStops != null)
                 {
                     yield return new StopsTriggered(triggeredStops);
-                    effectiveAuctionPriceTicks = null;
+
+                    // Once a stop fires mid-sweep, everything after it prices continuously - an
+                    // auction print is the resolution mechanism for the book as it stood at open,
+                    // not for orders that have just newly arrived because of it.
+                    algorithm = ContinuousMatch.Instance;
                 }
 
                 buy = BestOrder(Side.Buy);

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -36,14 +36,17 @@ namespace Circus.OrderBook
         // without mutating anything or emitting events. algorithm supplies the pricing/sizing
         // policy (see IMatchingAlgorithm.cs); everything else here - the crossing condition,
         // self-match detection, stop-triggering - is identical regardless of which algorithm is
-        // active. checkTradeRestrictionBreach is a pure query (consulted only when
+        // active. afterStopTrigger is the algorithm the remainder of this run switches to once a
+        // stop fires (see below) - the security's continuous algorithm, which for a run that was
+        // already continuous is simply the same instance again.
+        // checkTradeRestrictionBreach is a pure query (consulted only when
         // algorithm.ChecksTradeRestrictions) returning the breach action of the first Trade-scoped
         // restriction that disallows the prospective trade price, if any. Re-reads the book fresh
         // on every iteration, so the caller must fully apply each yielded outcome - including any
         // ladder mutation - before asking for the next one; a converted stop landing in Working is
         // exactly what lets this same loop pick it up and keep matching, with no separate
         // recursive pass needed.
-        public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm,
+        public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm, IMatchingAlgorithm afterStopTrigger,
             Func<long, RestrictionBreachAction?> checkTradeRestrictionBreach)
         {
             var buy = BestOrder(Side.Buy);
@@ -91,7 +94,7 @@ namespace Circus.OrderBook
                     // Once a stop fires mid-sweep, everything after it prices continuously - an
                     // auction print is the resolution mechanism for the book as it stood at open,
                     // not for orders that have just newly arrived because of it.
-                    algorithm = ContinuousMatch.Instance;
+                    algorithm = afterStopTrigger;
                 }
 
                 buy = BestOrder(Side.Buy);

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -38,7 +38,8 @@ namespace Circus.OrderBook
         // self-match detection, stop-triggering - is identical regardless of which algorithm is
         // active. afterStopTrigger is the algorithm the remainder of this run switches to once a
         // stop fires (see below) - the security's continuous algorithm, which for a run that was
-        // already continuous is simply the same instance again.
+        // already continuous is simply the same instance again; it is taken as already prepared,
+        // never TryBegin'd mid-run.
         // checkTradeRestrictionBreach is a pure query (consulted only when
         // algorithm.ChecksTradeRestrictions) returning the breach action of the first Trade-scoped
         // restriction that disallows the prospective trade price, if any. Re-reads the book fresh
@@ -49,6 +50,9 @@ namespace Circus.OrderBook
         public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm, IMatchingAlgorithm afterStopTrigger,
             Func<long, RestrictionBreachAction?> checkTradeRestrictionBreach)
         {
+            if (!algorithm.TryBegin(_working))
+                yield break;
+
             var buy = BestOrder(Side.Buy);
             var sell = BestOrder(Side.Sell);
 
@@ -134,79 +138,6 @@ namespace Circus.OrderBook
             }
 
             return triggered?.Values.ToList();
-        }
-
-        private static int SumRemaining(InternalOrder? first)
-        {
-            var total = 0;
-            for (var order = first; order != null; order = order.LevelNext)
-                total += order.RemainingQuantity;
-            return total;
-        }
-
-        // The call-auction uncrossing price: the price that maximizes executable volume across
-        // the resting book, i.e. min(cumulative bid quantity at/above p, cumulative ask quantity
-        // at/below p). Ties break by (1) minimum surplus - CME's rule, (2) closest to
-        // auctionReferencePriceTicks, since neither venue's public docs cover a case this granular,
-        // (3) CME's final rule: highest price if the surplus is on the buy side, lowest if on the
-        // sell side. Stops are deliberately not folded into this search (unlike CME's iterative
-        // stop-election loop) - they're picked up afterward by Run's own stop-triggering check,
-        // same as any other trade.
-        public bool TryComputeAuctionPrice(long? auctionReferencePriceTicks, out long priceTicks, out int quantity)
-        {
-            priceTicks = 0;
-            quantity = 0;
-
-            var buyLevels = _working[Side.Buy].EnumerateFromBest()
-                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
-            var sellLevels = _working[Side.Sell].EnumerateFromBest()
-                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
-
-            if (buyLevels.Count == 0 || sellLevels.Count == 0 || buyLevels[0].Tick < sellLevels[0].Tick)
-                return false;
-
-            var candidates = buyLevels.Select(l => l.Tick).Concat(sellLevels.Select(l => l.Tick)).Distinct();
-
-            (long Price, int Executable, long Surplus)? best = null;
-            foreach (var p in candidates)
-            {
-                var cumBid = buyLevels.Where(l => l.Tick >= p).Sum(l => l.Qty);
-                var cumAsk = sellLevels.Where(l => l.Tick <= p).Sum(l => l.Qty);
-                var executable = Math.Min(cumBid, cumAsk);
-                var surplus = cumBid - cumAsk;
-
-                if (best == null || executable > best.Value.Executable ||
-                    (executable == best.Value.Executable &&
-                     IsBetterAuctionPriceTieBreak(p, surplus, best.Value.Price, best.Value.Surplus,
-                         auctionReferencePriceTicks)))
-                {
-                    best = (p, executable, surplus);
-                }
-            }
-
-            priceTicks = best!.Value.Price;
-            quantity = best.Value.Executable;
-            return quantity > 0;
-        }
-
-        private static bool IsBetterAuctionPriceTieBreak(long candidatePrice, long candidateSurplus,
-            long currentPrice, long currentSurplus, long? auctionReferencePriceTicks)
-        {
-            var candidateAbsSurplus = Math.Abs(candidateSurplus);
-            var currentAbsSurplus = Math.Abs(currentSurplus);
-            if (candidateAbsSurplus != currentAbsSurplus)
-                return candidateAbsSurplus < currentAbsSurplus;
-
-            if (auctionReferencePriceTicks.HasValue)
-            {
-                var candidateDistance = Math.Abs(candidatePrice - auctionReferencePriceTicks.Value);
-                var currentDistance = Math.Abs(currentPrice - auctionReferencePriceTicks.Value);
-                if (candidateDistance != currentDistance)
-                    return candidateDistance < currentDistance;
-            }
-
-            // surplus on the buy side (positive) -> prefer the higher price; sell side -> lower
-            return candidateSurplus > 0 ? candidatePrice > currentPrice : candidatePrice < currentPrice;
         }
 
         // selfMatchPreventionId/selfMatchPreventionInstruction are the incoming order's own

--- a/Circus/OrderBook/PriceTime.cs
+++ b/Circus/OrderBook/PriceTime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Circus.OrderBook
 {
@@ -9,6 +10,10 @@ namespace Circus.OrderBook
     // priority) once that peak is exhausted.
     internal sealed class PriceTime : IMatchingAlgorithm
     {
+        // Nothing to derive up front - each trade is priced and sized from the two orders at the
+        // touch - and whether anything crosses is the matching loop's own question to answer.
+        public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => true;
+
         public long PriceTicks(InternalOrder resting) =>
             resting.Price ?? throw new InvalidOperationException("limit order requires price");
 

--- a/Circus/OrderBook/PriceTime.cs
+++ b/Circus/OrderBook/PriceTime.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Circus.OrderBook
+{
+    // Continuous trading. Each trade prints at the resting order's own limit price - the
+    // earlier-arrived side sets the price, so an aggressor whose limit was better than the touch
+    // gets the improvement - and is sized off both sides' displayed quantity, since an iceberg
+    // only ever shows one peak's worth to the book at a time and replenishes (losing queue
+    // priority) once that peak is exhausted.
+    internal sealed class PriceTime : IMatchingAlgorithm
+    {
+        public long PriceTicks(InternalOrder resting) =>
+            resting.Price ?? throw new InvalidOperationException("limit order requires price");
+
+        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
+            Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
+
+        public bool UsesFullRemainingQuantity => false;
+
+        public bool ChecksTradeRestrictions => true;
+    }
+}

--- a/Circus/OrderBook/PriceTime.cs
+++ b/Circus/OrderBook/PriceTime.cs
@@ -3,22 +3,23 @@ using System.Collections.Generic;
 
 namespace Circus.OrderBook
 {
-    // Continuous trading. Each trade prints at the resting order's own limit price - the
-    // earlier-arrived side sets the price, so an aggressor whose limit was better than the touch
-    // gets the improvement - and is sized off both sides' displayed quantity, since an iceberg
-    // only ever shows one peak's worth to the book at a time and replenishes (losing queue
-    // priority) once that peak is exhausted.
+    // Continuous trading under price-time priority. The aggressor trades against the FIFO-earliest
+    // order at the best crossing level - taking the head, and only moving on once it is consumed,
+    // is the time-priority rule - at that order's own limit price, so an aggressor whose limit was
+    // better than the touch gets the improvement.
+    //
+    // Sized off both sides' displayed quantity: an iceberg shows the book one peak's worth at a
+    // time and replenishes (losing queue priority) once that peak is exhausted.
     internal sealed class PriceTime : IMatchingAlgorithm
     {
         // Nothing to derive up front - each trade is priced and sized from the two orders at the
         // touch - and whether anything crosses is the matching loop's own question to answer.
         public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => true;
 
-        public long PriceTicks(InternalOrder resting) =>
-            resting.Price ?? throw new InvalidOperationException("limit order requires price");
-
-        public int Quantity(InternalOrder resting, InternalOrder aggressor) =>
-            Math.Min(resting.DisplayedQuantity, aggressor.DisplayedQuantity);
+        public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
+            new Allocation(restingHead,
+                Math.Min(restingHead.DisplayedQuantity, aggressor.DisplayedQuantity),
+                restingHead.Price ?? throw new InvalidOperationException("limit order requires price"));
 
         public bool UsesFullRemainingQuantity => false;
 


### PR DESCRIPTION
## Summary

Turns matching policy into a real extension point. Builds on #38; three commits, each behaviour-preserving.

**1. Split pricing/sizing policy out of `Matcher.Run`.** Instead of a raw `auctionPriceTicks` parameter the loop branched on inline, the policy becomes `IMatchingAlgorithm`.

**2. Give each algorithm its own file; drop the shared singleton.** `PriceTime` and `Auction`, in `PriceTime.cs` and `Auction.cs`, with `IMatchingAlgorithm.cs` holding just the interface. Algorithms are ordinary instances rather than statics, so a security can eventually carry its own set differing by phase. `InMemoryOrderBook` holds them as fields; `Match` takes an `IMatchingAlgorithm` rather than a price. `Matcher.Run` gains `afterStopTrigger` for the algorithm the rest of a run switches to when a stop fires mid-print — which is where the static was being read from.

**3. Move auction pricing, and counterparty selection, into the algorithms.**
- `TryComputeAuctionPrice`, its tie-break and `SumRemaining` move off `Matcher` onto `Auction` as `TryComputeClearingPrice`. The reference anchor moves with them — it was documented as feeding the auction tie-break and nothing else — so `Auction` owns it behind `OnTrade`/`OnSessionChange`, mirroring how each `IPriceRestriction` owns its anchor. `InMemoryOrderBook` drops `_auctionReferencePriceTicks`.
- `TryBegin` lets an algorithm derive run-scoped state from the book: `Auction` strikes its clearing price there, fixed for the print rather than re-derived per trade from a book those trades are consuming. Returning false means nothing to match, so an uncrossing pass over an uncrossed book is a no-op the caller no longer guards.
- **`SelectNext` replaces `PriceTicks`/`Quantity`.** Choosing the counterparty is the decision that actually separates matching algorithms, and the loop was making it: `BestOrder` took the head of the best level and only moved on once it was consumed, which *is* price-time priority. So price-time lived in the loop and `PriceTime` the class held none of it, and pro-rata — or anything reallocating within a level — was inexpressible, because the algorithm had no way to say "this order has had its share, move on". `Run` now offers the level head and the aggressor; the algorithm returns whichever order at that level trades next, for how much, at what price. `PriceLadder` already unlinks from any position, so out-of-FIFO allocation is safe. Self-match prevention now runs against the order the algorithm picked rather than the head it was offered.

`Matcher` keeps what is genuinely common across algorithms: the crossing condition, which side is the aggressor, self-match prevention, stop-triggering, and the outcome stream.

## Test plan

- [x] Both algorithms return the level head with the same price and quantity the loop previously computed, so every existing path is unchanged — traced each branch of the old `auctionPriceTicks` logic and of the old `PriceTicks`/`Quantity` pair against the new shape.
- [x] Hand-traced the auction + stop-interrupt path, the one place `algorithm` is swapped mid-run.
- [x] New `MatcherTests` — first coverage driving `Matcher` directly, which is the only way to run it against an algorithm the book doesn't construct. Proves a non-head selection is honoured (the thing that was impossible before), that `PriceTime` still takes the head, and that declining to begin or to select yields nothing rather than spinning on a crossed book.
- [ ] CI (`dotnet build` + `dotnet test`) — no local .NET SDK in this sandbox, so CI is the gate for the full suite, including the iceberg/auction tests from #38.

## Notes

- `OnTrade`/`OnSessionChange` sit on `Auction`, not on the interface: only the auction needs them and the book holds it concretely typed, so putting them up would force `PriceTime` into stubs nobody calls polymorphically. `TryBegin` and `SelectNext` are on the interface because `Run` genuinely calls them that way.
- A *stateful* algorithm (pro-rata caching per-level shares) could see its state go stale if a selection is cancelled by self-match prevention instead of trading. Neither algorithm here is stateful, so nothing is affected today; the interface documents keying cached shares on the level's price tick for whoever implements one.
- No `ProRata` is shipped — that's a feature with its own remainder-distribution decisions, not part of this refactor.