### PR TITLE
Govern each trading phase with a matching algorithm

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -226,6 +226,58 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
+        public void PreOpen_CrossedBook_QuotesButNeverTrades()
+        {
+            // arrange - pre-open is governed by an auction, so the one thing that must never
+            // happen is that governance turning into execution: a crossed book during pre-open is
+            // quoted, not printed. Orders sit untouched until the open.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+
+            // act - deeply crossed: the bid is well through the offer
+            var buy = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
+            var sell = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+
+            // assert - a confirmation each, and nothing else
+            Assert.AreEqual(1, buy.Count);
+            Assert.IsInstanceOf<CreateOrderConfirmed>(buy[0]);
+            Assert.AreEqual(1, sell.Count);
+            Assert.IsInstanceOf<CreateOrderConfirmed>(sell[0]);
+
+            // the auction is quoting the whole time, it just isn't acting on it
+            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out _, out var indicativeQuantity));
+            Assert.AreEqual(10, indicativeQuantity);
+
+            // and both orders are still resting in full
+            Assert.AreEqual(10, book.GetLevels(Side.Buy, 10)[0].Quantity);
+            Assert.AreEqual(10, book.GetLevels(Side.Sell, 10)[0].Quantity);
+        }
+
+        [Test]
+        public void TryGetIndicativeAuctionPrice_WhileOpen_Declines()
+        {
+            // arrange - continuous trading is governed by price-time, which has no single price it
+            // would print at, so there is no indicative auction price to report while open. This
+            // is what IOrderBook has always documented the method to mean.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+
+            // act + assert
+            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+
+            // ...and it comes back the moment a volatility pause returns the book to PreOpen
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+
+            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out var price, out var quantity));
+            Assert.AreEqual(100, price);
+            Assert.AreEqual(10, quantity);
+        }
+
+        [Test]
         public void TryGetIndicativeAuctionPrice_ReflectsLiveStateDuringPreOpen()
         {
             // arrange

--- a/Circus.Tests/OrderBook/MatcherTests.cs
+++ b/Circus.Tests/OrderBook/MatcherTests.cs
@@ -128,6 +128,22 @@ namespace Circus.Tests.OrderBook
 
             public bool UsesFullRemainingQuantity => true;
             public bool ChecksTradeRestrictions => false;
+
+            public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+                out long priceTicks, out int quantity)
+            {
+                priceTicks = 0;
+                quantity = 0;
+                return false;
+            }
+
+            public void OnTrade(long priceTicks)
+            {
+            }
+
+            public void OnSessionChange(long? referencePriceTicks)
+            {
+            }
         }
 
         private sealed class DeclinesToMatch : IMatchingAlgorithm
@@ -136,6 +152,22 @@ namespace Circus.Tests.OrderBook
             public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) => null;
             public bool UsesFullRemainingQuantity => false;
             public bool ChecksTradeRestrictions => false;
+
+            public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+                out long priceTicks, out int quantity)
+            {
+                priceTicks = 0;
+                quantity = 0;
+                return false;
+            }
+
+            public void OnTrade(long priceTicks)
+            {
+            }
+
+            public void OnSessionChange(long? referencePriceTicks)
+            {
+            }
         }
 
         private sealed class DeclinesToBegin : IMatchingAlgorithm
@@ -145,6 +177,22 @@ namespace Circus.Tests.OrderBook
                 throw new InvalidOperationException("must not be consulted once TryBegin declines");
             public bool UsesFullRemainingQuantity => false;
             public bool ChecksTradeRestrictions => false;
+
+            public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+                out long priceTicks, out int quantity)
+            {
+                priceTicks = 0;
+                quantity = 0;
+                return false;
+            }
+
+            public void OnTrade(long priceTicks)
+            {
+            }
+
+            public void OnSessionChange(long? referencePriceTicks)
+            {
+            }
         }
     }
 }

--- a/Circus/OrderBook/Auction.cs
+++ b/Circus/OrderBook/Auction.cs
@@ -29,10 +29,15 @@ namespace Circus.OrderBook
 
         public void OnSessionChange(long? referencePriceTicks) => _referencePriceTicks = referencePriceTicks;
 
-        // False when the book isn't crossed, which is what makes an uncrossing pass over an
-        // uncrossed book a no-op rather than something the caller has to check for first.
+        // Strikes the price this print will clear at and holds it for the run. False when the book
+        // isn't crossed, which is what makes an uncrossing pass over an uncrossed book a no-op
+        // rather than something the caller has to check for first.
+        //
+        // The price committed to here is exactly the one TryQuoteIndicative was publishing a
+        // moment earlier - quoting and printing are the same computation, differing only in
+        // whether the caller then runs the algorithm or merely asked it a question.
         public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) =>
-            TryComputeClearingPrice(working, out _clearingPriceTicks, out _);
+            TryQuoteIndicative(working, out _clearingPriceTicks, out _);
 
         // Time priority at the clearing price: the FIFO-earliest order at the level fills first,
         // same order the continuous algorithm would take them in - what differs is the price they
@@ -57,9 +62,9 @@ namespace Circus.OrderBook
         // they're picked up afterward by Matcher.Run's own stop-triggering check, same as any
         // other trade.
         //
-        // Public and side-effect-free so the book can also publish it as a live indicative price
-        // during pre-open, without committing to a print.
-        public bool TryComputeClearingPrice(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+        // Side-effect-free, which is what lets pre-open publish it as a live indicative quote
+        // without committing to a print.
+        public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
             out long priceTicks, out int quantity)
         {
             priceTicks = 0;

--- a/Circus/OrderBook/IMatchingAlgorithm.cs
+++ b/Circus/OrderBook/IMatchingAlgorithm.cs
@@ -11,11 +11,18 @@ namespace Circus.OrderBook
     // active and stays owned by Matcher. Only the decisions below vary.
     //
     // Implementations are instances rather than shared singletons, so a security can eventually
-    // carry its own configured set: a dry-run auction publishing an indicative price during
-    // pre-open, a committing auction for the opening print, price-time (or a pro-rata variant of
-    // it) once continuous trading starts.
+    // carry its own configured set - the auction governing pre-open and the opening print, and
+    // price-time (or a pro-rata variant of it) governing continuous trading.
     internal interface IMatchingAlgorithm
     {
+        // What this algorithm would print against the current book if it ran right now, without
+        // committing to any of it. An auction answers with its clearing price and the volume that
+        // would cross there, which is what pre-open publishes as an indicative quote; continuous
+        // trading has no single indicative print to give - the touch is already public - and
+        // declines. Side-effect-free, so asking is not the same as beginning.
+        bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+            out long priceTicks, out int quantity);
+
         // Prepare for a run against the current working book, deriving whatever run-scoped state
         // this algorithm needs from it - an auction strikes its clearing price here. False means
         // there is nothing for this algorithm to match, so the run yields no outcomes at all.
@@ -46,5 +53,13 @@ namespace Circus.OrderBook
         // Whether a prospective trade price is checked against Trade-scoped price restrictions
         // (a volatility band pausing the book, say) before it executes.
         bool ChecksTradeRestrictions { get; }
+
+        // Anchor maintenance, mirroring IPriceRestriction.OnTrade / OnSessionChange. An algorithm
+        // that keys off a reference price - the auction's tie-break does - keeps it current here
+        // rather than reading one the book holds on its behalf. The book fans both across every
+        // algorithm it governs a phase with, so an algorithm with no anchor simply ignores them.
+        void OnTrade(long priceTicks);
+
+        void OnSessionChange(long? referencePriceTicks);
     }
 }

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -28,7 +28,7 @@ namespace Circus.OrderBook
         // Held as instances rather than reached for statically so a security can eventually
         // supply its own set, differing by phase.
         private readonly IMatchingAlgorithm _continuous = new PriceTime();
-        private readonly Auction _auction = new();
+        private readonly IMatchingAlgorithm _auction = new Auction();
 
         // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
         private readonly Dictionary<long, InternalOrder> _orders = new();
@@ -65,7 +65,7 @@ namespace Circus.OrderBook
 
         // Market data reports what's publicly visible - an iceberg's hidden reserve is
         // deliberately excluded here even though Matcher.HasSufficientLiquidity and
-        // Auction.TryComputeClearingPrice still count it in full for liquidity/price-discovery
+        // Auction.TryQuoteIndicative still count it in full for liquidity/price-discovery
         // purposes.
         private static int SumDisplayed(InternalOrder? first)
         {
@@ -77,7 +77,7 @@ namespace Circus.OrderBook
 
         public bool TryGetIndicativeAuctionPrice(out decimal price, out int quantity)
         {
-            if (!_auction.TryComputeClearingPrice(_matcher.Working, out var priceTicks, out quantity))
+            if (!_auction.TryQuoteIndicative(_matcher.Working, out var priceTicks, out quantity))
             {
                 price = 0;
                 return false;

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -22,13 +22,20 @@ namespace Circus.OrderBook
         // self-match verdicts) that read them.
         private readonly Matcher _matcher = new();
 
-        // The algorithms this book matches under: one for continuous trading - also what an
-        // interrupted auction print hands the rest of its sweep to - and one for the auction
-        // print itself, which owns its own clearing-price computation and reference anchor.
-        // Held as instances rather than reached for statically so a security can eventually
-        // supply its own set, differing by phase.
-        private readonly IMatchingAlgorithm _continuous = new PriceTime();
-        private readonly IMatchingAlgorithm _auction = new Auction();
+        // The algorithm governing each trading phase. PreOpen quotes an indicative price but never
+        // trades; Open trades continuously; and the transition between them commits PreOpen's own
+        // auction as the opening print, so what opening prints is what pre-open was quoting a
+        // moment earlier - one instance, one reference anchor, nothing to keep in sync.
+        //
+        // Closed has no entry: nothing matches or quotes with the book shut. Built here with
+        // defaults, shaped so a security could eventually supply its own set - a pro-rata variant
+        // of continuous trading, say - without anything else moving.
+        private readonly IReadOnlyDictionary<OrderBookStatus, IMatchingAlgorithm> _algorithms =
+            new Dictionary<OrderBookStatus, IMatchingAlgorithm>
+            {
+                {OrderBookStatus.PreOpen, new Auction()},
+                {OrderBookStatus.Open, new PriceTime()}
+            };
 
         // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
         private readonly Dictionary<long, InternalOrder> _orders = new();
@@ -75,13 +82,20 @@ namespace Circus.OrderBook
             return total;
         }
 
+        // Answered by whichever algorithm governs the current phase, so this reports a price
+        // exactly when there is an auction to report one for: during PreOpen, whether that is the
+        // start-of-day session or a mid-session volatility pause. Continuous trading declines,
+        // which is what the interface has always documented this to mean.
         public bool TryGetIndicativeAuctionPrice(out decimal price, out int quantity)
         {
-            if (!_auction.TryQuoteIndicative(_matcher.Working, out var priceTicks, out quantity))
-            {
-                price = 0;
+            price = 0;
+            quantity = 0;
+
+            if (!_algorithms.TryGetValue(_status, out var algorithm))
                 return false;
-            }
+
+            if (!algorithm.TryQuoteIndicative(_matcher.Working, out var priceTicks, out quantity))
+                return false;
 
             price = ToDecimal(priceTicks);
             return true;
@@ -487,7 +501,12 @@ namespace Circus.OrderBook
             return null;
         }
 
-        // algorithm defaults to continuous trading; the opening print passes an Auction instead.
+        // Continuous matching, under the algorithm governing the open phase; the opening print
+        // passes PreOpen's auction instead. The status guard stays explicit rather than falling
+        // out of the phase lookup: pre-open has a governing algorithm and it is an auction, so a
+        // Match that ran during pre-open would print trades at the indicative price rather than
+        // merely quoting it. That phases other than Open do not match continuously is a fact about
+        // the book, and it should be one visible line.
         private void Match(List<OrderBookEvent> events, IMatchingAlgorithm? algorithm = null)
         {
             if (_status != OrderBookStatus.Open)
@@ -495,10 +514,11 @@ namespace Circus.OrderBook
                 return;
             }
 
+            var continuous = _algorithms[OrderBookStatus.Open];
             var time = Now();
             var pendingImmediateOrCancelStops = new List<InternalOrder>();
 
-            foreach (var outcome in _matcher.Run(algorithm ?? _continuous, _continuous, CheckTradeRestrictionBreach))
+            foreach (var outcome in _matcher.Run(algorithm ?? continuous, continuous, CheckTradeRestrictionBreach))
                 Apply(outcome, events, time, pendingImmediateOrCancelStops);
 
             // Deferred until the whole sweep is done, not checked right after each stop's own
@@ -591,7 +611,8 @@ namespace Circus.OrderBook
             if (_lastTradedPrice != priceTicks)
             {
                 _lastTradedPrice = priceTicks;
-                _auction.OnTrade(priceTicks);
+                foreach (var algorithm in _algorithms.Values)
+                    algorithm.OnTrade(priceTicks);
                 foreach (var restriction in _priceRestrictions)
                     restriction.OnTrade(priceTicks, time);
             }
@@ -661,7 +682,8 @@ namespace Circus.OrderBook
         {
             if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
             {
-                _auction.OnSessionChange(referenceTicks);
+                foreach (var algorithm in _algorithms.Values)
+                    algorithm.OnSessionChange(referenceTicks);
                 foreach (var restriction in _priceRestrictions)
                     restriction.OnSessionChange(referenceTicks);
             }
@@ -689,10 +711,11 @@ namespace Circus.OrderBook
             _status = OrderBookStatus.Open;
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
 
-            // Runs whether the prior status was the real start-of-day PreOpen or PreOpen
-            // re-entered mid-session for a volatility pause - same uncrossing either way, and a
-            // no-op when the book isn't crossed, since the auction declines to begin.
-            Match(events, _auction);
+            // Commits the auction pre-open was quoting. Runs whether the prior status was the real
+            // start-of-day PreOpen or PreOpen re-entered mid-session for a volatility pause - same
+            // uncrossing either way, and a no-op when the book isn't crossed, since the auction
+            // declines to begin.
+            Match(events, _algorithms[OrderBookStatus.PreOpen]);
 
             Match(events);
             return events;

--- a/Circus/OrderBook/PriceTime.cs
+++ b/Circus/OrderBook/PriceTime.cs
@@ -16,6 +16,17 @@ namespace Circus.OrderBook
         // touch - and whether anything crosses is the matching loop's own question to answer.
         public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
 
+        // Continuous trading has no single price it would print at: it prints at as many prices as
+        // the sweep touches, and the best of them is already visible as the touch. Nothing to
+        // quote that the book isn't publishing anyway.
+        public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+            out long priceTicks, out int quantity)
+        {
+            priceTicks = 0;
+            quantity = 0;
+            return false;
+        }
+
         public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
             new Allocation(restingHead,
                 Math.Min(restingHead.DisplayedQuantity, aggressor.DisplayedQuantity),
@@ -24,5 +35,15 @@ namespace Circus.OrderBook
         public bool UsesFullRemainingQuantity => false;
 
         public bool ChecksTradeRestrictions => true;
+
+        // No anchor to maintain - every price this algorithm uses comes from the two orders at the
+        // touch, so there is nothing a reference price would tell it.
+        public void OnTrade(long priceTicks)
+        {
+        }
+
+        public void OnSessionChange(long? referencePriceTicks)
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary

Finding 5 from the coupling review: pre-open had no algorithm at all. `Match` returns early unless the book is open, so the indicative price was computed on demand through a concrete-typed field — the one part of the trading path sitting outside the seam everything else goes through. Two commits.

### 1. Put indicative quoting and anchor upkeep on `IMatchingAlgorithm`

The book held its auction as concrete `Auction` while holding continuous behind the interface, because three of the auction's members weren't on it.

`TryQuoteIndicative` replaces `Auction.TryComputeClearingPrice` and joins the interface: *what would you print against this book right now, without committing to any of it*. The auction answers with clearing price and crossing volume; price-time declines, since it prints at as many prices as the sweep touches and the best of them is already the visible touch. `TryBegin` now goes through it too, which says plainly that quoting and printing are one computation differing only in whether the caller then runs the algorithm or merely asked it a question.

`OnTrade` and `OnSessionChange` join it as well — **reversing a call made in #39**, where I kept them off precisely because only the auction needed them and the book held it concretely, so `PriceTime` stubs would have been dead weight. Commit 2 has the book fan both across every algorithm it governs a phase with, the same shape already used for `IPriceRestriction`, which makes them genuinely polymorphic and the stubs the same trade-off that interface already makes.

No behaviour change; resolves the polymorphism-asymmetry finding on its own.

### 2. Govern each phase with an algorithm

```csharp
private readonly IReadOnlyDictionary<OrderBookStatus, IMatchingAlgorithm> _algorithms = new ...
{
    {OrderBookStatus.PreOpen, new Auction()},
    {OrderBookStatus.Open, new PriceTime()}
};
```

`Closed` has no entry — nothing matches or quotes with the book shut. The opening print runs **PreOpen's own auction instance**, so what opening commits is exactly what pre-open had been quoting, sharing one reference anchor with no second instance to keep in sync.

**Dry-run stays a usage, not a mode.** The original review proposed `Uncross(commit: false)`; that flag doesn't exist here. Quoting is asking the algorithm a question, printing is running it through `Match` — same object, no mutable mode, no `commit` parameter to get wrong. This is why the change came in well under the M–L the review estimated.

**`Match` keeps its explicit status guard** rather than letting the phase lookup imply it. Pre-open's governing algorithm is an auction, so a `Match` that ran during pre-open would print trades *at the indicative price* instead of merely quoting it. That phases other than `Open` don't match continuously is a fact about the book and should be one visible line, not an emergent property of a dictionary lookup.

## Test plan

- [x] New `PreOpen_CrossedBook_QuotesButNeverTrades` pins the severe failure mode from the outside: a deeply crossed book (bid 150 through offer 100) during pre-open returns one confirmation per order and nothing else, quotes an indicative quantity of 10, and leaves both orders resting in full.
- [x] New `TryGetIndicativeAuctionPrice_WhileOpen_Declines` documents the gating, and checks the quote returns the moment a pause puts the book back in PreOpen.
- [x] Existing `VolatilityBandBreach_..._StopElectsOnReopen` covers the pause → reopen transition, the path most at risk.
- [x] The existing indicative-price test uses pre-open exclusively, so the gating breaks nothing.
- [x] Fan-out equivalence checked: `PriceTime` no-ops both hooks, so notifying the map notifies exactly what `_auction` alone did before.
- [ ] CI (`dotnet build` + `dotnet test`) — no local .NET SDK in this sandbox, so CI is the gate.

## Behaviour change

`TryGetIndicativeAuctionPrice` is now answered by the algorithm governing the current phase, so **while open it declines** where before it computed off the ladders. In practice the book is never crossed while open, so the old answer was almost always false anyway — but *almost always* is an argument, not a guarantee, so it's called out rather than buried. It also makes the method match what `IOrderBook` has always documented it to mean ("during PreOpen, or a mid-session volatility pause"), and a pause is `PreOpen`, so that case still works.

## Out of scope

**Emitting indicative prices as events.** Tempting adjacent feature — pushing a quote on the feed during pre-open instead of making callers poll, which is what real venues do. Deliberately excluded: it adds a public `OrderBookEvent` type flowing into all four data producers, and every pre-open test asserting `events.Count` would need revisiting. Market-data feature, not a decoupling change, and folding it in would make this diff's behaviour-preserving core impossible to review separately.

**Algorithm config on `Security`.** The map is built with defaults in the book's constructor, shaped so a security could supply its own set later. Putting it on `Security` is a public API change with no caller yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PqcnfvPNmBnm2xthgwgED)_