### PR TITLE
Publish the indicative auction price as market data

### DIFF
--- a/Circus.Examples/DataProducerExample.cs
+++ b/Circus.Examples/DataProducerExample.cs
@@ -24,35 +24,47 @@ namespace Circus.Examples
             var bboDataProducer1 = new LevelDataProducer(1);
             var top10DataProducer1 = new LevelDataProducer(10);
             var fullBookDataProducer1 = new FullBookDataProducer();
+            var indicativeDataProducer1 = new IndicativePriceDataProducer();
 
             var tradeDataProducer2 = new TradeDataProducer();
             var bboDataProducer2 = new LevelDataProducer(1);
             var top10DataProducer2 = new LevelDataProducer(10);
             var fullBookDataProducer2 = new FullBookDataProducer();
+            var indicativeDataProducer2 = new IndicativePriceDataProducer();
 
             void Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> events, TradeDataProducer tradeDataProducer,
                 LevelDataProducer bboDataProducer, LevelDataProducer top10DataProducer,
-                FullBookDataProducer fullBookDataProducer)
+                FullBookDataProducer fullBookDataProducer, IndicativePriceDataProducer indicativeDataProducer)
             {
                 Print(tradeDataProducer.Process(book, events));
                 Print(bboDataProducer.Process(book, events));
                 Print(top10DataProducer.Process(book, events));
                 Print(fullBookDataProducer.Process(book, events));
+                Print(indicativeDataProducer.Process(book, events));
             }
 
-            Publish(book1, book1.UpdateStatus(OrderBookStatus.Open), tradeDataProducer1, bboDataProducer1,
-                top10DataProducer1, fullBookDataProducer1);
+            // book1 opens on an auction: orders accumulate in pre-open with the indicative quote
+            // tracking them, and the print happens on the way out - the same orders as book2, which
+            // opens first and trades them continuously.
+            Publish(book1, book1.UpdateStatus(OrderBookStatus.PreOpen), tradeDataProducer1, bboDataProducer1,
+                top10DataProducer1, fullBookDataProducer1, indicativeDataProducer1);
             Publish(book1, book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100),
-                tradeDataProducer1, bboDataProducer1, top10DataProducer1, fullBookDataProducer1);
+                tradeDataProducer1, bboDataProducer1, top10DataProducer1, fullBookDataProducer1,
+                indicativeDataProducer1);
             Publish(book1, book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100),
-                tradeDataProducer1, bboDataProducer1, top10DataProducer1, fullBookDataProducer1);
+                tradeDataProducer1, bboDataProducer1, top10DataProducer1, fullBookDataProducer1,
+                indicativeDataProducer1);
+            Publish(book1, book1.UpdateStatus(OrderBookStatus.Open), tradeDataProducer1, bboDataProducer1,
+                top10DataProducer1, fullBookDataProducer1, indicativeDataProducer1);
 
             Publish(book2, book2.UpdateStatus(OrderBookStatus.Open), tradeDataProducer2, bboDataProducer2,
-                top10DataProducer2, fullBookDataProducer2);
+                top10DataProducer2, fullBookDataProducer2, indicativeDataProducer2);
             Publish(book2, book2.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100),
-                tradeDataProducer2, bboDataProducer2, top10DataProducer2, fullBookDataProducer2);
+                tradeDataProducer2, bboDataProducer2, top10DataProducer2, fullBookDataProducer2,
+                indicativeDataProducer2);
             Publish(book2, book2.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100),
-                tradeDataProducer2, bboDataProducer2, top10DataProducer2, fullBookDataProducer2);
+                tradeDataProducer2, bboDataProducer2, top10DataProducer2, fullBookDataProducer2,
+                indicativeDataProducer2);
         }
 
         private static void Print(IEnumerable<TradedDataEvent> events)
@@ -69,6 +81,14 @@ namespace Circus.Examples
             {
                 Console.WriteLine(
                     $"LevelsDataEvent {{ Bids = [{string.Join(", ", @event.Bids)}], Offers = [{string.Join(", ", @event.Offers)}] }}");
+            }
+        }
+
+        private static void Print(IEnumerable<IndicativePriceDataEvent> events)
+        {
+            foreach (var @event in events)
+            {
+                Console.WriteLine(@event);
             }
         }
 

--- a/Circus.Simulator/OrderFlowSimulator.cs
+++ b/Circus.Simulator/OrderFlowSimulator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 
@@ -20,6 +21,11 @@ namespace Circus.Simulator
         private readonly int _seed;
 
         private readonly InMemoryOrderBook _shadowBook;
+
+        // The touch, rebuilt from the shadow book's events the same way any market data consumer
+        // would - the book itself answers no questions about its levels.
+        private readonly LevelDataProducer _touch = new(1);
+        private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
 
         // Keyed by ClientOrderId, not ExchangeOrderId - the latter no longer stays constant for
         // an order's whole life (a reprice, a quantity increase, or an iceberg peak refilling
@@ -69,6 +75,10 @@ namespace Circus.Simulator
         private void Apply(OrderBookAction action)
         {
             var events = _shadowBook.Process(action);
+
+            foreach (var levels in _touch.Process(_shadowBook, events))
+                _levels = levels;
+
             foreach (var e in events)
             {
                 switch (e)
@@ -243,8 +253,8 @@ namespace Circus.Simulator
         private decimal ComputePrice(Side side)
         {
             var tick = _security.TickSize;
-            var bestBuy = _shadowBook.GetLevels(Side.Buy, 1);
-            var bestSell = _shadowBook.GetLevels(Side.Sell, 1);
+            var bestBuy = _levels.Bids;
+            var bestSell = _levels.Offers;
 
             if (bestBuy.Count == 0 && bestSell.Count == 0)
                 return AlignToTick(_options.StartingPrice);

--- a/Circus.Tests/DataProducers/IndicativePriceDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/IndicativePriceDataProducerTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using Circus.DataProducers;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.DataProducers
+{
+    public class IndicativePriceDataProducerTests
+    {
+        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+
+        private static TestTimeProvider TimeProvider;
+        private static IOrderBook Book;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+            Book = new InMemoryOrderBook(Sec, TimeProvider);
+        }
+
+        private static IList<IndicativePriceDataEvent> Publish(IndicativePriceDataProducer producer,
+            IReadOnlyList<OrderBookEvent> bookEvents) =>
+            producer.Process(Book, bookEvents);
+
+        [Test]
+        public void CrossedPreOpenBook_PublishesTheQuote()
+        {
+            var producer = new IndicativePriceDataProducer();
+            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+            Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+
+            var events = Publish(producer,
+                Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
+
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(Now1, events[0].Time);
+            Assert.AreEqual(100, events[0].Price);
+            Assert.AreEqual(3, events[0].Quantity);
+        }
+
+        [Test]
+        public void UncrossedBook_PublishesNothing()
+        {
+            var producer = new IndicativePriceDataProducer();
+            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+
+            var events = Publish(producer,
+                Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+
+            Assert.IsEmpty(events);
+        }
+
+        [Test]
+        public void ContinuousTrading_PublishesNothing()
+        {
+            var producer = new IndicativePriceDataProducer();
+            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+            Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+
+            var events = Publish(producer,
+                Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
+
+            Assert.IsEmpty(events, "price-time has no single price it would print at");
+        }
+
+        [Test]
+        public void AuctionPrints_WithdrawsTheQuote()
+        {
+            var producer = new IndicativePriceDataProducer();
+            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+            Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+            Publish(producer, Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+
+            TimeProvider.SetCurrentTime(Now2);
+            var events = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(Now2, events[0].Time);
+            Assert.IsNull(events[0].Price, "there is no auction left to quote once it has printed");
+            Assert.AreEqual(0, events[0].Quantity);
+        }
+    }
+}

--- a/Circus.Tests/DataProducers/LevelDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/LevelDataProducerTests.cs
@@ -7,10 +7,10 @@ using NUnit.Framework;
 
 namespace Circus.Tests.DataProducers
 {
-    // LevelDataProducer maintains its own state purely from the OrderConfirmedEvent stream (it
-    // no longer queries IOrderBook.GetLevels), so every test must route every book action
-    // through the same producer instance, in order - never feed it only the final action's
-    // events after driving earlier actions directly through the book.
+    // LevelDataProducer maintains its own state purely from the OrderConfirmedEvent stream, so
+    // every test must route every book action through the same producer instance, in order -
+    // never feed it only the final action's events after driving earlier actions directly
+    // through the book.
     public class LevelDataProducerTests
     {
         private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
@@ -277,6 +277,29 @@ namespace Circus.Tests.DataProducers
             Assert.AreEqual(1, level.Offers.Count);
             Assert.AreEqual(110, level.Offers[0].Price);
             Assert.AreEqual(5, level.Offers[0].Quantity, "still only the displayed peak after moving levels");
+        }
+
+        [Test]
+        public void AuctionPrint_TradesThroughIcebergPeak_LevelShowsTheRefreshedPeak()
+        {
+            var producer = new LevelDataProducer(2);
+            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+
+            // total 100, only 10 displayed - but an auction sizes its print off full remaining
+            // quantity, so this trades 45, far more than the order was ever showing
+            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
+                maxVisibleQuantity: 10));
+            TimeProvider.SetCurrentTime(Now2);
+            Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100));
+
+            var level = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+
+            Assert.IsEmpty(level.Offers);
+            Assert.AreEqual(1, level.Bids.Count);
+            Assert.AreEqual(100, level.Bids[0].Price);
+            Assert.AreEqual(10, level.Bids[0].Quantity,
+                "a fresh peak, not the traded quantity taken off the peak it was showing");
+            Assert.AreEqual(1, level.Bids[0].Count);
         }
 
         [Test]

--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -48,7 +48,7 @@ namespace Circus.Tests.OrderBook
             // sells fully fill (also price improvement - they get 120, not their own lower limit),
             // and the 120 buy (the marginal order) only partially fills for the 1 unit left over
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen);
 
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
@@ -63,17 +63,15 @@ namespace Circus.Tests.OrderBook
 
             // assert - every fill in this batch prints at the single auction price of 120
             Assert.IsInstanceOf<StatusChanged>(events[0]);
-            for (var i = 1; i < events.Count; i++)
-            {
-                var matched = events[i] as OrdersMatched;
-                Assert.IsNotNull(matched);
+            var matches = events.OfType<OrdersMatched>().ToList();
+            Assert.IsNotEmpty(matches);
+            foreach (var matched in matches)
                 Assert.AreEqual(120, matched.Price);
-            }
 
-            var totalQuantity = 0;
-            for (var i = 1; i < events.Count; i++)
-                totalQuantity += ((OrdersMatched) events[i]).Quantity;
-            Assert.AreEqual(11, totalQuantity);
+            Assert.AreEqual(11, matches.Sum(m => m.Quantity));
+
+            // the auction it was quoting is over, so the quote is withdrawn
+            Assert.IsNull(events.OfType<IndicativePriceChanged>().Last().Price);
 
             // the marginal buy order (120) is left resting, partially filled
             var buyLevels = book.GetLevels(Side.Buy, 10);
@@ -99,7 +97,7 @@ namespace Circus.Tests.OrderBook
             // before the later order gets anything - it must not lose its place in the queue just
             // because its displayed peak needs replenishing mid-print.
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen);
 
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
@@ -132,7 +130,7 @@ namespace Circus.Tests.OrderBook
             // than the 10-unit peak must not leave DisplayedQuantity negative or stale - it should
             // come out re-derived to a fresh full peak, the same as if it had just been entered.
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen);
 
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
@@ -161,7 +159,7 @@ namespace Circus.Tests.OrderBook
             // arrange - 120 and 130 tie for max executable volume (10 each), with the surplus on
             // the sell side at both - CME's rule picks the lowest of the tied prices in that case
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen);
 
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
@@ -186,7 +184,7 @@ namespace Circus.Tests.OrderBook
             // arrange - same tie as above (120 vs 130), but with a reference price seeded at 130
             // (must be tick-aligned to TickSize 10) - that should win over the default rule
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen, 130);
 
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
@@ -210,7 +208,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen);
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
@@ -232,22 +230,24 @@ namespace Circus.Tests.OrderBook
             // happen is that governance turning into execution: a crossed book during pre-open is
             // quoted, not printed. Orders sit untouched until the open.
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen);
 
             // act - deeply crossed: the bid is well through the offer
             var buy = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
             var sell = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
 
-            // assert - a confirmation each, and nothing else
-            Assert.AreEqual(1, buy.Count);
+            // assert - a confirmation each, and no trade
+            Assert.AreEqual(1, buy.Count, "nothing crosses yet, so not even a quote");
             Assert.IsInstanceOf<CreateOrderConfirmed>(buy[0]);
-            Assert.AreEqual(1, sell.Count);
+            Assert.AreEqual(2, sell.Count);
             Assert.IsInstanceOf<CreateOrderConfirmed>(sell[0]);
 
             // the auction is quoting the whole time, it just isn't acting on it
-            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out _, out var indicativeQuantity));
-            Assert.AreEqual(10, indicativeQuantity);
+            var quote = sell[1] as IndicativePriceChanged;
+            Assert.IsNotNull(quote);
+            Assert.AreEqual(100, quote.Price);
+            Assert.AreEqual(10, quote.Quantity);
 
             // and both orders are still resting in full
             Assert.AreEqual(10, book.GetLevels(Side.Buy, 10)[0].Quantity);
@@ -259,11 +259,11 @@ namespace Circus.Tests.OrderBook
         {
             // arrange - a crossed book in pre-open, quoting a price it would clear at
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.PreOpen);
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
-            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out _, out _));
+            var quoting = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+            Assert.IsNotEmpty(quoting.OfType<IndicativePriceChanged>().ToList());
 
             // act - closing rather than opening. Pre-open is a phase that prints on the way out,
             // but the phase being entered doesn't trade, so the orders it accumulated are
@@ -275,55 +275,83 @@ namespace Circus.Tests.OrderBook
                 "the auction must not print into a phase that doesn't trade");
             Assert.AreEqual(2, events.OfType<ExpireOrderConfirmed>().ToList().Count);
             Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+
+            // the quote goes with it - a closed book is not still quoting one
+            var quote = events.OfType<IndicativePriceChanged>().Last();
+            Assert.IsNull(quote.Price);
+            Assert.AreEqual(0, quote.Quantity);
         }
 
         [Test]
-        public void TryGetIndicativeAuctionPrice_WhileOpen_Declines()
+        public void IndicativePrice_NotQuotedWhileOpen()
         {
             // arrange - continuous trading is governed by price-time, which has no single price it
-            // would print at, so there is no indicative auction price to report while open. This
-            // is what IOrderBook has always documented the method to mean.
+            // would print at, so there is no indicative auction price to publish while open
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
 
-            // act + assert
-            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+            // act + assert - a resting order, then one that crosses it and trades: neither quotes
+            var resting = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+            var crossing = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
+
+            Assert.IsEmpty(resting.OfType<IndicativePriceChanged>().ToList());
+            Assert.IsInstanceOf<OrdersMatched>(crossing[^1]);
+            Assert.IsEmpty(crossing.OfType<IndicativePriceChanged>().ToList());
 
             // ...and it comes back the moment a volatility pause returns the book to PreOpen
             book.UpdateStatus(OrderBookStatus.PreOpen);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+            var paused = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 10, 100);
 
-            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out var price, out var quantity));
-            Assert.AreEqual(100, price);
-            Assert.AreEqual(10, quantity);
+            var quote = paused.OfType<IndicativePriceChanged>().Last();
+            Assert.AreEqual(100, quote.Price);
+            Assert.AreEqual(6, quote.Quantity, "what is left of the buy after the trade above");
         }
 
         [Test]
-        public void TryGetIndicativeAuctionPrice_ReflectsLiveStateDuringPreOpen()
+        public void IndicativePrice_PublishedAsThePreOpenBookMoves()
         {
             // arrange
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
+            var preOpen = book.UpdateStatus(OrderBookStatus.PreOpen);
 
-            // assert - nothing resting yet
-            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+            // assert - nothing resting yet, so nothing to quote
+            Assert.IsEmpty(preOpen.OfType<IndicativePriceChanged>().ToList());
 
             // act - one-sided book, still no cross
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
-            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+            var oneSided = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+            Assert.IsEmpty(oneSided.OfType<IndicativePriceChanged>().ToList());
 
             // act - a crossing sell arrives
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
-            Assert.IsTrue(book.TryGetIndicativeAuctionPrice(out var price, out var quantity));
-            Assert.AreEqual(100, price);
-            Assert.AreEqual(10, quantity);
+            var crossed = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+            var quote = crossed.OfType<IndicativePriceChanged>().Last();
+            Assert.AreEqual(100, quote.Price);
+            Assert.AreEqual(10, quote.Quantity);
 
-            // act - cancelling the crossing sell removes the cross again
-            book.CancelOrder(CompanyId2, CancelId1, OrderId2);
-            Assert.IsFalse(book.TryGetIndicativeAuctionPrice(out _, out _));
+            // act - more sell liquidity at the same price. The buy side still caps what could
+            // clear, so the quote hasn't moved and nothing is published for it
+            var deeperSell = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 100);
+            Assert.IsEmpty(deeperSell.OfType<IndicativePriceChanged>().ToList());
+
+            // act - the buy side catching up does move it
+            var deeperBuy = book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 100);
+            var requoted = deeperBuy.OfType<IndicativePriceChanged>().Last();
+            Assert.AreEqual(100, requoted.Price);
+            Assert.AreEqual(15, requoted.Quantity);
+
+            // act - cancelling every sell removes the cross again, withdrawing the quote
+            var thinner = book.CancelOrder(CompanyId3, CancelId1, OrderId3);
+            Assert.AreEqual(10, thinner.OfType<IndicativePriceChanged>().Last().Quantity);
+
+            var uncrossed = book.CancelOrder(CompanyId2, CancelId1, OrderId2);
+            var withdrawn = uncrossed.OfType<IndicativePriceChanged>().Last();
+            Assert.IsNull(withdrawn.Price);
+            Assert.AreEqual(0, withdrawn.Quantity);
+
+            // and nothing more is published while there is still nothing to quote
+            var stillNothing = book.CancelOrder(CompanyId1, CancelId1, OrderId1);
+            Assert.IsEmpty(stillNothing.OfType<IndicativePriceChanged>().ToList());
         }
 
         [Test]
@@ -334,7 +362,7 @@ namespace Circus.Tests.OrderBook
             // pause the book. This order doesn't cross anything (isolated at 200, nothing on the
             // opposing side), so it must not trigger a pause just for being entered.
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // act
@@ -353,7 +381,7 @@ namespace Circus.Tests.OrderBook
             // sell stop (trigger 90) is added, plus a resting sell at 200 that hasn't crossed
             // anything yet (so hasn't paused anything, per the test above)
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
             book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
@@ -368,10 +396,17 @@ namespace Circus.Tests.OrderBook
             var events = book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 10, 200);
 
             // assert
-            Assert.AreEqual(2, events.Count);
+            Assert.AreEqual(3, events.Count);
             Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
             Assert.AreEqual(OrderBookStatus.PreOpen, ((StatusChanged) events[1]).Status);
             Assert.AreEqual(OrderBookStatus.PreOpen, book.Status);
+
+            // the pause is an auction, and it quotes the crossed book it inherited rather than
+            // printing it
+            var paused = events[2] as IndicativePriceChanged;
+            Assert.IsNotNull(paused);
+            Assert.AreEqual(200, paused.Price);
+            Assert.AreEqual(10, paused.Quantity);
 
             var sellLevels = book.GetLevels(Side.Sell, 10);
             Assert.AreEqual(1, sellLevels.Count);
@@ -401,7 +436,7 @@ namespace Circus.Tests.OrderBook
             // arrange - #23's hard-reject band still works exactly as before when
             // VolatilityAuctionBandTicks isn't set
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // act

--- a/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
@@ -26,13 +26,13 @@ namespace Circus.Tests.OrderBook
         private static readonly string OrderId1B = "Order1b";
 
         private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        private static LevelTrackingOrderBook Book;
 
         [SetUp]
         public void SetUp()
         {
             TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
+            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
         }
 
         [TestCase(0)]
@@ -54,7 +54,7 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
-        public void GetLevels_ReportsDisplayedPeak_NotTrueRemainingSize()
+        public void Levels_ReportDisplayedPeak_NotTrueRemainingSize()
         {
             // arrange
             Book.UpdateStatus(OrderBookStatus.Open);
@@ -163,8 +163,8 @@ namespace Circus.Tests.OrderBook
                 maxVisibleQuantity: 3);
             TimeProvider.SetCurrentTime(Now2);
 
-            // act - requires the full 15 to fill immediately or nothing does; GetLevels would only
-            // show 3, but the true available liquidity (20) is what the gate actually checks
+            // act - requires the full 15 to fill immediately or nothing does; the published level
+            // only shows 3, but the true available liquidity (20) is what the gate actually checks
             var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
                 new OrderValidity.ImmediateOrCancel { MinQuantity = 15 }, Side.Buy, 15, 100);
 

--- a/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
@@ -36,13 +36,13 @@ namespace Circus.Tests.OrderBook
         private static readonly string OrderId6 = "Order6";
 
         private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        private static LevelTrackingOrderBook Book;
 
         [SetUp]
         public void SetUp()
         {
             TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
+            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
         }
 
         // ----- no MinQuantity (classic IOC/FillAndKill behavior) -----
@@ -145,7 +145,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange
             var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
-            var book = new InMemoryOrderBook(sec, TimeProvider);
+            var book = new LevelTrackingOrderBook(sec, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
             TimeProvider.SetCurrentTime(Now2);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
@@ -22,13 +22,13 @@ namespace Circus.Tests.OrderBook
         private static readonly string OrderId3 = "Order3";
 
         private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        private static LevelTrackingOrderBook Book;
 
         [SetUp]
         public void SetUp()
         {
             TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
+            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
         }
 
         [Test]
@@ -101,12 +101,12 @@ namespace Circus.Tests.OrderBook
             // the second level, contrasted against a MarketLimit order in the identical setup
             var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
 
-            var marketBook = new InMemoryOrderBook(sec, TimeProvider);
+            var marketBook = new LevelTrackingOrderBook(sec, TimeProvider);
             marketBook.UpdateStatus(OrderBookStatus.Open);
             marketBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
             marketBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
 
-            var marketLimitBook = new InMemoryOrderBook(sec, TimeProvider);
+            var marketLimitBook = new LevelTrackingOrderBook(sec, TimeProvider);
             marketLimitBook.UpdateStatus(OrderBookStatus.Open);
             marketLimitBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
             marketLimitBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -34,7 +34,7 @@ namespace Circus.Tests.OrderBook
             // arrange - PriceBandTicks is null (the default), so banding is off even though a
             // reference price is seeded
             var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // act
@@ -53,7 +53,7 @@ namespace Circus.Tests.OrderBook
             // reject, and a narrow volatility band must still pause on the resulting trade.
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 1000,
                 VolatilityAuctionBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // act - 200 is far outside the narrow volatility band but well inside the wide entry
@@ -74,7 +74,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange - band is configured, but there's no anchor to check against yet
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open);
 
             // act
@@ -89,7 +89,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange - band of 5 ticks (50) around a seeded reference of 100, so [50, 150]
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // act/assert - at the reference price
@@ -112,7 +112,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange - reference seeded at 100, band [50, 150]
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
 
             // 160 is outside the original [50, 150] band
@@ -138,7 +138,7 @@ namespace Circus.Tests.OrderBook
         {
             // arrange - reference seeded at 100, band [50, 150]
             var security = new Security("GCZ6", SecurityType.Future, 10, 10, PriceBandTicks: 5);
-            var book = new InMemoryOrderBook(security, TimeProvider);
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
             book.UpdateStatus(OrderBookStatus.Open, 100);
             book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 

--- a/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
@@ -16,13 +16,13 @@ namespace Circus.Tests.OrderBook
         private static readonly string OrderId3 = "Order3";
 
         private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        private static LevelTrackingOrderBook Book;
 
         [SetUp]
         public void SetUp()
         {
             TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
+            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
         }
 
         [Test]

--- a/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
@@ -25,13 +25,13 @@ namespace Circus.Tests.OrderBook
         private static readonly string Smp2 = "Smp2";
 
         private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        private static LevelTrackingOrderBook Book;
 
         [SetUp]
         public void SetUp()
         {
             TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
+            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
         }
 
         [Test]

--- a/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
@@ -65,7 +65,10 @@ namespace Circus.Tests.OrderBook
 
             // assert
             Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
+            Assert.AreEqual(3, events.Count);
+            var withdrawn = events[2] as IndicativePriceChanged;
+            Assert.IsNotNull(withdrawn);
+            Assert.IsNull(withdrawn.Price, "the auction it was quoting has printed");
             var matched = events[1] as OrdersMatched;
             Assert.IsNotNull(matched);
             Assert.AreEqual(Sec, matched.Security);

--- a/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
+++ b/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Circus.DataProducers;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+
+namespace Circus.Tests.OrderBook
+{
+    // An InMemoryOrderBook plus the level view a subscriber would keep beside it. The book
+    // answers no questions about its own levels, so a test that needs to know where orders ended
+    // up rebuilds them from the event stream - which also means these assertions are against what
+    // a market data consumer can actually see, not the book's internals.
+    internal sealed class LevelTrackingOrderBook : IOrderBook
+    {
+        // Deeper than any test asks for, so a level is only ever missing because the caller's own
+        // maxPrices cut it off.
+        private const int MaxLevels = 100;
+
+        private readonly IOrderBook _book;
+        private readonly LevelDataProducer _levelDataProducer = new(MaxLevels);
+        private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
+
+        public LevelTrackingOrderBook(Security security, ITimeProvider timeProvider)
+        {
+            _book = new InMemoryOrderBook(security, timeProvider);
+        }
+
+        public Security Security => _book.Security;
+
+        public OrderBookStatus Status => _book.Status;
+
+        public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
+        {
+            var events = _book.Process(action);
+
+            foreach (var levels in _levelDataProducer.Process(_book, events))
+                _levels = levels;
+
+            return events;
+        }
+
+        public IReadOnlyList<Level> GetLevels(Side side, int maxPrices) =>
+            (side == Side.Buy ? _levels.Bids : _levels.Offers).Take(maxPrices).ToList();
+    }
+}

--- a/Circus/DataProducers/IndicativePriceDataProducer.cs
+++ b/Circus/DataProducers/IndicativePriceDataProducer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Circus.OrderBook;
+
+namespace Circus.DataProducers
+{
+    // Publishes the auction quote a book is running - CME's indicative opening price, Eurex's
+    // indicative auction price. Unlike the level producers this holds no state of its own: the
+    // book already emits IndicativePriceChanged only when the quote moves, so there is nothing
+    // here to deduplicate against.
+    //
+    // A null Price withdraws the quote (the book stopped crossing, or the auction ended), which a
+    // subscriber must publish as such rather than leaving the last price standing.
+    public class IndicativePriceDataProducer : IDataProducer<IndicativePriceDataEvent>
+    {
+        public IList<IndicativePriceDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+        {
+            List<IndicativePriceDataEvent>? output = null;
+
+            foreach (var ev in events)
+            {
+                if (ev is IndicativePriceChanged changed)
+                {
+                    output ??= new List<IndicativePriceDataEvent>();
+                    output.Add(new IndicativePriceDataEvent(changed.Time, changed.Price, changed.Quantity));
+                }
+            }
+
+            return output ?? (IList<IndicativePriceDataEvent>) Array.Empty<IndicativePriceDataEvent>();
+        }
+    }
+
+    public record IndicativePriceDataEvent(DateTime Time, decimal? Price, int Quantity);
+}

--- a/Circus/DataProducers/LevelDataProducer.cs
+++ b/Circus/DataProducers/LevelDataProducer.cs
@@ -6,17 +6,15 @@ using Circus.OrderBook;
 namespace Circus.DataProducers
 {
     // Maintains its own view of working-book price levels purely from the OrderConfirmedEvent
-    // stream, rather than querying IOrderBook.GetLevels - so one instance is required per
-    // IOrderBook, created before that book processes its first action, and it can never resync
-    // after a missed event (there's no snapshot fallback).
+    // stream - so one instance is required per IOrderBook, created before that book processes its
+    // first action, and it can never resync after a missed event (there's no snapshot fallback).
     //
-    // Tracks DisplayedQuantity, not RemainingQuantity - an iceberg's hidden reserve must never
-    // appear in market data. Known gap: when an iceberg's displayed peak is exhausted mid-fill
-    // and immediately replenished (InMemoryOrderBook.FillOrder/InternalOrder.Replenish), that
-    // replenishment happens silently within the same Match() pass with no event of its own - the
-    // Fill event this producer sees only carries the traded quantity, not the fact that the
-    // order's displayed size just jumped back up. The level will under-report until the next
-    // event touches that order.
+    // Every quantity here is DisplayedQuantity, never RemainingQuantity - an iceberg's hidden
+    // reserve must not appear in market data - which is why a fill moves a level by the change in
+    // the filled order's displayed size rather than by the quantity that traded. The two differ
+    // for an iceberg: a peak exhausted in continuous trading arrives as its own requeue event
+    // (Removed at 0, then Added showing a fresh peak), and an auction print can trade straight
+    // through the peak into the reserve, leaving the order still showing one.
     public class LevelDataProducer : IDataProducer<LevelsDataEvent>
     {
         private class LevelState
@@ -73,7 +71,8 @@ namespace Circus.DataProducers
                     case OrdersMatched matched:
                         foreach (var fill in matched.Fills)
                         {
-                            ReduceQuantity(fill.Order.Side, fill.Order.Price!.Value, fill.Quantity,
+                            ReduceQuantity(fill.Order.Side, fill.Order.Price!.Value,
+                                fill.PreviousDisplayedQuantity - fill.Order.DisplayedQuantity,
                                 fullyFilled: fill.Order.RemainingQuantity == 0);
                         }
 
@@ -130,4 +129,7 @@ namespace Circus.DataProducers
     }
 
     public record LevelsDataEvent(DateTime Time, IReadOnlyList<Level> Bids, IReadOnlyList<Level> Offers);
+
+    // Aggregated market data, not a book structure: one publishable line per price.
+    public record Level(decimal Price, int Quantity, int Count);
 }

--- a/Circus/OrderBook/IOrderBook.cs
+++ b/Circus/OrderBook/IOrderBook.cs
@@ -2,18 +2,14 @@ using System.Collections.Generic;
 
 namespace Circus.OrderBook
 {
+    // Actions in, events out. Everything a consumer knows about the book - price levels, trades,
+    // an auction's indicative quote - is derived from the event stream rather than queried back
+    // out of the book, so a market data feed and a downstream mirror see the same thing.
     public interface IOrderBook
     {
         Security Security { get; }
 
         OrderBookStatus Status { get; }
-
-        IReadOnlyList<Level> GetLevels(Side side, int maxPrices);
-
-        // Live indicative auction price during PreOpen (or a mid-session volatility pause) - the
-        // price/quantity that would result if the auction ended right now. Recalculated from the
-        // current book on every call, so it naturally tracks order entry/cancellation.
-        bool TryGetIndicativeAuctionPrice(out decimal price, out int quantity);
 
         IReadOnlyList<OrderBookEvent> Process(OrderBookAction action);
     }

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -14,6 +14,9 @@ namespace Circus.OrderBook
         private long _nextSequenceNumber;
         private long? _lastTradedPrice;
 
+        // The indicative quote as last published, so only moves in it are emitted.
+        private (long PriceTicks, int Quantity)? _indicativeQuote;
+
         // Order-entry and trade-time price bands, each maintaining its own reference anchor.
         // A future velocity limit or circuit breaker is a new entry here, not a redesign.
         private readonly IReadOnlyList<IPriceRestriction> _priceRestrictions;
@@ -73,39 +76,21 @@ namespace Circus.OrderBook
         public Security Security => _security;
         public OrderBookStatus Status => _status;
 
-        public IReadOnlyList<Level> GetLevels(Side side, int maxPrices)
-        {
-            return _matcher.Working[side].EnumerateFromBest().Take(maxPrices)
-                .Select(x => new Level(ToDecimal(x.Tick), SumDisplayed(x.First), x.Count))
-                .ToList();
-        }
-
-        // Market data shows only what is publicly visible, so an iceberg's hidden reserve is
-        // excluded - unlike liquidity checks and auction pricing, which count it in full.
-        private static int SumDisplayed(InternalOrder? first)
-        {
-            var total = 0;
-            for (var order = first; order != null; order = order.LevelNext)
-                total += order.DisplayedQuantity;
-            return total;
-        }
-
-        // Answered by the current phase's algorithm, so a price comes back exactly when there is
-        // an auction to report one for - the start-of-day session or a volatility pause.
-        public bool TryGetIndicativeAuctionPrice(out decimal price, out int quantity)
-        {
-            price = 0;
-            quantity = 0;
-
-            var algorithm = CurrentPhase.Algorithm;
-            if (algorithm == null || !algorithm.TryQuoteIndicative(_matcher.Working, out var priceTicks, out quantity))
-                return false;
-
-            price = ToDecimal(priceTicks);
-            return true;
-        }
-
         public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
+        {
+            var events = Handle(action);
+
+            // Last, so it reports where the action left the book rather than any state it passed
+            // through - a pre-open cancel that uncrosses the book withdraws the quote, and the
+            // opening print withdraws it after the trades it produced.
+            var quoteChange = TakeIndicativeQuoteChange();
+            if (quoteChange != null)
+                events.Add(quoteChange);
+
+            return events;
+        }
+
+        private List<OrderBookEvent> Handle(OrderBookAction action)
         {
             return action switch
             {
@@ -127,6 +112,27 @@ namespace Circus.OrderBook
                 CloseTrading => UpdateStatus(OrderBookStatus.Closed, null),
                 _ => throw new ArgumentException("Unknown order book action")
             };
+        }
+
+        // Asked of the phase's own algorithm, so a quote exists exactly when there is an auction
+        // to report one for - the start-of-day session or a volatility pause. Continuous trading
+        // declines (price-time prints at as many prices as a sweep touches, not one), as does an
+        // uncrossed book and a phase with no algorithm at all.
+        private OrderBookEvent? TakeIndicativeQuoteChange()
+        {
+            var algorithm = CurrentPhase.Algorithm;
+
+            (long PriceTicks, int Quantity)? quote = null;
+            if (algorithm != null &&
+                algorithm.TryQuoteIndicative(_matcher.Working, out var priceTicks, out var quantity))
+                quote = (priceTicks, quantity);
+
+            if (Nullable.Equals(quote, _indicativeQuote))
+                return null;
+
+            _indicativeQuote = quote;
+            return new IndicativePriceChanged(_security, Now(),
+                quote.HasValue ? (decimal?) ToDecimal(quote.Value.PriceTicks) : null, quote?.Quantity ?? 0);
         }
 
         private List<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity,
@@ -579,10 +585,12 @@ namespace Circus.OrderBook
                     order.Fill(time, quantity);
             }
 
+            var restingDisplayed = resting.DisplayedQuantity;
             FillOrder(resting);
             var restingSnapshot = resting.ToOrder();
             var restingReplenish = FinishFill(resting, time);
 
+            var aggressorDisplayed = aggressor.DisplayedQuantity;
             FillOrder(aggressor);
             var aggressorSnapshot = aggressor.ToOrder();
             var aggressorReplenish = FinishFill(aggressor, time);
@@ -591,9 +599,9 @@ namespace Circus.OrderBook
                 new[]
                 {
                     new FillOrderConfirmed(_security, time, resting.CompanyId, restingSnapshot, price, quantity,
-                        true),
+                        restingDisplayed, true),
                     new FillOrderConfirmed(_security, time, aggressor.CompanyId, aggressorSnapshot, price,
-                        quantity, false)
+                        quantity, aggressorDisplayed, false)
                 }
             ));
 
@@ -720,6 +728,4 @@ namespace Circus.OrderBook
             return orders.Select(ExpireOrder).ToList();
         }
     }
-
-    public record Level(decimal Price, int Quantity, int Count);
 }

--- a/Circus/OrderBook/OrderBookEvent.cs
+++ b/Circus/OrderBook/OrderBookEvent.cs
@@ -43,8 +43,13 @@ namespace Circus.OrderBook
             decimal? PreviousPrice, int PreviousQuantity)
         : OrderConfirmedEvent(Security, Time, CompanyId, Order);
 
+    // Quantity is what traded; PreviousDisplayedQuantity is the order's DisplayedQuantity before
+    // it did. The two differ whenever an auction sizes a fill off full remaining quantity - an
+    // iceberg can trade more than it was showing, and comes out of it displaying a fresh peak
+    // rather than what is left of the old one. A level aggregate must move by the change in
+    // displayed size, not by the traded quantity.
     public record FillOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order, decimal Price,
-            int Quantity, bool IsResting)
+            int Quantity, int PreviousDisplayedQuantity, bool IsResting)
         : OrderConfirmedEvent(Security, Time, CompanyId, Order);
 
     public record OrderRejectedEvent(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
@@ -68,5 +73,14 @@ namespace Circus.OrderBook
 
     public record OrdersMatched(Security Security, DateTime Time, decimal Price, int Quantity,
             IList<FillOrderConfirmed> Fills)
+        : OrderBookEvent(Security, Time);
+
+    // The price and quantity the current phase would print if it ended right now - an auction's
+    // indicative quote, published as it moves rather than answered on request, so a consumer's
+    // view of it follows from the event stream alone. Emitted only on a change, which makes a
+    // null Price (with Quantity 0) the withdrawal of a quote previously published: the book has
+    // stopped crossing, or the phase quoting it has ended. A phase that trades continuously has
+    // no such price and so publishes none.
+    public record IndicativePriceChanged(Security Security, DateTime Time, decimal? Price, int Quantity)
         : OrderBookEvent(Security, Time);
 }


### PR DESCRIPTION
The book stops answering questions about itself. GetLevels and
TryGetIndicativeAuctionPrice are gone from IOrderBook; what they
reported now arrives on the event stream, so a consumer's view of the
book - levels, trades, the auction quote - follows from the events alone
rather than from a query that only the process holding the book can make.

InMemoryOrderBook emits IndicativePriceChanged at the end of every
Process, and only when the quote has moved. A null price withdraws one
previously published: the book stopped crossing, or the phase quoting it
ended. The quote comes from the phase's own algorithm, so it exists
exactly where an auction does - pre-open and a volatility pause - and
continuous trading publishes none. IndicativePriceDataProducer turns
that into IndicativePriceDataEvent alongside the trade, level and
full-book producers.

Fills now carry PreviousDisplayedQuantity, since a level aggregate has to
move by the change in displayed size rather than by what traded: an
auction sizes its print off full remaining quantity, so an iceberg can
trade straight through its peak into the reserve and come out still
showing a full one. LevelDataProducer used to subtract the traded
quantity there and drive the level negative.

The simulator rebuilds the touch from its shadow book's events like any
other consumer, and the tests do the same through LevelTrackingOrderBook.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe