### PR TITLE
Support more than one trading session per day

### DIFF
--- a/Circus.Examples/OrderBookExample.cs
+++ b/Circus.Examples/OrderBookExample.cs
@@ -21,7 +21,8 @@ namespace Circus.Examples
             var open = new TimeSpan(1, 10, 0);
             var close = new TimeSpan(22, 10, 0);
             var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Changed += (_, args) => book.UpdateStatus(args.Status);
+            sessionProvider.Changed += (_, args) =>
+                book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
             sessionProvider.Update(new DateTime(2020, 1, 1, 1, 30, 0));
 
             Print(book.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
@@ -42,7 +43,7 @@ namespace Circus.Examples
             sessionProvider.Changed += (_, args) =>
             {
                 timeProvider.SetCurrentTime(args.Time);
-                book.UpdateStatus(args.Status);
+                book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
             };
 
             // loop through data
@@ -71,7 +72,8 @@ namespace Circus.Examples
             var open = new TimeSpan(1, 10, 0);
             var close = new TimeSpan(22, 10, 0);
             var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Changed += (_, args) => book.UpdateStatus(args.Status);
+            sessionProvider.Changed += (_, args) =>
+                book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
             Task.Run(() =>
             {
                 var i = 0;

--- a/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Linq;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // A trading day can hold more than one session. Sequence numbers are seeded from the date, so
+    // the thing to prove is that a second session on the same date carries on issuing ids rather
+    // than restarting - orders surviving the break still hold the ids a restart would hand out
+    // again, and both _orders and _completedOrders are keyed on exactly those.
+    [TestFixture]
+    public class InMemoryOrderBookMultipleSessionsTests
+    {
+        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+        private static readonly DateTime MorningSession = new(2000, 1, 1, 9, 0, 0);
+        private static readonly DateTime AfternoonSession = new(2000, 1, 1, 14, 0, 0);
+        private static readonly DateTime NextDay = new(2000, 1, 2, 9, 0, 0);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+
+        private static readonly string OrderId1 = "Order1";
+        private static readonly string OrderId2 = "Order2";
+        private static readonly string OrderId3 = "Order3";
+        private static readonly string OrderId4 = "Order4";
+
+        private TestTimeProvider TimeProvider;
+        private IOrderBook Book;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(MorningSession);
+            Book = new InMemoryOrderBook(Sec, TimeProvider);
+        }
+
+        // The seed InMemoryOrderBook derives from a date, so a test can say which run of ids it
+        // expects without hard-coding an 18-digit literal.
+        private static long SeedFor(DateTime date) =>
+            ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
+
+        private static long ExchangeOrderIdOf(IOrderBook book, string companyId, string clientOrderId,
+            OrderValidity validity, Side side, int quantity, decimal price)
+        {
+            var events = book.CreateLimitOrder(companyId, clientOrderId, validity, side, quantity, price);
+            var created = events.OfType<CreateOrderConfirmed>().Single();
+            return long.Parse(created.Order.ExchangeOrderId);
+        }
+
+        [Test]
+        public void TwoSessionsSameDay_SurvivingGoodTilCanceledOrder_NoIdCollision()
+        {
+            // arrange - a GTC order rests through the morning session and survives the break, so it
+            // still holds its id when the afternoon session starts
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var morningId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
+                Side.Buy, 5, 100);
+            Book.CloseTrading(endsTradingDay: false);
+
+            // act - the same date, so the seed is one the counter has already passed
+            TimeProvider.SetCurrentTime(AfternoonSession);
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var afternoonId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
+                Side.Buy, 5, 90);
+
+            // assert
+            Assert.IsTrue(afternoonId > morningId, "the afternoon session continues the morning's run of ids");
+            Assert.AreEqual(SeedFor(MorningSession) + 1, morningId);
+            Assert.AreEqual(SeedFor(MorningSession) + 2, afternoonId);
+        }
+
+        [Test]
+        public void TwoSessionsSameDay_CompletedOrderIdsNotReissued()
+        {
+            // arrange - both morning orders fill completely, so they leave the working book and are
+            // held as completed under their ids
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+            Book.CloseTrading(endsTradingDay: false);
+
+            // act
+            TimeProvider.SetCurrentTime(AfternoonSession);
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 100);
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+            // assert - the afternoon pair traded rather than colliding with the morning pair's ids
+            var matched = events.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(100, matched.Price);
+            Assert.AreEqual(5, matched.Quantity);
+        }
+
+        [Test]
+        public void PreOpenTwice_SameDay_DoesNotRestartSequenceNumbers()
+        {
+            // arrange - re-entering pre-open without an intervening close (as reopening a volatility
+            // pause does) must not look like the start of a fresh run of ids either
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            var first = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
+                Side.Buy, 5, 100);
+
+            // act
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            var second = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
+                Side.Buy, 5, 90);
+
+            // assert
+            Assert.IsTrue(second > first);
+        }
+
+        [Test]
+        public void NewDay_SeedsFromDate()
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var day1Id = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
+                Side.Buy, 5, 100);
+            Book.CloseTrading();
+
+            // act
+            TimeProvider.SetCurrentTime(NextDay);
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var day2Id = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
+                Side.Buy, 5, 90);
+
+            // assert - a new date still re-anchors, so an id carries the day it was issued
+            Assert.AreEqual(SeedFor(MorningSession) + 1, day1Id);
+            Assert.AreEqual(SeedFor(NextDay) + 1, day2Id);
+        }
+
+        [Test]
+        public void IntradayClose_DayOrderSurvives()
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+
+            // act - closing for a break, with a session still to come today
+            var events = Book.CloseTrading(endsTradingDay: false);
+
+            // assert
+            Assert.AreEqual(1, events.Count);
+            Assert.IsInstanceOf<StatusChanged>(events[0]);
+            Assert.AreEqual(0, events.OfType<ExpireOrderConfirmed>().Count(), "a break does not retire day orders");
+        }
+
+        [Test]
+        public void IntradayClose_DayOrderStillTradesInTheNextSession()
+        {
+            // arrange - the surviving order has to be genuinely resting, not merely unexpired
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.CloseTrading(endsTradingDay: false);
+
+            TimeProvider.SetCurrentTime(AfternoonSession);
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+            // assert
+            var matched = events.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(100, matched.Price);
+            Assert.AreEqual(5, matched.Quantity);
+        }
+
+        [Test]
+        public void FinalClose_DayOrderExpires()
+        {
+            // arrange - survives the break, then meets the close that ends the day
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.CloseTrading(endsTradingDay: false);
+
+            TimeProvider.SetCurrentTime(AfternoonSession);
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            var events = Book.CloseTrading();
+
+            // assert
+            var expired = events.OfType<ExpireOrderConfirmed>().Single();
+            Assert.AreEqual(AfternoonSession, expired.Time);
+            Assert.AreEqual(CompanyId1, expired.CompanyId);
+            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+        }
+
+        [Test]
+        public void IntradayClose_GoodTilDateOrderDueToday_SurvivesUntilFinalClose()
+        {
+            // arrange - good til today, so the day's last close is what retires it
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var goodTilDate = DateOnly.FromDateTime(MorningSession);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate {Date = goodTilDate},
+                Side.Buy, 5, 100);
+
+            // act
+            var breakEvents = Book.CloseTrading(endsTradingDay: false);
+
+            TimeProvider.SetCurrentTime(AfternoonSession);
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var closeEvents = Book.CloseTrading();
+
+            // assert
+            Assert.AreEqual(0, breakEvents.OfType<ExpireOrderConfirmed>().Count(),
+                "not due until the day actually ends");
+
+            var expired = closeEvents.OfType<ExpireOrderConfirmed>().Single();
+            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+        }
+
+        [Test]
+        public void GoodTilCanceledOrder_SurvivesFinalCloseToo()
+        {
+            // arrange - the day ending retires day orders, never a GTC one
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
+
+            // act
+            var events = Book.CloseTrading();
+
+            // assert
+            Assert.AreEqual(1, events.Count);
+            Assert.IsInstanceOf<StatusChanged>(events[0]);
+        }
+    }
+}

--- a/Circus.Tests/SessionProviderTests.cs
+++ b/Circus.Tests/SessionProviderTests.cs
@@ -277,6 +277,221 @@ namespace Circus.Tests
             Assert.AreEqual(now2.Date.Add(open), statuses[2].Time);
         }
 
+        // A day with a morning and an afternoon session, closing for a break in between.
+        private static readonly TradingSession Morning =
+            new(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(11, 0, 0));
+
+        private static readonly TradingSession Afternoon =
+            new(new TimeSpan(13, 0, 0), new TimeSpan(13, 30, 0), new TimeSpan(16, 0, 0));
+
+        private static SessionProvider TwoSessionProvider() =>
+            new(new[] {Morning, Afternoon});
+
+        [Test]
+        public void Constructor_NoSessions_ArgumentException()
+        {
+            // assert
+            Assert.Catch<ArgumentException>(
+                () => new SessionProvider(Array.Empty<TradingSession>())
+            );
+        }
+
+        [Test]
+        public void Constructor_OverlappingSessions_ArgumentException()
+        {
+            // arrange - the afternoon pre-opens before the morning has closed
+            var overlapping = new TradingSession(new TimeSpan(10, 0, 0), new TimeSpan(13, 30, 0),
+                new TimeSpan(16, 0, 0));
+
+            // assert
+            Assert.Catch<ArgumentException>(
+                () => new SessionProvider(new[] {Morning, overlapping})
+            );
+        }
+
+        [Test]
+        public void Constructor_UnorderedSessions_ArgumentException()
+        {
+            // assert
+            Assert.Catch<ArgumentException>(
+                () => new SessionProvider(new[] {Afternoon, Morning})
+            );
+        }
+
+        [Test]
+        public void Constructor_TouchingSessions_Success()
+        {
+            // arrange - a session may begin the moment the previous one closes
+            var touching = new TradingSession(new TimeSpan(11, 0, 0), new TimeSpan(11, 30, 0),
+                new TimeSpan(16, 0, 0));
+
+            // assert
+            new SessionProvider(new[] {Morning, touching});
+        }
+
+        [Test]
+        public void Update_TwoSessions_FullDayCycle()
+        {
+            // arrange
+            var sessionProvider = TwoSessionProvider();
+
+            var statuses = new List<SessionStatusChangedArgs>();
+            sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+            var day = new DateTime(2000, 1, 1);
+
+            // act - walk the whole day past the last close
+            sessionProvider.Update(day.Add(new TimeSpan(7, 0, 0)));
+            sessionProvider.Update(day.Add(new TimeSpan(8, 30, 0)));
+            sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
+            sessionProvider.Update(day.Add(new TimeSpan(13, 30, 0)));
+            sessionProvider.Update(day.Add(new TimeSpan(16, 0, 0)));
+
+            // assert
+            Assert.AreEqual(7, statuses.Count);
+
+            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+
+            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+            Assert.AreEqual(day.Add(Morning.PreOpen), statuses[1].Time);
+            Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
+            Assert.AreEqual(day.Add(Morning.Open), statuses[2].Time);
+            Assert.AreEqual(OrderBookStatus.Closed, statuses[3].Status);
+            Assert.AreEqual(day.Add(Morning.Close), statuses[3].Time);
+
+            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[4].Status);
+            Assert.AreEqual(day.Add(Afternoon.PreOpen), statuses[4].Time);
+            Assert.AreEqual(OrderBookStatus.Open, statuses[5].Status);
+            Assert.AreEqual(day.Add(Afternoon.Open), statuses[5].Time);
+            Assert.AreEqual(OrderBookStatus.Closed, statuses[6].Status);
+            Assert.AreEqual(day.Add(Afternoon.Close), statuses[6].Time);
+        }
+
+        [Test]
+        public void Update_IntradayClose_DoesNotEndTradingDay()
+        {
+            // arrange
+            var sessionProvider = TwoSessionProvider();
+            var day = new DateTime(2000, 1, 1);
+            sessionProvider.Update(day.Add(new TimeSpan(8, 30, 0)));
+
+            var statuses = new List<SessionStatusChangedArgs>();
+            sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+            // act
+            sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
+
+            // assert - the afternoon is still to come, so day orders must survive this close
+            Assert.AreEqual(1, statuses.Count);
+            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+            Assert.IsFalse(statuses[0].EndsTradingDay);
+        }
+
+        [Test]
+        public void Update_FinalClose_EndsTradingDay()
+        {
+            // arrange
+            var sessionProvider = TwoSessionProvider();
+            var day = new DateTime(2000, 1, 1);
+            sessionProvider.Update(day.Add(new TimeSpan(13, 30, 0)));
+
+            var statuses = new List<SessionStatusChangedArgs>();
+            sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+            // act
+            sessionProvider.Update(day.Add(new TimeSpan(16, 0, 0)));
+
+            // assert
+            Assert.AreEqual(1, statuses.Count);
+            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+            Assert.IsTrue(statuses[0].EndsTradingDay);
+        }
+
+        [Test]
+        public void Update_SingleSession_CloseEndsTradingDay()
+        {
+            // arrange - a lone session is also the day's last
+            var sessionProvider = new SessionProvider(new TimeSpan(1, 0, 0), new TimeSpan(1, 10, 0),
+                new TimeSpan(22, 10, 0));
+            sessionProvider.Update(new DateTime(2000, 1, 1, 1, 10, 0));
+
+            var statuses = new List<SessionStatusChangedArgs>();
+            sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+            // act
+            sessionProvider.Update(new DateTime(2000, 1, 1, 22, 10, 0));
+
+            // assert
+            Assert.AreEqual(1, statuses.Count);
+            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+            Assert.IsTrue(statuses[0].EndsTradingDay);
+        }
+
+        [Test]
+        public void Update_BetweenSessions_StaysClosed()
+        {
+            // arrange
+            var sessionProvider = TwoSessionProvider();
+            var day = new DateTime(2000, 1, 1);
+            sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
+
+            var statuses = new List<SessionStatusChangedArgs>();
+            sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+            // act - the middle of the break
+            sessionProvider.Update(day.Add(new TimeSpan(12, 0, 0)));
+
+            // assert - nothing happens until the afternoon pre-opens
+            Assert.AreEqual(0, statuses.Count);
+        }
+
+        [Test]
+        public void Update_CatchUpIntoSecondSession_SkipsStraightToOpen()
+        {
+            // arrange - the first Update lands mid-afternoon, having missed the whole morning
+            var sessionProvider = TwoSessionProvider();
+
+            var statuses = new List<SessionStatusChangedArgs>();
+            sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+            var now = new DateTime(2000, 1, 1, 14, 0, 0);
+
+            // act
+            sessionProvider.Update(now);
+
+            // assert - the session in progress wins; the morning is not replayed
+            Assert.AreEqual(3, statuses.Count);
+            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+            Assert.AreEqual(now.Date.Add(Afternoon.PreOpen), statuses[1].Time);
+            Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
+            Assert.AreEqual(now.Date.Add(Afternoon.Open), statuses[2].Time);
+        }
+
+        [Test]
+        public void Update_TwoSessions_NextDay_WrapsToFirstSession()
+        {
+            // arrange - closed after the afternoon of day 1
+            var sessionProvider = TwoSessionProvider();
+            var day1 = new DateTime(2000, 1, 1);
+            sessionProvider.Update(day1.Add(new TimeSpan(16, 0, 0)));
+
+            var statuses = new List<SessionStatusChangedArgs>();
+            sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+            var day2 = new DateTime(2000, 1, 2);
+
+            // act
+            sessionProvider.Update(day2.Add(new TimeSpan(8, 30, 0)));
+
+            // assert - day 2 begins with the morning session again
+            Assert.AreEqual(2, statuses.Count);
+            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[0].Status);
+            Assert.AreEqual(day2.Add(Morning.PreOpen), statuses[0].Time);
+            Assert.AreEqual(OrderBookStatus.Open, statuses[1].Status);
+            Assert.AreEqual(day2.Add(Morning.Open), statuses[1].Time);
+        }
+
         [Test]
         public void Update_OpenTwoDaysLater_SkipsEmptyDay()
         {

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -109,7 +109,7 @@ namespace Circus.OrderBook
                 CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId),
                 PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice),
                 OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice),
-                CloseTrading => UpdateStatus(OrderBookStatus.Closed, null),
+                CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay),
                 _ => throw new ArgumentException("Unknown order book action")
             };
         }
@@ -677,7 +677,11 @@ namespace Circus.OrderBook
             }
         }
 
-        private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null)
+        // endsTradingDay qualifies a close: several sessions can share one trading day, and only the
+        // last of them ends it. The phase table stays the authority on whether a phase expires day
+        // orders at all - this only says whether this particular close is that day's last.
+        private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null,
+            bool endsTradingDay = true)
         {
             if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
             {
@@ -696,9 +700,16 @@ namespace Circus.OrderBook
 
             if (arriving.StartsSession)
             {
-                // TODO: need better system for multiple sessions per day
+                // Seeded from the date so an id carries the day it was issued, but only ever
+                // forwards: a second session on the same date computes a seed the counter has
+                // already passed and so continues from where it was. Restarting it would re-issue
+                // ids that orders surviving the previous session (GTC, or GTD not yet due) still
+                // hold, and _orders/_completedOrders are keyed on exactly that. Math.Max is also
+                // what keeps a replay whose clock moves backwards from colliding - a run of ids
+                // that no longer encodes its date beats one that repeats itself.
                 var date = Now();
-                _nextSequenceNumber = ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
+                var seed = ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
+                _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
             }
 
             var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
@@ -712,7 +723,7 @@ namespace Circus.OrderBook
             // Then trading continues under whatever governs the phase just entered.
             Match(events);
 
-            if (arriving.ExpiresDayOrders)
+            if (arriving.ExpiresDayOrders && endsTradingDay)
                 events.AddRange(ExpireOrders());
 
             return events;

--- a/Circus/OrderBook/OrderBookAction.cs
+++ b/Circus/OrderBook/OrderBookAction.cs
@@ -15,7 +15,13 @@ namespace Circus.OrderBook
         public decimal? ReferencePrice { get; init; }
     }
 
-    public sealed record CloseTrading : OrderBookAction;
+    // A trading day can hold several sessions, and only the last close of the day retires that
+    // day's Day/GoodTilDate orders - an intra-day close (a lunch break, say) leaves them resting.
+    // Defaults to true so a single-session day needs to say nothing.
+    public sealed record CloseTrading : OrderBookAction
+    {
+        public bool EndsTradingDay { get; init; } = true;
+    }
 
     public abstract record OrderAction : OrderBookAction
     {

--- a/Circus/OrderBook/OrderBookExtensions.cs
+++ b/Circus/OrderBook/OrderBookExtensions.cs
@@ -102,20 +102,21 @@ namespace Circus.OrderBook
             decimal? referencePrice = null) =>
             book.Process(new OpenTrading { Security = book.Security, ReferencePrice = referencePrice });
 
-        public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book) =>
-            book.Process(new CloseTrading { Security = book.Security });
+        public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book, bool endsTradingDay = true) =>
+            book.Process(new CloseTrading { Security = book.Security, EndsTradingDay = endsTradingDay });
 
         // Bridge for callers that only know the target status at runtime (e.g. a session/schedule
         // provider driving the book off a clock) and so can't pick PreOpenTrading/OpenTrading/
         // CloseTrading directly. ReferencePrice is ignored when closing - CloseTrading has no such
-        // property, since a reference price is meaningless once the book stops accepting orders.
+        // property, since a reference price is meaningless once the book stops accepting orders -
+        // and endsTradingDay is ignored for the two opening statuses, which end nothing.
         public static IReadOnlyList<OrderBookEvent> UpdateStatus(this IOrderBook book, OrderBookStatus status,
-            decimal? referencePrice = null) =>
+            decimal? referencePrice = null, bool endsTradingDay = true) =>
             status switch
             {
                 OrderBookStatus.PreOpen => book.PreOpenTrading(referencePrice),
                 OrderBookStatus.Open => book.OpenTrading(referencePrice),
-                OrderBookStatus.Closed => book.CloseTrading(),
+                OrderBookStatus.Closed => book.CloseTrading(endsTradingDay),
                 _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
             };
     }

--- a/Circus/SessionProviders/ISessionProvider.cs
+++ b/Circus/SessionProviders/ISessionProvider.cs
@@ -10,5 +10,8 @@ namespace Circus.SessionProviders
         void Update(DateTime current);
     }
 
-    public record SessionStatusChangedArgs(OrderBookStatus Status, DateTime Time);
+    // EndsTradingDay is meaningful only when Status is Closed: false for a session closing with
+    // another still to come the same day, so a consumer can forward it to the book and leave Day
+    // orders resting across the break. True (the default) for every other status, which ends nothing.
+    public record SessionStatusChangedArgs(OrderBookStatus Status, DateTime Time, bool EndsTradingDay = true);
 }

--- a/Circus/SessionProviders/SessionProvider.cs
+++ b/Circus/SessionProviders/SessionProvider.cs
@@ -1,28 +1,51 @@
 using System;
+using System.Collections.Generic;
 using Circus.OrderBook;
 
 namespace Circus.SessionProviders
 {
+    // Drives an order book's status off a clock, given a day's schedule. Update() is pushed the
+    // current time and fires whatever boundaries have been passed since it was last called, so a
+    // caller that goes quiet for a day catches up rather than replaying every boundary it missed.
     public class SessionProvider : ISessionProvider
     {
-        private readonly TimeSpan _preOpenTime;
-        private readonly TimeSpan _openTime;
-        private readonly TimeSpan _closeTime;
+        private readonly IReadOnlyList<TradingSession> _sessions;
         public event EventHandler<SessionStatusChangedArgs>? Changed;
 
         private OrderBookStatus? _status;
 
+        // The session the current (or upcoming) PreOpen/Open/Closed run belongs to. Resolved when
+        // leaving Closed, then reused for that session's open and close.
+        private int _sessionIndex;
+        private int _nextSessionIndex;
+
         private DateTime _nextTime;
         private OrderBookStatus _nextStatus;
+        private bool _nextEndsTradingDay = true;
 
+        // A single continuous session, the common case.
         public SessionProvider(TimeSpan preOpenTime, TimeSpan openTime, TimeSpan closeTime)
+            : this(new[] {new TradingSession(preOpenTime, openTime, closeTime)})
         {
-            if (preOpenTime > openTime) throw new ArgumentException("pre-open must be before open");
-            if (openTime > closeTime) throw new ArgumentException("open must be before close");
+        }
 
-            _preOpenTime = preOpenTime;
-            _openTime = openTime;
-            _closeTime = closeTime;
+        public SessionProvider(IReadOnlyList<TradingSession> sessions)
+        {
+            if (sessions.Count == 0) throw new ArgumentException("at least one session is required");
+
+            for (var i = 0; i < sessions.Count; i++)
+            {
+                var session = sessions[i];
+                if (session.PreOpen > session.Open) throw new ArgumentException("pre-open must be before open");
+                if (session.Open > session.Close) throw new ArgumentException("open must be before close");
+
+                // Ordered and non-overlapping in one check: a session may begin the moment the
+                // previous one closes, but not before.
+                if (i > 0 && session.PreOpen < sessions[i - 1].Close)
+                    throw new ArgumentException("sessions must be ordered and must not overlap");
+            }
+
+            _sessions = sessions;
         }
 
         public void Update(DateTime time)
@@ -31,44 +54,70 @@ namespace Circus.SessionProviders
             {
                 _status = OrderBookStatus.Closed;
                 Changed?.Invoke(this, new SessionStatusChangedArgs(_status.Value, time));
-                Console.WriteLine(time + ": " + _status);
                 SetNextTime(time);
             }
 
             while (time >= _nextTime)
             {
                 _status = _nextStatus;
-                Changed?.Invoke(this, new SessionStatusChangedArgs(_status.Value, _nextTime));
-                Console.WriteLine(time + ": " + _status);
+                if (_nextStatus == OrderBookStatus.PreOpen)
+                    _sessionIndex = _nextSessionIndex;
+
+                Changed?.Invoke(this, new SessionStatusChangedArgs(_status.Value, _nextTime, _nextEndsTradingDay));
                 SetNextTime(time);
             }
         }
 
+        // Every boundary is anchored on the caller's own date rather than walked forward from the
+        // last one, which is what lets an idle day be skipped instead of replayed.
         private void SetNextTime(DateTime time)
         {
+            _nextEndsTradingDay = true;
+
             switch (_status)
             {
                 case OrderBookStatus.Closed:
                 {
+                    var (index, dayOffset) = ResolveNextSession(time.TimeOfDay);
+                    _nextSessionIndex = index;
                     _nextStatus = OrderBookStatus.PreOpen;
-                    _nextTime = time.Date.Add(_preOpenTime);
-
-                    if (time.TimeOfDay >= _closeTime)
-                    {
-                        _nextTime = _nextTime.AddDays(1);
-                    }
-
+                    _nextTime = time.Date.AddDays(dayOffset).Add(_sessions[index].PreOpen);
                     break;
                 }
                 case OrderBookStatus.PreOpen:
                     _nextStatus = OrderBookStatus.Open;
-                    _nextTime = time.Date.Add(_openTime);
+                    _nextTime = time.Date.Add(_sessions[_sessionIndex].Open);
                     break;
                 default:
                     _nextStatus = OrderBookStatus.Closed;
-                    _nextTime = time.Date.Add(_closeTime);
+                    _nextTime = time.Date.Add(_sessions[_sessionIndex].Close);
+
+                    // Only the day's last session ends the trading day; closing for a break leaves
+                    // Day orders resting for the session still to come.
+                    _nextEndsTradingDay = _sessionIndex == _sessions.Count - 1;
                     break;
             }
+        }
+
+        // Which session to head for from Closed, and whether it falls on the next day. A session
+        // already in progress wins, so a provider started (or woken) mid-session catches up into
+        // it rather than waiting for the next one.
+        private (int Index, int DayOffset) ResolveNextSession(TimeSpan timeOfDay)
+        {
+            for (var i = 0; i < _sessions.Count; i++)
+            {
+                if (timeOfDay >= _sessions[i].PreOpen && timeOfDay < _sessions[i].Close)
+                    return (i, 0);
+            }
+
+            for (var i = 0; i < _sessions.Count; i++)
+            {
+                if (_sessions[i].PreOpen > timeOfDay)
+                    return (i, 0);
+            }
+
+            // Past the last close of the day - start again with tomorrow's first session.
+            return (0, 1);
         }
     }
 }

--- a/Circus/SessionProviders/TradingSession.cs
+++ b/Circus/SessionProviders/TradingSession.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Circus.SessionProviders
+{
+    // One session's boundaries as times of day. A day's schedule is an ordered, non-overlapping
+    // list of these - a single continuous session for most products, two or more for one that
+    // breaks (a lunch recess, a separate evening session).
+    //
+    // All three times fall within the same day, so a session cannot span midnight. An overnight
+    // product would need boundaries that carry a day offset, which nothing here models yet.
+    public record TradingSession(TimeSpan PreOpen, TimeSpan Open, TimeSpan Close);
+}

--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ Time in force/order validity
 Sessions
 - [x] Time provider
 - [x] Sessions
+- [x] Multiple sessions per day
 - [ ] Market statistics
 
 Market data


### PR DESCRIPTION
Resolves the `// TODO: need better system for multiple sessions per day` in `InMemoryOrderBook`, and generalises `SessionProvider` to schedule a day with more than one session.

## The bug

Sequence numbers were reseeded to `yyyyMMdd * 10^10` on every phase with `StartsSession`. A second pre-open on the same date reseeded to the *same* base and re-issued ids the first session had already handed out — a hard failure, not a cosmetic one:

- an order surviving the break (GTC, or GTD not yet due) is still in `_orders` under its id, so the next `_orders.Add` throws `ArgumentException`;
- even with no survivors, session 1's order sits in `_completedOrders`, so `CompleteOrder` throws on the same duplicate key.

`ExchangeOrderId` is `SequenceNumber.ToString()`, so colliding ids would also put two live orders on one public identity and corrupt any `FullBookDataProducer` mirror.

It went unnoticed because only the `PreOpen` phase starts a session, and almost everything — the test suite, the benchmark, the simulator — drives the book `Closed → Open` directly, which never reseeded.

## Changes

**Seed forward, never restart.** A new date's seed is above the running counter and wins; a second session on the same date computes a seed the counter has already passed, so it continues from where it was. `ExchangeOrderId` keeps its `yyyyMMdd`+10-digit shape. The `Math.Max` also stops a replay whose clock moves backwards from colliding.

**A close that doesn't end the trading day.** `CloseTrading` gains `EndsTradingDay`, defaulting to `true` so a single-session day is unchanged. The phase table stays the authority on whether a phase expires day orders; the flag says whether *this* close is the day's last. A Day order now survives a lunch break and expires at the afternoon close.

**`SessionProvider` takes a schedule.** New `TradingSession(PreOpen, Open, Close)` record; the provider takes an ordered, non-overlapping list of them, keeping the existing three-argument constructor as the single-session case so the public API and every existing test are untouched. It tracks which session a `PreOpen/Open/Closed` run belongs to and reports `EndsTradingDay` on the day's last close only. Boundaries are still anchored on the caller's own date, which is what lets an idle day be skipped rather than replayed. Sessions spanning midnight remain unsupported, as before.

Also drops the two `Console.WriteLine` calls `SessionProvider` made from library code.

## Tests

New `InMemoryOrderBookMultipleSessionsTests` covers the collision regression (both the surviving-order and completed-order paths), re-entering pre-open without a close, the date still anchoring a new day's ids, and Day/GTD orders surviving an intra-day close but expiring at the final one.

`SessionProviderTests` gains schedule validation (empty, overlapping, unordered, touching), a full two-session day, the gap between sessions, `EndsTradingDay` on both kinds of close, catching up into a session already in progress, and the wrap to the next day's first session.

## Verification

**I could not build or run the tests locally** — this environment has no .NET SDK, and the install host (`builds.dotnet.microsoft.com`) is blocked by the sandbox network policy. The changes were written against the existing code and traced by hand, including each existing `SessionProviderTests` case against the new state machine, but CI is the first actual execution. Worth a close look at the test results rather than assuming green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_