### PR TITLE
Describe each trading phase in a table instead of testing the status

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -255,6 +255,29 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
+        public void ClosingFromPreOpen_AbandonsTheAuction_WithoutPrinting()
+        {
+            // arrange - a crossed book in pre-open, quoting a price it would clear at
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out _, out _));
+
+            // act - closing rather than opening. Pre-open is a phase that prints on the way out,
+            // but the phase being entered doesn't trade, so the orders it accumulated are
+            // abandoned rather than crossed.
+            var events = book.UpdateStatus(OrderBookStatus.Closed);
+
+            // assert
+            Assert.IsEmpty(events.OfType<OrdersMatched>().ToList(),
+                "the auction must not print into a phase that doesn't trade");
+            Assert.AreEqual(2, events.OfType<ExpireOrderConfirmed>().ToList().Count);
+            Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+        }
+
+        [Test]
         public void TryGetIndicativeAuctionPrice_WhileOpen_Declines()
         {
             // arrange - continuous trading is governed by price-time, which has no single price it

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -22,20 +22,36 @@ namespace Circus.OrderBook
         // self-match verdicts) that read them.
         private readonly Matcher _matcher = new();
 
-        // The algorithm governing each trading phase. PreOpen quotes an indicative price but never
-        // trades; Open trades continuously; and the transition between them commits PreOpen's own
-        // auction as the opening print, so what opening prints is what pre-open was quoting a
-        // moment earlier - one instance, one reference anchor, nothing to keep in sync.
+        // What each phase permits and which algorithm governs it - see TradingPhase. Nothing
+        // outside this table names a status: the rest of the book reads the current phase and acts
+        // on what it says, so adding a phase is adding a row here, and a security could eventually
+        // be handed a table of its own without anything else moving.
         //
-        // Closed has no entry: nothing matches or quotes with the book shut. Built here with
-        // defaults, shaped so a security could eventually supply its own set - a pro-rata variant
-        // of continuous trading, say - without anything else moving.
-        private readonly IReadOnlyDictionary<OrderBookStatus, IMatchingAlgorithm> _algorithms =
-            new Dictionary<OrderBookStatus, IMatchingAlgorithm>
+        // PreOpen accumulates orders and quotes what they would clear at without trading any of
+        // them; leaving it commits that same auction instance as the opening print, so what opens
+        // is what was being quoted a moment earlier, on one reference anchor with nothing to keep
+        // in sync.
+        private readonly IReadOnlyDictionary<OrderBookStatus, TradingPhase> _phases =
+            new Dictionary<OrderBookStatus, TradingPhase>
             {
-                {OrderBookStatus.PreOpen, new Auction()},
-                {OrderBookStatus.Open, new PriceTime()}
+                {
+                    OrderBookStatus.PreOpen,
+                    new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                        MatchesContinuously: false, StartsSession: true, ExpiresDayOrders: false)
+                },
+                {
+                    OrderBookStatus.Open,
+                    new TradingPhase(new PriceTime(), AcceptsOrderActions: true, AcceptsMarketOrders: true,
+                        MatchesContinuously: true, StartsSession: false, ExpiresDayOrders: false)
+                },
+                {
+                    OrderBookStatus.Closed,
+                    new TradingPhase(null, AcceptsOrderActions: false, AcceptsMarketOrders: false,
+                        MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: true)
+                }
             };
+
+        private TradingPhase CurrentPhase => _phases[_status];
 
         // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
         private readonly Dictionary<long, InternalOrder> _orders = new();
@@ -91,10 +107,8 @@ namespace Circus.OrderBook
             price = 0;
             quantity = 0;
 
-            if (!_algorithms.TryGetValue(_status, out var algorithm))
-                return false;
-
-            if (!algorithm.TryQuoteIndicative(_matcher.Working, out var priceTicks, out quantity))
+            var algorithm = CurrentPhase.Algorithm;
+            if (algorithm == null || !algorithm.TryQuoteIndicative(_matcher.Working, out var priceTicks, out quantity))
                 return false;
 
             price = ToDecimal(priceTicks);
@@ -133,9 +147,9 @@ namespace Circus.OrderBook
             var selfMatchPreventionInstruction = selfMatchPrevention?.Instruction;
             var status = triggerPrice.HasValue ? OrderStatus.Hidden : OrderStatus.Working;
 
-            if (_status == OrderBookStatus.Closed)
+            if (!CurrentPhase.AcceptsOrderActions)
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketClosed);
-            if (type == OrderType.Market && _status == OrderBookStatus.PreOpen)
+            if (type == OrderType.Market && !CurrentPhase.AcceptsMarketOrders)
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketPreOpen);
             if (string.IsNullOrEmpty(clientOrderId))
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdRequired);
@@ -269,7 +283,7 @@ namespace Circus.OrderBook
         private List<OrderBookEvent> UpdateOrder(string companyId, string clientOrderId, string previousClientOrderId,
             int? newTotalQuantity = null, decimal? price = null, decimal? triggerPrice = null)
         {
-            if (_status == OrderBookStatus.Closed)
+            if (!CurrentPhase.AcceptsOrderActions)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
             if (string.IsNullOrEmpty(clientOrderId))
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
@@ -387,7 +401,7 @@ namespace Circus.OrderBook
 
         private List<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId)
         {
-            if (_status == OrderBookStatus.Closed)
+            if (!CurrentPhase.AcceptsOrderActions)
                 return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
             if (string.IsNullOrEmpty(clientOrderId))
                 return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
@@ -501,20 +515,21 @@ namespace Circus.OrderBook
             return null;
         }
 
-        // Continuous matching, under the algorithm governing the open phase; the opening print
-        // passes PreOpen's auction instead. The status guard stays explicit rather than falling
-        // out of the phase lookup: pre-open has a governing algorithm and it is an auction, so a
-        // Match that ran during pre-open would print trades at the indicative price rather than
-        // merely quoting it. That phases other than Open do not match continuously is a fact about
-        // the book, and it should be one visible line.
+        // Matching under the current phase's algorithm, or under one supplied by the caller - a
+        // departing phase's auction, committed as it leaves. Either way this is the single gate on
+        // whether trading can happen at all right now, which is why the print of an exiting
+        // auction goes through it too: a phase that accumulated orders but is being left for one
+        // that does not trade abandons them rather than crossing them.
         private void Match(List<OrderBookEvent> events, IMatchingAlgorithm? algorithm = null)
         {
-            if (_status != OrderBookStatus.Open)
+            var phase = CurrentPhase;
+            if (!phase.MatchesContinuously)
             {
                 return;
             }
 
-            var continuous = _algorithms[OrderBookStatus.Open];
+            var continuous = phase.Algorithm ??
+                throw new InvalidOperationException("a phase that matches continuously needs an algorithm");
             var time = Now();
             var pendingImmediateOrCancelStops = new List<InternalOrder>();
 
@@ -611,8 +626,8 @@ namespace Circus.OrderBook
             if (_lastTradedPrice != priceTicks)
             {
                 _lastTradedPrice = priceTicks;
-                foreach (var algorithm in _algorithms.Values)
-                    algorithm.OnTrade(priceTicks);
+                foreach (var phase in _phases.Values)
+                    phase.Algorithm?.OnTrade(priceTicks);
                 foreach (var restriction in _priceRestrictions)
                     restriction.OnTrade(priceTicks, time);
             }
@@ -682,50 +697,43 @@ namespace Circus.OrderBook
         {
             if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
             {
-                foreach (var algorithm in _algorithms.Values)
-                    algorithm.OnSessionChange(referenceTicks);
+                foreach (var phase in _phases.Values)
+                    phase.Algorithm?.OnSessionChange(referenceTicks);
                 foreach (var restriction in _priceRestrictions)
                     restriction.OnSessionChange(referenceTicks);
             }
 
-            return status switch
+            if (!_phases.ContainsKey(status))
+                throw new ArgumentOutOfRangeException(nameof(status), status, "no phase configured for this status");
+
+            var departing = CurrentPhase;
+            _status = status;
+            var arriving = CurrentPhase;
+
+            if (arriving.StartsSession)
             {
-                OrderBookStatus.PreOpen => PreOpenMarket(),
-                OrderBookStatus.Open => OpenMarket(),
-                OrderBookStatus.Closed => CloseMarket(),
-                _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
-            };
-        }
+                // TODO: need better system for multiple sessions per day
+                var date = Now();
+                _nextSequenceNumber = ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
+            }
 
-        private List<OrderBookEvent> PreOpenMarket()
-        {
-            // TODO: need better system for multiple sessions per day
-            var date = Now();
-            _nextSequenceNumber = ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
-            _status = OrderBookStatus.PreOpen;
-            return new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
-        }
-
-        private List<OrderBookEvent> OpenMarket()
-        {
-            _status = OrderBookStatus.Open;
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
 
-            // Commits the auction pre-open was quoting. Runs whether the prior status was the real
-            // start-of-day PreOpen or PreOpen re-entered mid-session for a volatility pause - same
-            // uncrossing either way, and a no-op when the book isn't crossed, since the auction
-            // declines to begin.
-            Match(events, _algorithms[OrderBookStatus.PreOpen]);
+            // A phase that was quoting rather than trading has been accumulating orders for a
+            // print, and this is where that print happens - so the opening print is pre-open's own
+            // auction rather than anything the open phase owns, and a second auction phase would
+            // print on the way out of itself with nothing here to change. Match declines it
+            // outright if the phase just entered does not trade, which is what makes leaving
+            // pre-open for a close abandon the auction instead of crossing it.
+            if (departing.PrintsOnExit)
+                Match(events, departing.Algorithm);
 
+            // Then trading continues under whatever governs the phase just entered.
             Match(events);
-            return events;
-        }
 
-        private List<OrderBookEvent> CloseMarket()
-        {
-            _status = OrderBookStatus.Closed;
-            var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
-            events.AddRange(ExpireOrders());
+            if (arriving.ExpiresDayOrders)
+                events.AddRange(ExpireOrders());
+
             return events;
         }
 

--- a/Circus/OrderBook/TradingPhase.cs
+++ b/Circus/OrderBook/TradingPhase.cs
@@ -1,0 +1,35 @@
+namespace Circus.OrderBook
+{
+    // What a trading phase permits, and which algorithm governs it.
+    //
+    // Everything the book does differently from one phase to the next is a field here rather than
+    // a comparison against OrderBookStatus, so the behaviour of a phase is one row to read instead
+    // of guard clauses scattered across order entry, matching and the status transitions. Adding a
+    // phase is adding a row; giving a security a table of its own is supplying a different set.
+    internal sealed record TradingPhase(
+        // Governs matching while the phase is current, and quoting throughout it. Null for a phase
+        // where neither happens.
+        IMatchingAlgorithm? Algorithm,
+        // Whether clients can create, amend or cancel at all. A no-cancel period ahead of an
+        // auction would be the reason to split this into separate facets per action; nothing needs
+        // that yet, and every phase today either takes all three or none.
+        bool AcceptsOrderActions,
+        // Market orders need a resting book to price themselves against, so a phase that never
+        // trades has nothing to protect them with.
+        bool AcceptsMarketOrders,
+        // Whether an incoming order is matched as it arrives. False for a phase that only
+        // accumulates orders, however much its algorithm can already tell you about them.
+        bool MatchesContinuously,
+        // Whether entering the phase begins a new session, restarting order sequence numbers.
+        bool StartsSession,
+        // Whether entering the phase expires the day orders that did not survive it.
+        bool ExpiresDayOrders)
+    {
+        // A phase that quotes a price without trading at it is accumulating orders for a print,
+        // and leaving it is when that print happens - which is why the opening print is the
+        // auction pre-open was quoting, rather than anything the open phase owns. Continuous
+        // trading has already printed everything it is going to, and a phase with no algorithm has
+        // nothing to print at all.
+        public bool PrintsOnExit => Algorithm != null && !MatchesContinuously;
+    }
+}


### PR DESCRIPTION
## Summary

Steps 1 and 2 from the phase-generalisation discussion. Phase behaviour was spread across seven places that each compared against `OrderBookStatus` — three closed-market rejections, the market-order rejection in pre-open, the continuous-matching guard, the algorithm map, and a switch over three entry methods. Answering "what does pre-open permit" meant finding all of them.

### One table

```csharp
internal sealed record TradingPhase(
    IMatchingAlgorithm? Algorithm,
    bool AcceptsOrderActions,
    bool AcceptsMarketOrders,
    bool MatchesContinuously,
    bool StartsSession,
    bool ExpiresDayOrders);
```

| Status | Algorithm | Order actions | Market orders | Matches continuously | Starts session | Expires day orders |
|---|---|---|---|---|---|---|
| PreOpen | `Auction` | ✓ | ✗ | ✗ | ✓ | ✗ |
| Open | `PriceTime` | ✓ | ✓ | ✓ | ✗ | ✗ |
| Closed | — | ✗ | ✗ | ✗ | ✗ | ✓ |

`Closed` gains a row rather than being absent from the map, so the lookup never misses. **Nothing outside the table selects an algorithm by naming a status**: matching takes the current phase's, the opening print takes the departing phase's.

### Prints happen on exit, not entry

A phase that quotes without trading has been accumulating orders for a print, so leaving it is where that print belongs. This is derivable rather than configured — an algorithm plus no continuous matching means a phase that prints on exit — so there's no seventh flag:

```csharp
public bool PrintsOnExit => Algorithm != null && !MatchesContinuously;
```

The opening print stops being something the open phase reaches back for (`Match(events, _algorithms[OrderBookStatus.PreOpen])`), and a closing auction would print on the way out of itself with nothing in `UpdateStatus` to change.

`Match` becomes the single gate on whether trading may happen at all right now, since the exit print goes through it too. That's what makes closing straight from pre-open *abandon* the accumulated auction rather than crossing it.

## Test plan

- [x] All five transition paths traced against the originals: Closed→PreOpen (seq reset, no print), PreOpen→Open (auction print then continuous), Open→Closed (expiries, no print), Open→PreOpen (pause — seq reset, matching old `PreOpenMarket`), PreOpen→Closed.
- [x] New `ClosingFromPreOpen_AbandonsTheAuction_WithoutPrinting` — the last of those was reachable through the public API before but never exercised, and it's the path most changed by moving the print to exit. Asserts no `OrdersMatched` and both orders expired.
- [x] Every facet the table now drives has existing coverage: `MarketPreOpen` rejection in `InMemoryOrderBookCreateOrderTests`, `MarketClosed` across create/update/cancel tests, continuous matching throughout, and the pre-open/opening auction tests from #42.
- [ ] CI (`dotnet build` + `dotnet test`) — no local .NET SDK in this sandbox, so CI is the gate.

## What's still status-specific, deliberately

Two comparisons remain, and neither is phase behaviour:

- `Process` maps the three public action records (`PreOpenTrading` / `OpenTrading` / `CloseTrading`) to their statuses. Generalising this means changing the public API — that's step 3.
- A trade-restriction breach picks which status to pause or halt into. It's a different axis (breach consequence → phase, not phase → permissions), and it sets `_status` directly precisely to skip the entry side effects. Routing it through `UpdateStatus` would now reset sequence numbers on a pause and expire orders on a halt, which would be a behaviour change rather than a preservation.

Per-security phase *tables* are now a constructor parameter away; per-security phase *sets* still need step 3, since `OrderBookStatus` and the action records are public and `SessionProvider` encodes the three-phase cycle in its constructor.

---
_Generated by [Claude Code](https://claude.ai/code/session_016PqcnfvPNmBnm2xthgwgED)_