### PR TITLE
Give Matcher the verbs for its own ladders

### DIFF
--- a/Circus.Tests/OrderBook/MatcherTests.cs
+++ b/Circus.Tests/OrderBook/MatcherTests.cs
@@ -42,10 +42,10 @@ namespace Circus.Tests.OrderBook
             second = Order(2, Side.Buy, 30, Early);
             third = Order(3, Side.Buy, 10, Early);
 
-            matcher.Working[Side.Buy].Add(Tick, first);
-            matcher.Working[Side.Buy].Add(Tick, second);
-            matcher.Working[Side.Buy].Add(Tick, third);
-            matcher.Working[Side.Sell].Add(Tick, Order(4, Side.Sell, aggressorQuantity, Late));
+            matcher.Rest(first);
+            matcher.Rest(second);
+            matcher.Rest(third);
+            matcher.Rest(Order(4, Side.Sell, aggressorQuantity, Late));
 
             return matcher;
         }
@@ -117,7 +117,7 @@ namespace Circus.Tests.OrderBook
 
         private sealed class SelectsBehindTheHead : IMatchingAlgorithm
         {
-            public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => true;
+            public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
 
             public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor)
             {
@@ -132,7 +132,7 @@ namespace Circus.Tests.OrderBook
 
         private sealed class DeclinesToMatch : IMatchingAlgorithm
         {
-            public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => true;
+            public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
             public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) => null;
             public bool UsesFullRemainingQuantity => false;
             public bool ChecksTradeRestrictions => false;
@@ -140,7 +140,7 @@ namespace Circus.Tests.OrderBook
 
         private sealed class DeclinesToBegin : IMatchingAlgorithm
         {
-            public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => false;
+            public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => false;
             public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
                 throw new InvalidOperationException("must not be consulted once TryBegin declines");
             public bool UsesFullRemainingQuantity => false;

--- a/Circus/OrderBook/Auction.cs
+++ b/Circus/OrderBook/Auction.cs
@@ -31,7 +31,7 @@ namespace Circus.OrderBook
 
         // False when the book isn't crossed, which is what makes an uncrossing pass over an
         // uncrossed book a no-op rather than something the caller has to check for first.
-        public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) =>
+        public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) =>
             TryComputeClearingPrice(working, out _clearingPriceTicks, out _);
 
         // Time priority at the clearing price: the FIFO-earliest order at the level fills first,
@@ -59,8 +59,8 @@ namespace Circus.OrderBook
         //
         // Public and side-effect-free so the book can also publish it as a live indicative price
         // during pre-open, without committing to a print.
-        public bool TryComputeClearingPrice(IReadOnlyDictionary<Side, PriceLadder> working, out long priceTicks,
-            out int quantity)
+        public bool TryComputeClearingPrice(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+            out long priceTicks, out int quantity)
         {
             priceTicks = 0;
             quantity = 0;

--- a/Circus/OrderBook/IMatchingAlgorithm.cs
+++ b/Circus/OrderBook/IMatchingAlgorithm.cs
@@ -19,7 +19,7 @@ namespace Circus.OrderBook
         // Prepare for a run against the current working book, deriving whatever run-scoped state
         // this algorithm needs from it - an auction strikes its clearing price here. False means
         // there is nothing for this algorithm to match, so the run yields no outcomes at all.
-        bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working);
+        bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working);
 
         // Picks the counterparty for the next trade. This is the decision that actually separates
         // one matching algorithm from another - price-time takes the head of the level, pro-rata

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -183,9 +183,7 @@ namespace Circus.OrderBook
 
             _orders.Add(order.InternalId, order);
             _clientOrderIndex.Add((companyId, clientOrderId), order);
-            var orders = (triggerTicks.HasValue ? _matcher.Stops : _matcher.Working);
-            var newPriceTicks = (triggerTicks ?? priceTicks) ?? throw new Exception("error");
-            orders[side].Add(newPriceTicks, order);
+            _matcher.Rest(order);
 
             List<OrderBookEvent> events = new();
             events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
@@ -347,19 +345,17 @@ namespace Circus.OrderBook
             var isQuantityIncrease = order.MaxVisibleQuantity == null &&
                 (newTotalQuantity != null && newTotalQuantity > order.Quantity);
 
-            var orders = (order.Status == OrderStatus.Hidden ? _matcher.Stops : _matcher.Working);
-
             if (isPriceChange || isQuantityIncrease)
             {
                 _nextSequenceNumber++;
                 sequenceNumber = _nextSequenceNumber;
-                var currentPriceTicks = (order.Status == OrderStatus.Hidden ? order.TriggerPrice : order.Price) ??
-                                   throw new InvalidOperationException("missing price");
                 var updatedPriceTicks =
                     (order.Status == OrderStatus.Hidden ? triggerTicks ?? order.TriggerPrice : priceTicks ?? order.Price) ??
                     throw new InvalidOperationException("missing price");
-                orders[order.Side].Remove(currentPriceTicks, order);
-                orders[order.Side].Add(updatedPriceTicks, order);
+
+                // Called before order.Update() below, so the order still carries the price it
+                // currently rests at - which is what Reprice moves it off.
+                _matcher.Reprice(order, updatedPriceTicks);
             }
 
             // captured before Update() below, which - since sequenceNumber may have just been
@@ -447,17 +443,7 @@ namespace Circus.OrderBook
 
         private void CompleteOrder(InternalOrder order)
         {
-            if (order.Type == OrderType.StopLimit || order.Type == OrderType.StopMarket)
-            {
-                var price = order.TriggerPrice ?? throw new InvalidOperationException("stop order missing stop price");
-                _matcher.Stops[order.Side].Remove(price, order);
-            }
-            else
-            {
-                var price = order.Price ?? throw new InvalidOperationException("limit order missing price");
-                _matcher.Working[order.Side].Remove(price, order);
-            }
-
+            _matcher.Unrest(order);
             FinishOrder(order);
         }
 
@@ -483,16 +469,16 @@ namespace Circus.OrderBook
             if (order.DisplayedQuantity == 0 && order.MaxVisibleQuantity.HasValue)
             {
                 // iceberg peak exhausted with hidden reserve remaining - replenish and requeue to
-                // the back of this price level (PriceLadder.Add always appends to the tail),
+                // the back of this price level (resting always appends to the tail of it),
                 // losing time priority and getting a fresh ExchangeOrderId - matches both CME and
                 // Eurex, and lets a full-order-book feed show the old id leaving the book and a
                 // new one arriving, rather than an in-place modify.
                 var previousExchangeOrderId = order.ExchangeOrderId;
                 var priceTicks = order.Price ?? throw new InvalidOperationException("limit order missing price");
-                _matcher.Working[order.Side].Remove(priceTicks, order);
+                _matcher.Unrest(order);
                 _nextSequenceNumber++;
                 order.Replenish(_nextSequenceNumber, time);
-                _matcher.Working[order.Side].Add(priceTicks, order);
+                _matcher.Rest(order);
 
                 return new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
                     order.ClientOrderId, previousExchangeOrderId, ToDecimal(priceTicks), 0);
@@ -616,9 +602,9 @@ namespace Circus.OrderBook
         {
             foreach (var order in orders)
             {
-                var triggerPriceTicks = order.TriggerPrice ??
-                    throw new InvalidOperationException("stop order missing stop price");
-                _matcher.Stops[order.Side].Remove(triggerPriceTicks, order);
+                // Lifted out of the stops ladder while it is still typed as a stop; whether it
+                // then converts into the working book or is cancelled outright is decided below.
+                _matcher.Unrest(order);
 
                 if (order.Validity is OrderValidity.ImmediateOrCancel)
                     pendingImmediateOrCancelStops.Add(order);
@@ -633,8 +619,9 @@ namespace Circus.OrderBook
                     order.Cancel(Now());
                     FinishOrder(order);
 
-                    // still Hidden here (never converted to a working limit order), so there's
-                    // no working-book level to remove it from.
+                    // FinishOrder, not CompleteOrder: it left the stops ladder above and never
+                    // reached the working book, so there is nothing left to unrest it from.
+                    // previousPrice null for the same reason - it was never at a working level.
                     events.Add(new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(),
                         previousClientOrderId, OrderCancelledReason.NoOrdersToMatchMarketOrder, null,
                         previousQuantity));
@@ -660,8 +647,8 @@ namespace Circus.OrderBook
                 _nextSequenceNumber++;
                 order.ConvertToLimit(time, _nextSequenceNumber, newPriceTicks);
 
-                var limitPriceTicks = order.Price ?? throw new Exception("missing price");
-                _matcher.Working[order.Side].Add(limitPriceTicks, order);
+                // Now typed as a limit order, so this rests it in the working book.
+                _matcher.Rest(order);
 
                 // previousPrice null - the order was resting in the stops ladder, not the
                 // working book, so this is an arrival, not a move between working-book levels.

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -4,11 +4,17 @@ using System.Linq;
 
 namespace Circus.OrderBook
 {
-    // Owns the resting-order state (working + stop ladders), decides what should happen against
-    // that state via Run, and hosts the pure, state-reading decision helpers Run and
-    // InMemoryOrderBook both need. Run only ever decides - it never mutates state or emits
-    // events; InMemoryOrderBook.Apply does that, order by order, between calls into Run's
-    // enumerator, so Run always resumes against state Apply has already caught up to.
+    // Owns the resting-order state - the working and stop ladders - outright: Rest, Unrest and
+    // Reprice are the only ways an order enters, leaves or moves within them, and the ladders
+    // themselves never leave this class in a form anything else could write to. Callers name the
+    // order they want moved and this works out which ladder holds it and at what price, so the
+    // rule that an untriggered stop rests at its trigger price lives in one place.
+    //
+    // Also decides what should happen against that state via Run, and hosts the pure,
+    // state-reading decision helpers Run and InMemoryOrderBook both need. Run only ever decides -
+    // it never mutates state or emits events; InMemoryOrderBook.Apply does that, order by order,
+    // between calls into Run's enumerator, so Run always resumes against state Apply has already
+    // caught up to.
     internal sealed class Matcher
     {
         // Array-backed, indexed by tick count (price / Security.TickSize) rather than decimal —
@@ -25,8 +31,46 @@ namespace Circus.OrderBook
             {Side.Sell, new PriceLadder(descending: true)}
         };
 
-        public IReadOnlyDictionary<Side, PriceLadder> Working => _working;
-        public IReadOnlyDictionary<Side, PriceLadder> Stops => _stops;
+        // Projected once, so what leaves this class can be read but not written. The stop ladders
+        // are not projected at all - nothing outside has any business reading them, and everything
+        // that used to reach in to move a stop now goes through Rest/Unrest below.
+        private readonly IReadOnlyDictionary<Side, IReadOnlyPriceLadder> _workingView;
+
+        public Matcher()
+        {
+            _workingView = _working.ToDictionary(x => x.Key, x => (IReadOnlyPriceLadder) x.Value);
+        }
+
+        public IReadOnlyDictionary<Side, IReadOnlyPriceLadder> Working => _workingView;
+
+        // Which ladder an order rests in, and the price that ladder keys it by, both follow from
+        // its type: an untriggered stop sits in the stops ladder at its trigger price, everything
+        // else in the working book at its limit price. Type rather than Status is the discriminator
+        // because these are routinely called after Cancel/Expire/Fill has already overwritten
+        // Status - and ConvertToLimit moves an elected stop to Limit, so the two never disagree.
+        private static bool RestsInStops(InternalOrder order) =>
+            order.Type is OrderType.StopLimit or OrderType.StopMarket;
+
+        private PriceLadder LadderFor(InternalOrder order) =>
+            RestsInStops(order) ? _stops[order.Side] : _working[order.Side];
+
+        private static long RestingPriceOf(InternalOrder order) =>
+            (RestsInStops(order) ? order.TriggerPrice : order.Price) ??
+            throw new InvalidOperationException($"{order.Type} order missing the price it rests at");
+
+        public void Rest(InternalOrder order) => LadderFor(order).Add(RestingPriceOf(order), order);
+
+        public void Unrest(InternalOrder order) => LadderFor(order).Remove(RestingPriceOf(order), order);
+
+        // Moves an order to a new price within whichever ladder holds it, landing at the back of
+        // the new level. Passing the price it already rests at requeues it in place, which is what
+        // a quantity increase needs - losing time priority is the point, not a side effect.
+        public void Reprice(InternalOrder order, long newPriceTicks)
+        {
+            var ladder = LadderFor(order);
+            ladder.Remove(RestingPriceOf(order), order);
+            ladder.Add(newPriceTicks, order);
+        }
 
         private InternalOrder? BestOrder(Side side) =>
             _working[side].TryGetBest(out _, out var order) ? order : null;
@@ -52,7 +96,7 @@ namespace Circus.OrderBook
         public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm, IMatchingAlgorithm afterStopTrigger,
             Func<long, RestrictionBreachAction?> checkTradeRestrictionBreach)
         {
-            if (!algorithm.TryBegin(_working))
+            if (!algorithm.TryBegin(_workingView))
                 yield break;
 
             var buy = BestOrder(Side.Buy);

--- a/Circus/OrderBook/PriceLadder.cs
+++ b/Circus/OrderBook/PriceLadder.cs
@@ -3,6 +3,17 @@ using System.Collections.Generic;
 
 namespace Circus.OrderBook
 {
+    // The reading half of PriceLadder, which is all anything outside Matcher is ever handed: market
+    // data, the market-order protection price, and an auction's clearing-price search all only look.
+    // Resting, removing and repricing go through Matcher's own verbs, so the ladders it owns cannot
+    // be written from outside it.
+    internal interface IReadOnlyPriceLadder
+    {
+        bool TryGetBest(out long tick, out InternalOrder? firstOrder);
+
+        IEnumerable<(long Tick, InternalOrder First, int Count)> EnumerateFromBest();
+    }
+
     // Dense, array-backed replacement for SortedDictionary<long, SortedDictionary<long, InternalOrder>>
     // keyed by price tick: the tick is used directly as an array offset (tick - _minTick) for O(1)
     // level access instead of an O(log n) tree lookup, with a cached best-price index so callers
@@ -18,7 +29,7 @@ namespace Circus.OrderBook
     //
     // It grows on demand (like List<T>'s doubling) if an order arrives outside the currently
     // allocated range, so it stays correct with no pre-sizing at all.
-    internal sealed class PriceLadder(bool descending)
+    internal sealed class PriceLadder(bool descending) : IReadOnlyPriceLadder
     {
         private const int InitialRadius = 64;
 
@@ -76,22 +87,6 @@ namespace Circus.OrderBook
             _counts[index]--;
 
             if (_heads[index] == null && index == _bestIndex)
-            {
-                AdvanceBest();
-            }
-        }
-
-        // Removes every order resting at `tick` in one go (used when a stop price level triggers).
-        public void RemoveLevel(long tick)
-        {
-            var index = (int) (tick - _minTick);
-            if (_heads[index] == null)
-                return;
-
-            _heads[index] = null;
-            _tails[index] = null;
-            _counts[index] = 0;
-            if (index == _bestIndex)
             {
                 AdvanceBest();
             }

--- a/Circus/OrderBook/PriceTime.cs
+++ b/Circus/OrderBook/PriceTime.cs
@@ -14,7 +14,7 @@ namespace Circus.OrderBook
     {
         // Nothing to derive up front - each trade is priced and sized from the two orders at the
         // touch - and whether anything crosses is the matching loop's own question to answer.
-        public bool TryBegin(IReadOnlyDictionary<Side, PriceLadder> working) => true;
+        public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
 
         public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
             new Allocation(restingHead,


### PR DESCRIPTION
## Summary

`Matcher` declared ownership of the four `PriceLadder`s and never wrote to a single one. Every write in the system was made from `InMemoryOrderBook`, reaching through an `IReadOnlyDictionary` that stops a caller swapping the dictionary but does nothing to stop it calling `Add` or `Remove` on the ladders inside it. This was a deliberate deferral when the seam was first stood up, on the grounds that the apply loop would need to own writes anyway — that loop now exists, so the reason has expired.

**Adds `Rest`, `Unrest` and `Reprice`**, and routes all nine write sites through them. Callers now name the order they want moved rather than picking a ladder and computing a price key: which ladder holds an order, and which of its two prices that ladder keys it by, both follow from its type. That rule was restated in four methods and now lives in one place, so the book no longer needs to know that stops and working orders are stored apart. `CompleteOrder` collapses from a twelve-line type-discriminating branch to two lines; `CreateOrder`'s three lines become one.

**Exposure narrows to match**, which is what makes the ownership real rather than nominal:
- New `IReadOnlyPriceLadder` — `TryGetBest` and `EnumerateFromBest` only. The working ladders are projected through it once, for the three genuine readers: market data, market-order protection pricing, and the auction's clearing-price search.
- **`Stops` is gone.** Once the writes moved, every remaining use of it was a write — nothing outside `Matcher` reads the stop ladders at all.
- **`RemoveLevel` deleted** — unused since #37 stopped clearing whole stop levels during election.

## Test plan

- [x] Behaviour-preserving by inspection at all nine sites. Two discriminator changes needed checking and both hold:
  - `CompleteOrder` discriminated on `Type` but `UpdateOrder` on `Status`; unified on `Type`. Safe because `Status == Hidden` exactly when `Type` is a stop and `ConvertToLimit` moves both together — and `Status` alone would have been *wrong*, since `CompleteOrder` runs after `Cancel`/`Expire`/`Fill` has already overwritten it.
  - `CreateOrder` discriminated on `triggerTicks.HasValue`; equivalent because `TriggerPrice` is `required decimal` on both stop actions, so a stop order cannot exist without one.
- [x] Ordering preserved where it matters: `FinishFill` still unrests, replenishes, then rests, so the sequence-number bump lands between; `TriggerStops` still unrests while the order is typed as a stop and rests it after `ConvertToLimit` has retyped it.
- [x] `MatcherTests` from #39 built its books via `matcher.Working[side].Add(...)`, which no longer compiles — updated to use `Rest`. A reasonable sign the encapsulation holds.
- [ ] CI (`dotnet build` + `dotnet test`) — no local .NET SDK in this sandbox, so CI is the gate for the full suite.

## Notes

This is finding 1 from the coupling review, and the only one of the five I'd have called overdue. It does not touch `HasSufficientLiquidity`'s hardcoded traversal order, the self-trade policy's missing type, or the pre-open special case — those remain open and independent.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PqcnfvPNmBnm2xthgwgED)_