### PR TITLE
Give a pause and a halt statuses of their own

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -299,8 +299,8 @@ namespace Circus.Tests.OrderBook
             Assert.IsInstanceOf<OrdersMatched>(crossing[^1]);
             Assert.IsEmpty(crossing.OfType<IndicativePriceChanged>().ToList());
 
-            // ...and it comes back the moment a volatility pause returns the book to PreOpen
-            book.UpdateStatus(OrderBookStatus.PreOpen);
+            // ...and it comes back the moment a volatility pause interrupts trading
+            book.UpdateStatus(OrderBookStatus.Paused);
             var paused = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 10, 100);
 
             var quote = paused.OfType<IndicativePriceChanged>().Last();
@@ -398,8 +398,8 @@ namespace Circus.Tests.OrderBook
             // assert
             Assert.AreEqual(3, events.Count);
             Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.AreEqual(OrderBookStatus.PreOpen, ((StatusChanged) events[1]).Status);
-            Assert.AreEqual(OrderBookStatus.PreOpen, book.Status);
+            Assert.AreEqual(OrderBookStatus.Paused, ((StatusChanged) events[1]).Status);
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
 
             // the pause is an auction, and it quotes the crossed book it inherited rather than
             // printing it

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
@@ -20,11 +20,9 @@ namespace Circus.Tests.OrderBook
 
         private static readonly string CompanyId1 = "Company1";
         private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
 
         private static readonly string OrderId1 = "Order1";
         private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
         private static readonly string CancelId1 = "Cancel1";
 
         private TestTimeProvider TimeProvider;

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Linq;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // Paused and Halted are both interruptions within a session, so neither may behave like the
+    // start of one (PreOpen) or the end of one (Closed). What separates the two from each other is
+    // price discovery: a pause keeps quoting and resolves into a print, a halt publishes nothing.
+    [TestFixture]
+    public class InMemoryOrderBookPausedHaltedTests
+    {
+        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+        private static readonly DateTime NextDay = new(2000, 1, 2, 12, 0, 0);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+        private static readonly string CompanyId3 = "Company3";
+
+        private static readonly string OrderId1 = "Order1";
+        private static readonly string OrderId2 = "Order2";
+        private static readonly string OrderId3 = "Order3";
+        private static readonly string CancelId1 = "Cancel1";
+
+        private TestTimeProvider TimeProvider;
+        private IOrderBook Book;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+            Book = new InMemoryOrderBook(Sec, TimeProvider);
+        }
+
+        [TestCase(OrderBookStatus.Paused)]
+        [TestCase(OrderBookStatus.Halted)]
+        public void UpdateStatus_ReachesTheNewStatuses(OrderBookStatus status)
+        {
+            // act
+            var events = Book.UpdateStatus(status);
+
+            // assert
+            Assert.AreEqual(1, events.Count);
+            var statusChanged = events[0] as StatusChanged;
+            Assert.IsNotNull(statusChanged);
+            Assert.AreEqual(status, statusChanged.Status);
+            Assert.AreEqual(Now1, statusChanged.Time);
+            Assert.AreEqual(status, Book.Status);
+        }
+
+        [TestCase(OrderBookStatus.Paused)]
+        [TestCase(OrderBookStatus.Halted)]
+        public void OrderActionsStillAccepted(OrderBookStatus status)
+        {
+            // arrange - resting from before the interruption
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.UpdateStatus(status);
+
+            // act - an interruption is not a close, so positions stay manageable
+            var created = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 90);
+            var cancelled = Book.CancelOrder(CompanyId1, CancelId1, OrderId1);
+
+            // assert
+            Assert.IsInstanceOf<CreateOrderConfirmed>(created[0]);
+            Assert.IsInstanceOf<CancelOrderConfirmed>(cancelled[0]);
+        }
+
+        [TestCase(OrderBookStatus.Paused)]
+        [TestCase(OrderBookStatus.Halted)]
+        public void MarketOrdersRejected(OrderBookStatus status)
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+            Book.UpdateStatus(status);
+
+            // act - nothing is trading, so there is no book to price a market order against
+            var events = Book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5);
+
+            // assert
+            var rejected = events[0] as CreateOrderRejected;
+            Assert.IsNotNull(rejected);
+        }
+
+        [TestCase(OrderBookStatus.Paused)]
+        [TestCase(OrderBookStatus.Halted)]
+        public void DayOrdersSurvive(OrderBookStatus status)
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            TimeProvider.SetCurrentTime(Now2);
+
+            // act - only a close that ends the trading day retires day orders
+            var events = Book.UpdateStatus(status);
+
+            // assert
+            Assert.AreEqual(0, events.OfType<ExpireOrderConfirmed>().Count());
+
+            // and the order is genuinely still resting, not merely unexpired
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+            Assert.AreEqual(1, crossing.OfType<OrdersMatched>().Count());
+        }
+
+        [TestCase(OrderBookStatus.Paused)]
+        [TestCase(OrderBookStatus.Halted)]
+        public void DoesNotStartASession(OrderBookStatus status)
+        {
+            // arrange - sequence numbers are seeded from the date, and a session start on a later
+            // date jumps them to that date's run. An interruption is not a session start, so the
+            // counter must simply carry on. PreOpen on the same setup is the contrast, below.
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
+
+            // act
+            TimeProvider.SetCurrentTime(NextDay);
+            Book.UpdateStatus(status);
+            var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
+
+            // assert
+            Assert.AreEqual(beforeId + 1, afterId, "the interruption did not reseed the run of ids");
+        }
+
+        [Test]
+        public void PreOpenOnALaterDate_DoesStartASession()
+        {
+            // arrange - the contrast for DoesNotStartASession: the same steps through PreOpen, which
+            // genuinely does start one, so the ids jump to the new date's run
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            Book.UpdateStatus(OrderBookStatus.Open);
+            var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
+
+            // act
+            TimeProvider.SetCurrentTime(NextDay);
+            Book.UpdateStatus(OrderBookStatus.PreOpen);
+            var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
+
+            // assert
+            Assert.IsTrue(afterId > beforeId + 1, "a session start reseeds from the new date");
+        }
+
+        [Test]
+        public void Paused_QuotesTheCrossedBook_AndPrintsOnResuming()
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.UpdateStatus(OrderBookStatus.Paused);
+
+            // act - orders accumulate into a cross while paused
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+            var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+
+            // assert - quoted, not printed
+            var quote = crossing.OfType<IndicativePriceChanged>().Last();
+            Assert.AreEqual(100, quote.Price);
+            Assert.AreEqual(10, quote.Quantity);
+            Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count(), "a pause quotes, it does not trade");
+
+            // act - resuming resolves the accumulated book in one print
+            var resumed = Book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert
+            var matched = resumed.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(100, matched.Price);
+            Assert.AreEqual(10, matched.Quantity);
+        }
+
+        [Test]
+        public void Halted_PublishesNoQuote_AndDoesNotPrintOnResuming()
+        {
+            // arrange
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.UpdateStatus(OrderBookStatus.Halted);
+
+            // act - the same crossed book a pause would have been quoting
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+            var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+
+            // assert - withholding price discovery is what makes this a halt
+            Assert.AreEqual(0, crossing.OfType<IndicativePriceChanged>().Count());
+            Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count());
+
+            // act - no algorithm means nothing prints on the way out; the cross is resolved by
+            // continuous trading once open, not by an uncrossing auction
+            var resumed = Book.UpdateStatus(OrderBookStatus.Open);
+
+            // assert
+            var matched = resumed.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(100, matched.Price);
+            Assert.AreEqual(10, matched.Quantity);
+        }
+
+        [Test]
+        public void VolatilityBandBreach_PausesRatherThanReturningToPreOpen()
+        {
+            // arrange - a reference of 100 and a 5-tick volatility band
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10, VolatilityAuctionBandTicks: 5);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+
+            // act - the trade at 200 breaches the band
+            var events = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+            Assert.AreEqual(OrderBookStatus.Paused, events.OfType<StatusChanged>().Single().Status);
+        }
+
+        [Test]
+        public void Halted_ThenClosed_ExpiresDayOrdersAsNormal()
+        {
+            // arrange - a halt defers the day's end, it does not cancel it
+            Book.UpdateStatus(OrderBookStatus.Open);
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            Book.UpdateStatus(OrderBookStatus.Halted);
+            TimeProvider.SetCurrentTime(Now2);
+
+            // act
+            var events = Book.UpdateStatus(OrderBookStatus.Closed);
+
+            // assert
+            var expired = events.OfType<ExpireOrderConfirmed>().Single();
+            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+        }
+
+        private static long ExchangeOrderIdOf(IOrderBook book, string companyId, string clientOrderId, Side side,
+            int quantity, decimal price)
+        {
+            var events = book.CreateLimitOrder(companyId, clientOrderId, new OrderValidity.GoodTilCanceled(), side,
+                quantity, price);
+            return long.Parse(events.OfType<CreateOrderConfirmed>().Single().Order.ExchangeOrderId);
+        }
+    }
+}

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -65,7 +65,7 @@ namespace Circus.Tests.OrderBook
             Assert.IsInstanceOf<CreateOrderConfirmed>(resting[0],
                 "entry band is 1000 wide - this order is nowhere near it");
             Assert.IsInstanceOf<CreateOrderConfirmed>(crossing[0]);
-            Assert.AreEqual(OrderBookStatus.PreOpen, book.Status,
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status,
                 "the 5-tick volatility band should have paused the book on the trade");
         }
 

--- a/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
@@ -35,6 +35,8 @@ namespace Circus.Tests.OrderBook
         [TestCase(OrderBookStatus.PreOpen)]
         [TestCase(OrderBookStatus.Open)]
         [TestCase(OrderBookStatus.Closed)]
+        [TestCase(OrderBookStatus.Paused)]
+        [TestCase(OrderBookStatus.Halted)]
         public void Valid_Success(OrderBookStatus status)
         {
             // act

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -45,6 +45,26 @@ namespace Circus.OrderBook
                     OrderBookStatus.Closed,
                     new TradingPhase(null, AcceptsOrderActions: false, AcceptsMarketOrders: false,
                         MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: true)
+                },
+                {
+                    // Quotes and prints on the way out exactly as pre-open does, so a pause
+                    // resolves into a single uncrossing price rather than resuming mid-sweep. It is
+                    // an interruption within a session and not the start of one, though, so unlike
+                    // pre-open it neither reseeds sequence numbers nor retires anything.
+                    OrderBookStatus.Paused,
+                    new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                        MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: false)
+                },
+                {
+                    // No algorithm, so nothing matches and no indicative quote is published -
+                    // withholding price discovery is what makes this a halt rather than a pause.
+                    // Order actions stay open so resting positions can still be managed, and the
+                    // day's orders survive: a halt is not a close. Nothing prints on the way out
+                    // either, so a caller wanting a reopening auction goes through PreOpen or
+                    // Paused rather than straight back to Open.
+                    OrderBookStatus.Halted,
+                    new TradingPhase(null, AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                        MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: false)
                 }
             };
 
@@ -110,6 +130,8 @@ namespace Circus.OrderBook
                 PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice),
                 OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice),
                 CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay),
+                PauseTrading => UpdateStatus(OrderBookStatus.Paused),
+                HaltTrading => UpdateStatus(OrderBookStatus.Halted),
                 _ => throw new ArgumentException("Unknown order book action")
             };
         }
@@ -561,8 +583,12 @@ namespace Circus.OrderBook
                     ApplyTrade(resting, aggressor, priceTicks, quantity, usesFullRemainingQuantity, events, time);
                     break;
 
+                // Assigned directly rather than routed through UpdateStatus: this runs inside the
+                // Run/Apply loop, and UpdateStatus matches, which would re-enter the matcher
+                // mid-enumeration. The phases these land on are deliberately ones with nothing to
+                // do on arrival anyway - neither starts a session nor expires orders.
                 case TradeRestrictionBreached(_, var action):
-                    _status = action == RestrictionBreachAction.Halt ? OrderBookStatus.Closed : OrderBookStatus.PreOpen;
+                    _status = action == RestrictionBreachAction.Halt ? OrderBookStatus.Halted : OrderBookStatus.Paused;
                     events.Add(new StatusChanged(_security, Now(), _status));
                     break;
 

--- a/Circus/OrderBook/OrderBookAction.cs
+++ b/Circus/OrderBook/OrderBookAction.cs
@@ -23,6 +23,14 @@ namespace Circus.OrderBook
         public bool EndsTradingDay { get; init; } = true;
     }
 
+    // Interrupt trading within a session, keeping a quote. The book raises this itself on a
+    // volatility band breach; as an action it is the operator-driven equivalent.
+    public sealed record PauseTrading : OrderBookAction;
+
+    // Suspend trading with no price discovery. The book raises this itself when a restriction
+    // breach calls for a halt; as an action it is the operator-driven equivalent.
+    public sealed record HaltTrading : OrderBookAction;
+
     public abstract record OrderAction : OrderBookAction
     {
         public required string CompanyId { get; init; }

--- a/Circus/OrderBook/OrderBookExtensions.cs
+++ b/Circus/OrderBook/OrderBookExtensions.cs
@@ -105,11 +105,17 @@ namespace Circus.OrderBook
         public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book, bool endsTradingDay = true) =>
             book.Process(new CloseTrading { Security = book.Security, EndsTradingDay = endsTradingDay });
 
+        public static IReadOnlyList<OrderBookEvent> PauseTrading(this IOrderBook book) =>
+            book.Process(new PauseTrading { Security = book.Security });
+
+        public static IReadOnlyList<OrderBookEvent> HaltTrading(this IOrderBook book) =>
+            book.Process(new HaltTrading { Security = book.Security });
+
         // Bridge for callers that only know the target status at runtime (e.g. a session/schedule
         // provider driving the book off a clock) and so can't pick PreOpenTrading/OpenTrading/
-        // CloseTrading directly. ReferencePrice is ignored when closing - CloseTrading has no such
-        // property, since a reference price is meaningless once the book stops accepting orders -
-        // and endsTradingDay is ignored for the two opening statuses, which end nothing.
+        // CloseTrading directly. ReferencePrice is ignored for every status but the two opening
+        // ones - a reference price is meaningless once the book stops trading - and endsTradingDay
+        // applies only to closing, since nothing else ends a day.
         public static IReadOnlyList<OrderBookEvent> UpdateStatus(this IOrderBook book, OrderBookStatus status,
             decimal? referencePrice = null, bool endsTradingDay = true) =>
             status switch
@@ -117,6 +123,8 @@ namespace Circus.OrderBook
                 OrderBookStatus.PreOpen => book.PreOpenTrading(referencePrice),
                 OrderBookStatus.Open => book.OpenTrading(referencePrice),
                 OrderBookStatus.Closed => book.CloseTrading(endsTradingDay),
+                OrderBookStatus.Paused => book.PauseTrading(),
+                OrderBookStatus.Halted => book.HaltTrading(),
                 _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
             };
     }

--- a/Circus/OrderBook/OrderBookStatus.cs
+++ b/Circus/OrderBook/OrderBookStatus.cs
@@ -1,9 +1,19 @@
 namespace Circus.OrderBook
 {
+    // Appended rather than reordered, so the numeric value of an existing status never moves.
     public enum OrderBookStatus
     {
         PreOpen,
         Open,
-        Closed
+        Closed,
+
+        // Trading interrupted within a session and expected to resume: orders accumulate into an
+        // auction and a quote keeps being published, but nothing matches. What a volatility band
+        // breach moves the book to.
+        Paused,
+
+        // Trading suspended with no price discovery at all - no matching and no quote. What a
+        // circuit breaker moves the book to.
+        Halted
     }
 }


### PR DESCRIPTION
Step 2 of the price-restriction plan, and the enabling refactor for the volatility-pause, velocity and circuit-breaker work behind it.

## The problem

A volatility band breach moved the book to `PreOpen`, and a halt to `Closed` — two statuses that already mean something else. `PreOpen` carries `StartsSession: true` and `Closed` carries `ExpiresDayOrders: true`, so the phase table was describing an interruption in terms of flags that are wrong for one: a pause is not the start of a session, and a halt is not the end of a trading day.

The breach path only avoided acting on those flags by assigning `_status` directly and skipping phase-arrival work altogether. It was correct by omission rather than by description — and it left market data unable to tell a scheduled pre-open from a volatility pause, since both reported the same status.

## The change

`Paused` and `Halted` are **appended** to `OrderBookStatus`, so no existing value moves, and each gets a row in the phase table:

| | Algorithm | Order actions | Market orders | Matches | Starts session | Expires day orders |
|---|---|---|---|---|---|---|
| `Paused` | `Auction` | yes | no | no | **no** | **no** |
| `Halted` | — | yes | no | no | no | no |

`Paused` quotes and prints on the way out exactly as pre-open does, so an interruption resolves into a single uncrossing price rather than resuming mid-sweep. `Halted` carries no algorithm at all — withholding price discovery is what separates a halt from a pause, and it also means nothing prints on the way out, so a caller wanting a reopening auction routes through `PreOpen`/`Paused` rather than straight back to `Open`. Both keep accepting order actions: an interruption is not a close, and resting positions still need managing.

The breach path still assigns `_status` directly, and now says why — it runs inside the `Run`/`Apply` loop and `UpdateStatus` matches, which would re-enter the matcher mid-enumeration. The difference is that the phases it lands on now have nothing to do on arrival, so the direct assignment and the table agree instead of one covering for the other.

`PauseTrading` and `HaltTrading` actions plus extension methods make both reachable operator-driven, and the `UpdateStatus` bridge maps them for callers holding a status at runtime.

## Tests

New `InMemoryOrderBookPausedHaltedTests`, parameterised over both statuses where behaviour is shared: reachable via `UpdateStatus`, order actions still accepted, market orders rejected, day orders survive and are genuinely still resting afterwards, and neither starts a session — that last one asserted against a same-setup `PreOpen` contrast that *does* reseed the id run, so the flag difference is observable rather than assumed. Then the pair that separates them: `Paused` quotes the crossed book and prints it on resuming; `Halted` publishes nothing and leaves the cross to continuous trading.

Three existing tests changed to expect `Paused` where they previously expected `PreOpen` after a band breach — that's the intended behaviour change, not incidental churn.

## Not in this PR

- **`StatusChanged` still carries no reason.** With distinct statuses the reason is largely implied, so I left it out rather than widen scope; it comes back when circuit breakers need to distinguish *which* limit fired.
- **No timed resume.** A pause still waits for an external transition. That needs time to enter the book as an action, which is the next step.
- **`RestrictionBreachAction.Halt` remains unreachable** — no restriction returns it yet, so the `Halted` breach path is untested by construction. It lights up with circuit breakers.
- **A market order rejected while paused reports `MarketPreOpen`.** That reason name is now inaccurate for two of the four phases that refuse market orders. Fixing it means either renaming a public enum member or moving the reason into the phase table; both are more than this PR should decide, so the new test asserts the rejection without pinning the reason.

## Verification

No .NET SDK in this environment — the install host is blocked by the sandbox network policy — so CI is the first execution of this code, as with #46. Traced by hand: every status transition through `UpdateStatus`, including that `PreOpen → Paused` does *not* fire the opening print (`Match` returns early because the arriving phase isn't continuous), and that `Paused → Open` does.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_