### PR TITLE
Coupling review tidy-ups: restriction dependencies and the IOC gate's assumption

### DIFF
--- a/Circus.Tests/OrderBook/DailyPriceBandLimitTests.cs
+++ b/Circus.Tests/OrderBook/DailyPriceBandLimitTests.cs
@@ -9,7 +9,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void Scope_IsTrade_OnBreach_IsPause()
         {
-            var restriction = new DailyPriceBandLimit(new Security("GCZ6", SecurityType.Future, 10, 10));
+            var restriction = new DailyPriceBandLimit(null);
 
             Assert.AreEqual(RestrictionScope.Trade, restriction.Scope);
             Assert.AreEqual(RestrictionBreachAction.Pause, restriction.OnBreach);
@@ -18,7 +18,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void NoBandConfigured_AlwaysAllows()
         {
-            var restriction = new DailyPriceBandLimit(new Security("GCZ6", SecurityType.Future, 10, 10));
+            var restriction = new DailyPriceBandLimit(null);
             restriction.OnSessionChange(100);
 
             Assert.IsTrue(restriction.Allows(1_000_000));
@@ -27,8 +27,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void BandConfigured_NoReferencePriceYet_AlwaysAllows()
         {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
-            var restriction = new DailyPriceBandLimit(security);
+            var restriction = new DailyPriceBandLimit(5);
 
             Assert.IsTrue(restriction.Allows(1_000_000));
         }
@@ -36,8 +35,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void WithinBand_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
         {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
-            var restriction = new DailyPriceBandLimit(security);
+            var restriction = new DailyPriceBandLimit(5);
             restriction.OnSessionChange(100);
 
             Assert.IsTrue(restriction.Allows(100));
@@ -48,23 +46,9 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
-        public void IndependentOfPriceBandTicks_OnlyReadsVolatilityAuctionBandTicks()
-        {
-            // PriceBandTicks configured wide, VolatilityAuctionBandTicks configured narrow -
-            // the two restrictions must not read each other's threshold.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 1000,
-                VolatilityAuctionBandTicks: 5);
-            var restriction = new DailyPriceBandLimit(security);
-            restriction.OnSessionChange(100);
-
-            Assert.IsFalse(restriction.Allows(200));
-        }
-
-        [Test]
         public void OnTrade_MovesReferenceToLastTrade()
         {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
-            var restriction = new DailyPriceBandLimit(security);
+            var restriction = new DailyPriceBandLimit(5);
             restriction.OnSessionChange(100);
 
             restriction.OnTrade(200, default);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -45,6 +45,31 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
+        public void BothBandsConfigured_EachRestrictionGetsItsOwnThreshold()
+        {
+            // arrange - the entry band wide (1000) and the volatility band narrow (5). Each
+            // restriction is handed only its own width, so the wiring in the book's constructor is
+            // now the only place these two could be crossed over. A wide entry band must not
+            // reject, and a narrow volatility band must still pause on the resulting trade.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 1000,
+                VolatilityAuctionBandTicks: 5);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+
+            // act - 200 is far outside the narrow volatility band but well inside the wide entry
+            // band, so both orders are accepted and it is the trade between them that pauses
+            var resting = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+            var crossing = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+
+            // assert
+            Assert.IsInstanceOf<CreateOrderConfirmed>(resting[0],
+                "entry band is 1000 wide - this order is nowhere near it");
+            Assert.IsInstanceOf<CreateOrderConfirmed>(crossing[0]);
+            Assert.AreEqual(OrderBookStatus.PreOpen, book.Status,
+                "the 5-tick volatility band should have paused the book on the trade");
+        }
+
+        [Test]
         public void NoReferencePriceSeeded_NoTradeYet_BandInactive_Accepted()
         {
             // arrange - band is configured, but there's no anchor to check against yet

--- a/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
@@ -9,7 +9,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void Scope_IsOrderEntry_OnBreach_IsReject()
         {
-            var restriction = new OrderPriceRestriction(new Security("GCZ6", SecurityType.Future, 10, 10));
+            var restriction = new OrderPriceRestriction(null);
 
             Assert.AreEqual(RestrictionScope.OrderEntry, restriction.Scope);
             Assert.AreEqual(RestrictionBreachAction.Reject, restriction.OnBreach);
@@ -18,7 +18,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void NoBandConfigured_AlwaysAllows()
         {
-            var restriction = new OrderPriceRestriction(new Security("GCZ6", SecurityType.Future, 10, 10));
+            var restriction = new OrderPriceRestriction(null);
             restriction.OnSessionChange(100);
 
             Assert.IsTrue(restriction.Allows(1_000_000));
@@ -27,8 +27,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void BandConfigured_NoReferencePriceYet_AlwaysAllows()
         {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var restriction = new OrderPriceRestriction(security);
+            var restriction = new OrderPriceRestriction(5);
 
             Assert.IsTrue(restriction.Allows(1_000_000));
         }
@@ -36,8 +35,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void WithinBand_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
         {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var restriction = new OrderPriceRestriction(security);
+            var restriction = new OrderPriceRestriction(5);
             restriction.OnSessionChange(100);
 
             Assert.IsTrue(restriction.Allows(100));
@@ -50,8 +48,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void OnSessionChange_Null_DoesNotClearExistingReference()
         {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var restriction = new OrderPriceRestriction(security);
+            var restriction = new OrderPriceRestriction(5);
             restriction.OnSessionChange(100);
             restriction.OnSessionChange(null);
 
@@ -62,8 +59,7 @@ namespace Circus.Tests.OrderBook
         [Test]
         public void OnTrade_MovesReferenceToLastTrade()
         {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var restriction = new OrderPriceRestriction(security);
+            var restriction = new OrderPriceRestriction(5);
             restriction.OnSessionChange(100);
 
             restriction.OnTrade(200, default);

--- a/Circus/OrderBook/DailyPriceBandLimit.cs
+++ b/Circus/OrderBook/DailyPriceBandLimit.cs
@@ -11,20 +11,21 @@ namespace Circus.OrderBook
     // future circuit breaker's larger, market-wide halt. Keeps its own anchor.
     internal sealed class DailyPriceBandLimit : IPriceRestriction
     {
-        private readonly Security _security;
+        private readonly int? _bandTicks;
         private long? _referencePriceTicks;
 
-        internal DailyPriceBandLimit(Security security)
+        // The band width only - see OrderPriceRestriction for why the Security itself stays out.
+        internal DailyPriceBandLimit(int? bandTicks)
         {
-            _security = security;
+            _bandTicks = bandTicks;
         }
 
         public RestrictionScope Scope => RestrictionScope.Trade;
         public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
 
         public bool Allows(long priceTicks) =>
-            !_security.VolatilityAuctionBandTicks.HasValue || !_referencePriceTicks.HasValue ||
-            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _security.VolatilityAuctionBandTicks.Value;
+            !_bandTicks.HasValue || !_referencePriceTicks.HasValue ||
+            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _bandTicks.Value;
 
         public void OnTrade(long priceTicks, DateTime time) => _referencePriceTicks = priceTicks;
 

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -46,8 +46,8 @@ namespace Circus.OrderBook
             _timeProvider = timeProvider;
             _priceRestrictions = new IPriceRestriction[]
             {
-                new OrderPriceRestriction(security),
-                new DailyPriceBandLimit(security)
+                new OrderPriceRestriction(security.PriceBandTicks),
+                new DailyPriceBandLimit(security.VolatilityAuctionBandTicks)
             };
         }
 

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -194,13 +194,27 @@ namespace Circus.OrderBook
             return triggered?.Values.ToList();
         }
 
-        // selfMatchPreventionId/selfMatchPreventionInstruction are the incoming order's own
-        // fields. Walks resting orders in the same price/time priority order Match() would
-        // actually consume them in: a self-matched order with CancelResting is simply skipped
-        // (the incoming order keeps going, only the resting order would die), but with
-        // CancelAggressor/CancelBoth the incoming order itself would be cancelled right there,
-        // so nothing beyond that point can ever count - liquidity checking must stop dead,
-        // not just exclude that one order's quantity and keep summing past it.
+        // Answers whether an incoming order would find at least `quantity` immediately fillable,
+        // for the IOC minimum-quantity gate. selfMatchPreventionId/selfMatchPreventionInstruction
+        // are the incoming order's own fields: a self-matched resting order with CancelResting is
+        // simply skipped (the incoming order keeps going, only the resting order would die), but
+        // with CancelAggressor/CancelBoth the incoming order itself would be cancelled right
+        // there, so nothing beyond that point can ever count - the walk must stop dead, not just
+        // exclude that one order's quantity and keep summing past it.
+        //
+        // Walks head-first within each level, which is how both algorithms shipped today allocate.
+        // That is not a free assumption now that IMatchingAlgorithm.SelectNext owns allocation
+        // order, but it is a narrow one: the *total* reachable quantity does not depend on the
+        // order orders are visited in, only the point at which the self-match stop above
+        // truncates the walk does. So this stays exact for any algorithm whose allocation reaches
+        // a prevented self-match at the same point - which includes every algorithm with no
+        // self-match interaction at all - and needs revisiting alongside one where it does not,
+        // pro-rata being the obvious candidate.
+        //
+        // Deliberately not delegated to SelectNext: the gate runs in CreateOrder before the
+        // incoming order is constructed, so there is no aggressor to offer an algorithm, and a
+        // stateful algorithm would in any case have its per-level bookkeeping polluted by a walk
+        // that never trades.
         public bool HasSufficientLiquidity(Side side, long priceTicks, int quantity, string? selfMatchPreventionId,
             SelfMatchPreventionInstruction? selfMatchPreventionInstruction)
         {

--- a/Circus/OrderBook/OrderPriceRestriction.cs
+++ b/Circus/OrderBook/OrderPriceRestriction.cs
@@ -10,20 +10,23 @@ namespace Circus.OrderBook
     // seeded from an explicit reference price pre-open.
     internal sealed class OrderPriceRestriction : IPriceRestriction
     {
-        private readonly Security _security;
+        private readonly int? _bandTicks;
         private long? _referencePriceTicks;
 
-        internal OrderPriceRestriction(Security security)
+        // Takes the band width rather than the Security it came from: nothing else about the
+        // instrument is any of this restriction's business, and a test shouldn't have to invent
+        // an instrument to configure one number.
+        internal OrderPriceRestriction(int? bandTicks)
         {
-            _security = security;
+            _bandTicks = bandTicks;
         }
 
         public RestrictionScope Scope => RestrictionScope.OrderEntry;
         public RestrictionBreachAction OnBreach => RestrictionBreachAction.Reject;
 
         public bool Allows(long priceTicks) =>
-            !_security.PriceBandTicks.HasValue || !_referencePriceTicks.HasValue ||
-            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _security.PriceBandTicks.Value;
+            !_bandTicks.HasValue || !_referencePriceTicks.HasValue ||
+            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _bandTicks.Value;
 
         public void OnTrade(long priceTicks, DateTime time) => _referencePriceTicks = priceTicks;
 


### PR DESCRIPTION
## Summary

Findings 2 and 3 from the coupling review, as two independent commits.

### Hand each price restriction its band width, not the `Security`

Both restrictions took a `Security` and read exactly one field from it. They now take that field. Nothing else about the instrument was ever their business, and the unit tests no longer invent an instrument — name, type, tick size, tick value — to configure one number.

One test moved rather than being dropped. `DailyPriceBandLimit` had a case asserting it read `VolatilityAuctionBandTicks` and not `PriceBandTicks`; the change makes that unfalsifiable, since it can no longer see the field it was proving it ignored. The risk moves to the book's constructor, now the only place the two widths could be crossed over — so the case moves there too, configuring both bands and checking that a wide entry band accepts while a narrow volatility band still pauses on the resulting trade.

### State what the IOC liquidity gate assumes about allocation order

`HasSufficientLiquidity` described itself as walking resting orders "in the same price/time priority order `Match()` would actually consume them in". That stopped being true in #39, when `SelectNext` took ownership of allocation order — the gate hardcodes head-first, the algorithm decides.

Comment only, no behaviour change, but the comment now says which part is load-bearing rather than restating a claim the types no longer back:

- Total reachable quantity does **not** depend on visit order. Only the point at which a prevented self-match truncates the walk does.
- So the gate is exact for any algorithm with no self-match interaction, and needs revisiting alongside one where the truncation point moves — pro-rata being the obvious candidate.

**A correction to the review:** it offered routing the gate's traversal through `SelectNext` as the better of two options. On inspection that isn't viable as described — the gate runs in `CreateOrder` *before* the incoming order is constructed, so there is no aggressor to hand an algorithm, and a stateful algorithm would have its per-level bookkeeping polluted by a walk that never trades. That reasoning is now recorded in the comment so the next person doesn't reach for it too.

## Test plan

- [x] Restriction change is mechanical: same comparison, same field, sourced at the constructor instead of on every call. All existing unit tests retained, minus the one relocated.
- [x] New `BothBandsConfigured_EachRestrictionGetsItsOwnThreshold` traced by hand against the tick conversion — reference `100` seeds at 10 ticks, orders at `200` are 20 ticks, so distance 10 sits inside the 1000-tick entry band and outside the 5-tick volatility band, giving accept-then-pause.
- [x] Second commit touches no executable code.
- [ ] CI (`dotnet build` + `dotnet test`) — no local .NET SDK in this sandbox, so CI is the gate.

## Remaining

Findings 4 and 5 are deliberately untouched — both need a decision rather than a tidy-up. Naming the self-trade policy is worth doing only when a second mode (decrement) is actually wanted, and making pre-open a phase changes observable behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PqcnfvPNmBnm2xthgwgED)_