### PR TITLE
Let an interruption end by itself

### DIFF
--- a/Circus.Tests/OrderBook/DailyPriceBandLimitTests.cs
+++ b/Circus.Tests/OrderBook/DailyPriceBandLimitTests.cs
@@ -16,12 +16,28 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
+        public void NoDurationConfigured_PauseIsOpenEnded()
+        {
+            var restriction = new DailyPriceBandLimit(5);
+
+            Assert.IsNull(restriction.ResumeAfter);
+        }
+
+        [Test]
+        public void DurationConfigured_IsWhatThePauseResumesAfter()
+        {
+            var restriction = new DailyPriceBandLimit(5, System.TimeSpan.FromMinutes(2));
+
+            Assert.AreEqual(System.TimeSpan.FromMinutes(2), restriction.ResumeAfter);
+        }
+
+        [Test]
         public void NoBandConfigured_AlwaysAllows()
         {
             var restriction = new DailyPriceBandLimit(null);
             restriction.OnSessionChange(100);
 
-            Assert.IsTrue(restriction.Allows(1_000_000));
+            Assert.IsTrue(restriction.Allows(1_000_000, default));
         }
 
         [Test]
@@ -29,7 +45,7 @@ namespace Circus.Tests.OrderBook
         {
             var restriction = new DailyPriceBandLimit(5);
 
-            Assert.IsTrue(restriction.Allows(1_000_000));
+            Assert.IsTrue(restriction.Allows(1_000_000, default));
         }
 
         [Test]
@@ -38,11 +54,11 @@ namespace Circus.Tests.OrderBook
             var restriction = new DailyPriceBandLimit(5);
             restriction.OnSessionChange(100);
 
-            Assert.IsTrue(restriction.Allows(100));
-            Assert.IsTrue(restriction.Allows(105));
-            Assert.IsTrue(restriction.Allows(95));
-            Assert.IsFalse(restriction.Allows(106));
-            Assert.IsFalse(restriction.Allows(94));
+            Assert.IsTrue(restriction.Allows(100, default));
+            Assert.IsTrue(restriction.Allows(105, default));
+            Assert.IsTrue(restriction.Allows(95, default));
+            Assert.IsFalse(restriction.Allows(106, default));
+            Assert.IsFalse(restriction.Allows(94, default));
         }
 
         [Test]
@@ -53,9 +69,9 @@ namespace Circus.Tests.OrderBook
 
             restriction.OnTrade(200, default);
 
-            Assert.IsTrue(restriction.Allows(205));
-            Assert.IsFalse(restriction.Allows(206));
-            Assert.IsFalse(restriction.Allows(100));
+            Assert.IsTrue(restriction.Allows(205, default));
+            Assert.IsFalse(restriction.Allows(206, default));
+            Assert.IsFalse(restriction.Allows(100, default));
         }
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Linq;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // An interruption that ends on its own, and the reason a consumer reads off the status change.
+    [TestFixture]
+    public class InMemoryOrderBookTimedResumeTests
+    {
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+        private static readonly string CompanyId3 = "Company3";
+
+        private static readonly string OrderId1 = "Order1";
+        private static readonly string OrderId2 = "Order2";
+        private static readonly string OrderId3 = "Order3";
+
+        private TestTimeProvider TimeProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+        }
+
+        // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it.
+        private IOrderBook PausingBook(TimeSpan? duration)
+        {
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                VolatilityAuctionBandTicks: 5, VolatilityAuctionDuration: duration);
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+            return book;
+        }
+
+        // Drives the book into a volatility pause, leaving the two orders that caused it crossed
+        // and unfilled - the trade is prevented, not executed.
+        private void Breach(IOrderBook book)
+        {
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+        }
+
+        [Test]
+        public void PauseWithDuration_ResumesOnceElapsed()
+        {
+            // arrange
+            var book = PausingBook(PauseFor);
+            Breach(book);
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+
+            // act
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            var events = book.AdvanceTime();
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+            var resumed = events.OfType<StatusChanged>().Single();
+            Assert.AreEqual(OrderBookStatus.Open, resumed.Status);
+            Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+        }
+
+        [Test]
+        public void PauseWithDuration_NotYetElapsed_StaysPaused()
+        {
+            // arrange
+            var book = PausingBook(PauseFor);
+            Breach(book);
+
+            // act - one second short
+            TimeProvider.SetCurrentTime(Now1 + PauseFor - TimeSpan.FromSeconds(1));
+            var events = book.AdvanceTime();
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+            Assert.AreEqual(0, events.Count);
+        }
+
+        [Test]
+        public void PauseWithoutDuration_StandsUntilEndedExplicitly()
+        {
+            // arrange - no duration configured, which is the older open-ended behaviour
+            var book = PausingBook(null);
+            Breach(book);
+
+            // act - however long passes
+            TimeProvider.SetCurrentTime(Now1.AddDays(1));
+            var events = book.AdvanceTime();
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+            Assert.AreEqual(0, events.Count);
+        }
+
+        [Test]
+        public void Resuming_PrintsWhatAccumulatedDuringThePause()
+        {
+            // arrange - the orders that caused the breach are still crossed and unfilled
+            var book = PausingBook(PauseFor);
+            Breach(book);
+
+            // act
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            var events = book.AdvanceTime();
+
+            // assert - the pause resolves into one uncrossing print rather than resuming mid-sweep
+            var matched = events.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(200, matched.Price);
+            Assert.AreEqual(5, matched.Quantity);
+        }
+
+        [Test]
+        public void ResumeAlsoFiresOnOrdinaryOrderFlow_NotOnlyAdvanceTime()
+        {
+            // arrange - a book being traded should not need poking to notice its pause has run out
+            var book = PausingBook(PauseFor);
+            Breach(book);
+
+            // act
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            var events = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 90);
+
+            // assert - resumed first, so the order arrived into an open book
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+            Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
+                events.OfType<StatusChanged>().Single().Reason);
+            Assert.AreEqual(1, events.OfType<CreateOrderConfirmed>().Count());
+        }
+
+        [Test]
+        public void ExplicitTransitionDuringPause_CancelsThePendingResume()
+        {
+            // arrange - the session closes while a pause is still running
+            var book = PausingBook(PauseFor);
+            Breach(book);
+            book.CloseTrading();
+
+            // act - the deadline the pause had set comes and goes
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            var events = book.AdvanceTime();
+
+            // assert - a closed book must not spring back open
+            Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+            Assert.AreEqual(0, events.Count);
+        }
+
+        [Test]
+        public void AdvanceTime_WithNothingPending_DoesNothing()
+        {
+            // arrange
+            var book = PausingBook(PauseFor);
+
+            // act
+            TimeProvider.SetCurrentTime(Now1.AddDays(1));
+            var events = book.AdvanceTime();
+
+            // assert
+            Assert.AreEqual(0, events.Count);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        }
+
+        [Test]
+        public void BreachReportsPriceRestriction_ExplicitTransitionReportsRequested()
+        {
+            // arrange
+            var book = PausingBook(PauseFor);
+
+            // act
+            var opened = book.UpdateStatus(OrderBookStatus.Open);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+            var breached = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+
+            // assert
+            Assert.AreEqual(StatusChangeReason.Requested, opened.OfType<StatusChanged>().Single().Reason);
+            Assert.AreEqual(StatusChangeReason.PriceRestriction,
+                breached.OfType<StatusChanged>().Single().Reason);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SeverestBreachWins_WhicheverOrderTheRestrictionsAreDeclaredIn(bool haltingFirst)
+        {
+            // arrange - two trade-scoped restrictions breached by the same price, disagreeing about
+            // what it costs. The severer must win either way round, so declaration order cannot be
+            // what decides whether a halt is served or shadowed by a pause.
+            var pausing = new AlwaysBreaches(RestrictionBreachAction.Pause, PauseFor);
+            var halting = new AlwaysBreaches(RestrictionBreachAction.Halt, null);
+            var restrictions = haltingFirst
+                ? new IPriceRestriction[] {halting, pausing}
+                : new IPriceRestriction[] {pausing, halting};
+
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+            var book = new InMemoryOrderBook(security, TimeProvider, restrictions);
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+
+            // and the halting restriction's own (absent) duration is the one that applies, so
+            // nothing resumes when the pausing restriction's would have elapsed
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            book.AdvanceTime();
+            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+        }
+
+        private sealed class AlwaysBreaches : IPriceRestriction
+        {
+            private readonly RestrictionBreachAction _action;
+            private readonly TimeSpan? _resumeAfter;
+
+            public AlwaysBreaches(RestrictionBreachAction action, TimeSpan? resumeAfter)
+            {
+                _action = action;
+                _resumeAfter = resumeAfter;
+            }
+
+            public RestrictionScope Scope => RestrictionScope.Trade;
+            public RestrictionBreachAction OnBreach => _action;
+            public TimeSpan? ResumeAfter => _resumeAfter;
+            public bool Allows(long priceTicks, DateTime time) => false;
+            public void OnTrade(long priceTicks, DateTime time) { }
+            public void OnSessionChange(long? referencePriceTicks) { }
+        }
+    }
+}

--- a/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
@@ -16,12 +16,20 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
+        public void RejectionInterruptsNothing_SoThereIsNothingToResumeFrom()
+        {
+            var restriction = new OrderPriceRestriction(5);
+
+            Assert.IsNull(restriction.ResumeAfter);
+        }
+
+        [Test]
         public void NoBandConfigured_AlwaysAllows()
         {
             var restriction = new OrderPriceRestriction(null);
             restriction.OnSessionChange(100);
 
-            Assert.IsTrue(restriction.Allows(1_000_000));
+            Assert.IsTrue(restriction.Allows(1_000_000, default));
         }
 
         [Test]
@@ -29,7 +37,7 @@ namespace Circus.Tests.OrderBook
         {
             var restriction = new OrderPriceRestriction(5);
 
-            Assert.IsTrue(restriction.Allows(1_000_000));
+            Assert.IsTrue(restriction.Allows(1_000_000, default));
         }
 
         [Test]
@@ -38,11 +46,11 @@ namespace Circus.Tests.OrderBook
             var restriction = new OrderPriceRestriction(5);
             restriction.OnSessionChange(100);
 
-            Assert.IsTrue(restriction.Allows(100));
-            Assert.IsTrue(restriction.Allows(105));
-            Assert.IsTrue(restriction.Allows(95));
-            Assert.IsFalse(restriction.Allows(106));
-            Assert.IsFalse(restriction.Allows(94));
+            Assert.IsTrue(restriction.Allows(100, default));
+            Assert.IsTrue(restriction.Allows(105, default));
+            Assert.IsTrue(restriction.Allows(95, default));
+            Assert.IsFalse(restriction.Allows(106, default));
+            Assert.IsFalse(restriction.Allows(94, default));
         }
 
         [Test]
@@ -52,8 +60,8 @@ namespace Circus.Tests.OrderBook
             restriction.OnSessionChange(100);
             restriction.OnSessionChange(null);
 
-            Assert.IsTrue(restriction.Allows(105));
-            Assert.IsFalse(restriction.Allows(106));
+            Assert.IsTrue(restriction.Allows(105, default));
+            Assert.IsFalse(restriction.Allows(106, default));
         }
 
         [Test]
@@ -65,9 +73,9 @@ namespace Circus.Tests.OrderBook
             restriction.OnTrade(200, default);
 
             // band now tracks the last trade (200), no longer the seed (100)
-            Assert.IsTrue(restriction.Allows(205));
-            Assert.IsFalse(restriction.Allows(206));
-            Assert.IsFalse(restriction.Allows(100));
+            Assert.IsTrue(restriction.Allows(205, default));
+            Assert.IsFalse(restriction.Allows(206, default));
+            Assert.IsFalse(restriction.Allows(100, default));
         }
     }
 }

--- a/Circus/OrderBook/DailyPriceBandLimit.cs
+++ b/Circus/OrderBook/DailyPriceBandLimit.cs
@@ -9,17 +9,24 @@ namespace Circus.OrderBook
     internal sealed class DailyPriceBandLimit : IPriceRestriction
     {
         private readonly int? _bandTicks;
+        private readonly TimeSpan? _resumeAfter;
         private long? _referencePriceTicks;
 
-        internal DailyPriceBandLimit(int? bandTicks)
+        internal DailyPriceBandLimit(int? bandTicks, TimeSpan? resumeAfter = null)
         {
             _bandTicks = bandTicks;
+            _resumeAfter = resumeAfter;
         }
 
         public RestrictionScope Scope => RestrictionScope.Trade;
         public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
 
-        public bool Allows(long priceTicks) =>
+        // Eurex times its volatility interruptions rather than leaving them open; configuring no
+        // duration leaves the pause standing until someone ends it, which is the older behaviour.
+        public TimeSpan? ResumeAfter => _resumeAfter;
+
+        // Anchored on the last trade rather than a window, so the time is not consulted.
+        public bool Allows(long priceTicks, DateTime time) =>
             !_bandTicks.HasValue || !_referencePriceTicks.HasValue ||
             Math.Abs(priceTicks - _referencePriceTicks.Value) <= _bandTicks.Value;
 

--- a/Circus/OrderBook/IPriceRestriction.cs
+++ b/Circus/OrderBook/IPriceRestriction.cs
@@ -15,6 +15,10 @@ namespace Circus.OrderBook
         Halt
     }
 
+    // A breached Trade-scoped restriction: what it costs the book, and how long for. ResumeAfter
+    // null leaves the interruption open-ended, waiting for someone to end it explicitly.
+    internal readonly record struct RestrictionBreach(RestrictionBreachAction Action, TimeSpan? ResumeAfter);
+
     // A price-restriction adapter: the order-entry price band and the trade-time volatility band
     // are the two that exist today; velocity limits and circuit breakers are expected future
     // adapters. Each adapter owns its own reference price - there is no shared anchor - updating
@@ -26,7 +30,13 @@ namespace Circus.OrderBook
         // Only consulted for Scope == Trade - an OrderEntry breach always means "reject the order".
         RestrictionBreachAction OnBreach { get; }
 
-        bool Allows(long priceTicks);
+        // How long the interruption this restriction causes lasts before the book returns by
+        // itself. Null means it does not end on its own. Only consulted for Scope == Trade.
+        TimeSpan? ResumeAfter { get; }
+
+        // The time is the moment being judged, not just bookkeeping: a restriction measuring
+        // movement over a rolling window has to know how much of its history is still in scope.
+        bool Allows(long priceTicks, DateTime time);
 
         // Maintain this restriction's own anchor. OnTrade fires on every print; OnSessionChange
         // fires when an explicit reference price (settlement-style) is supplied at a status change.

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -14,6 +14,11 @@ namespace Circus.OrderBook
         private long _nextSequenceNumber;
         private long? _lastTradedPrice;
 
+        // A timed interruption's deadline and where it returns to. Null whenever the book is not
+        // serving one, which includes an interruption configured to last until told otherwise.
+        private DateTime? _resumeAt;
+        private OrderBookStatus _resumeTo;
+
         // The indicative quote as last published, so only moves in it are emitted.
         private (long PriceTicks, int Quantity)? _indicativeQuote;
 
@@ -81,14 +86,23 @@ namespace Circus.OrderBook
         private const int MaxClientOrderIdLength = 20;
 
         public InMemoryOrderBook(Security security, ITimeProvider timeProvider)
+            : this(security, timeProvider, new IPriceRestriction[]
+            {
+                new OrderPriceRestriction(security.PriceBandTicks),
+                new DailyPriceBandLimit(security.VolatilityAuctionBandTicks, security.VolatilityAuctionDuration)
+            })
+        {
+        }
+
+        // Restrictions supplied outright rather than derived from the security. Internal because it
+        // is a seam, not an API: it exists so combinations a Security cannot yet describe - two
+        // trade-scoped restrictions disagreeing about severity, say - can still be exercised.
+        internal InMemoryOrderBook(Security security, ITimeProvider timeProvider,
+            IReadOnlyList<IPriceRestriction> priceRestrictions)
         {
             _security = security;
             _timeProvider = timeProvider;
-            _priceRestrictions = new IPriceRestriction[]
-            {
-                new OrderPriceRestriction(security.PriceBandTicks),
-                new DailyPriceBandLimit(security.VolatilityAuctionBandTicks)
-            };
+            _priceRestrictions = priceRestrictions;
         }
 
         private DateTime Now() => _timeProvider.GetCurrentTime();
@@ -98,7 +112,12 @@ namespace Circus.OrderBook
 
         public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
         {
-            var events = Handle(action);
+            // Before the action rather than after: an order arriving once the interruption has
+            // elapsed should meet a resumed book, not the paused one it would otherwise land in.
+            // Doing it here rather than only on AdvanceTime means a book being fed order flow
+            // resumes on its own, without needing anything to poke it.
+            var events = ResumeIfDue();
+            events.AddRange(Handle(action));
 
             // Last, so it reports where the action left the book rather than any state it passed
             // through - a pre-open cancel that uncrosses the book withdraws the quote, and the
@@ -132,8 +151,23 @@ namespace Circus.OrderBook
                 CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay),
                 PauseTrading => UpdateStatus(OrderBookStatus.Paused),
                 HaltTrading => UpdateStatus(OrderBookStatus.Halted),
+
+                // Carries nothing and does nothing: the work is the due-interruption check every
+                // Process already runs, and this is how a caller with no order flow reaches it.
+                AdvanceTime => new List<OrderBookEvent>(),
                 _ => throw new ArgumentException("Unknown order book action")
             };
+        }
+
+        // A timed interruption returns the book to whatever it interrupted. Cleared by any explicit
+        // status change, so a session closing over a pause ends it rather than being undone by it.
+        private List<OrderBookEvent> ResumeIfDue()
+        {
+            if (_resumeAt == null || Now() < _resumeAt.Value)
+                return new List<OrderBookEvent>();
+
+            _resumeAt = null;
+            return UpdateStatus(_resumeTo, reason: StatusChangeReason.InterruptionElapsed);
         }
 
         // Asked of the phase's own algorithm, so a quote exists exactly when there is an auction
@@ -280,7 +314,8 @@ namespace Circus.OrderBook
         // TriggerPriceMustBe... checks above, and Market/MarketLimit prices by
         // MarketOrderProtectionTicks.
         private bool AllowsOrderEntry(long priceTicks) =>
-            _priceRestrictions.Where(r => r.Scope == RestrictionScope.OrderEntry).All(r => r.Allows(priceTicks));
+            _priceRestrictions.Where(r => r.Scope == RestrictionScope.OrderEntry)
+                .All(r => r.Allows(priceTicks, Now()));
 
         // Only ever called on an order currently resting in the working book (a FAK remainder or
         // a self-match-prevention cancel during Match()) - never a still-Hidden stop order.
@@ -553,19 +588,35 @@ namespace Circus.OrderBook
             }
         }
 
-        // On the first Trade-scoped restriction that disallows priceTicks, returns its OnBreach
-        // consequence (Pause -> PreOpen, Halt -> Closed); a pure query, consulted by Matcher.Run
-        // only outside an auction uncrossing pass.
-        private RestrictionBreachAction? CheckTradeRestrictionBreach(long priceTicks)
+        // The severest consequence among the Trade-scoped restrictions that disallow priceTicks; a
+        // pure query, consulted by Matcher.Run only outside an auction uncrossing pass. Severest
+        // rather than first, so the order these are declared in cannot decide whether a breach that
+        // halts is served or shadowed by one that merely pauses.
+        private RestrictionBreach? CheckTradeRestrictionBreach(long priceTicks)
         {
+            var time = Now();
+            RestrictionBreach? worst = null;
+
             foreach (var restriction in _priceRestrictions)
             {
-                if (restriction.Scope == RestrictionScope.Trade && !restriction.Allows(priceTicks))
-                    return restriction.OnBreach;
+                if (restriction.Scope != RestrictionScope.Trade || restriction.Allows(priceTicks, time))
+                    continue;
+
+                if (worst == null || Severity(restriction.OnBreach) > Severity(worst.Value.Action))
+                    worst = new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
             }
 
-            return null;
+            return worst;
         }
+
+        // Ranked explicitly rather than leaning on the enum's declaration order, which is free to
+        // change. Reject never reaches here - it is an order-entry consequence.
+        private static int Severity(RestrictionBreachAction action) => action switch
+        {
+            RestrictionBreachAction.Halt => 2,
+            RestrictionBreachAction.Pause => 1,
+            _ => 0
+        };
 
         private void Apply(MatchOutcome outcome, List<OrderBookEvent> events, DateTime time,
             List<InternalOrder> pendingImmediateOrCancelStops)
@@ -587,9 +638,15 @@ namespace Circus.OrderBook
                 // Run/Apply loop, and UpdateStatus matches, which would re-enter the matcher
                 // mid-enumeration. The phases these land on are deliberately ones with nothing to
                 // do on arrival anyway - neither starts a session nor expires orders.
-                case TradeRestrictionBreached(_, var action):
-                    _status = action == RestrictionBreachAction.Halt ? OrderBookStatus.Halted : OrderBookStatus.Paused;
-                    events.Add(new StatusChanged(_security, Now(), _status));
+                case TradeRestrictionBreached(_, var breach):
+                    // Captured before the overwrite: an interruption returns to whatever it
+                    // interrupted, which is the only phase that could have been matching.
+                    _resumeTo = _status;
+                    _status = breach.Action == RestrictionBreachAction.Halt
+                        ? OrderBookStatus.Halted
+                        : OrderBookStatus.Paused;
+                    _resumeAt = breach.ResumeAfter.HasValue ? Now() + breach.ResumeAfter.Value : null;
+                    events.Add(new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction));
                     break;
 
                 case StopsTriggered(var orders):
@@ -707,7 +764,7 @@ namespace Circus.OrderBook
         // last of them ends it. The phase table stays the authority on whether a phase expires day
         // orders at all - this only says whether this particular close is that day's last.
         private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null,
-            bool endsTradingDay = true)
+            bool endsTradingDay = true, StatusChangeReason reason = StatusChangeReason.Requested)
         {
             if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
             {
@@ -719,6 +776,10 @@ namespace Circus.OrderBook
 
             if (!_phases.ContainsKey(status))
                 throw new ArgumentOutOfRangeException(nameof(status), status, "no phase configured for this status");
+
+            // Any transition supersedes a pending one, so a session closing over a running pause
+            // ends it rather than being undone when that pause's deadline arrives.
+            _resumeAt = null;
 
             var departing = CurrentPhase;
             _status = status;
@@ -738,7 +799,7 @@ namespace Circus.OrderBook
                 _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
             }
 
-            var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status)};
+            var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status, reason)};
 
             // A quoting phase has been accumulating orders for a print, and leaving it is where
             // that print happens - so a second auction phase would need nothing changed here.

--- a/Circus/OrderBook/MatchOutcome.cs
+++ b/Circus/OrderBook/MatchOutcome.cs
@@ -13,7 +13,7 @@ namespace Circus.OrderBook
         int Quantity, bool UsesFullRemainingQuantity) : MatchOutcome;
 
     // Terminal: Run stops yielding after this.
-    internal sealed record TradeRestrictionBreached(long PriceTicks, RestrictionBreachAction Action) : MatchOutcome;
+    internal sealed record TradeRestrictionBreached(long PriceTicks, RestrictionBreach Breach) : MatchOutcome;
 
     // Elected by the trade that just printed, in FIFO order across both sides, and still resting
     // in the stop ladders until Apply removes them.

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -77,10 +77,11 @@ namespace Circus.OrderBook
         // working book be picked up by this same loop rather than a recursive pass.
         //
         // afterStopTrigger takes over once a stop fires, and is assumed already prepared.
-        // checkTradeRestrictionBreach reports the first Trade-scoped restriction to disallow a
-        // prospective price, and is consulted only when the algorithm asks for it.
+        // checkTradeRestrictionBreach reports the severest consequence among the Trade-scoped
+        // restrictions disallowing a prospective price, and is consulted only when the algorithm
+        // asks for it.
         public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm, IMatchingAlgorithm afterStopTrigger,
-            Func<long, RestrictionBreachAction?> checkTradeRestrictionBreach)
+            Func<long, RestrictionBreach?> checkTradeRestrictionBreach)
         {
             if (!algorithm.TryBegin(_workingView))
                 yield break;
@@ -117,10 +118,10 @@ namespace Circus.OrderBook
 
                 if (algorithm.ChecksTradeRestrictions)
                 {
-                    var breachAction = checkTradeRestrictionBreach(priceTicks);
-                    if (breachAction.HasValue)
+                    var breach = checkTradeRestrictionBreach(priceTicks);
+                    if (breach.HasValue)
                     {
-                        yield return new TradeRestrictionBreached(priceTicks, breachAction.Value);
+                        yield return new TradeRestrictionBreached(priceTicks, breach.Value);
                         yield break;
                     }
                 }

--- a/Circus/OrderBook/OrderBookAction.cs
+++ b/Circus/OrderBook/OrderBookAction.cs
@@ -31,6 +31,12 @@ namespace Circus.OrderBook
     // breach calls for a halt; as an action it is the operator-driven equivalent.
     public sealed record HaltTrading : OrderBookAction;
 
+    // Nothing to do but let the clock be noticed. A timed interruption ends on its own, and a book
+    // with no order flow to carry it there needs something to ask - so a caller driving the book
+    // off a clock sends this as it ticks. Carries no time of its own: the book's time provider is
+    // the one authority on what time it is.
+    public sealed record AdvanceTime : OrderBookAction;
+
     public abstract record OrderAction : OrderBookAction
     {
         public required string CompanyId { get; init; }

--- a/Circus/OrderBook/OrderBookEvent.cs
+++ b/Circus/OrderBook/OrderBookEvent.cs
@@ -5,7 +5,9 @@ namespace Circus.OrderBook
 {
     public record OrderBookEvent(Security Security, DateTime Time);
 
-    public record StatusChanged(Security Security, DateTime Time, OrderBookStatus Status)
+    // Reason defaults to Requested, which is what every externally driven transition is.
+    public record StatusChanged(Security Security, DateTime Time, OrderBookStatus Status,
+            StatusChangeReason Reason = StatusChangeReason.Requested)
         : OrderBookEvent(Security, Time);
 
     public record OrderEvent(Security Security, DateTime Time, string CompanyId, string ClientOrderId,

--- a/Circus/OrderBook/OrderBookExtensions.cs
+++ b/Circus/OrderBook/OrderBookExtensions.cs
@@ -111,6 +111,11 @@ namespace Circus.OrderBook
         public static IReadOnlyList<OrderBookEvent> HaltTrading(this IOrderBook book) =>
             book.Process(new HaltTrading { Security = book.Security });
 
+        // Returns whatever the elapsed time turned out to imply - a resumption and its print, or
+        // nothing at all.
+        public static IReadOnlyList<OrderBookEvent> AdvanceTime(this IOrderBook book) =>
+            book.Process(new AdvanceTime { Security = book.Security });
+
         // Bridge for callers that only know the target status at runtime (e.g. a session/schedule
         // provider driving the book off a clock) and so can't pick PreOpenTrading/OpenTrading/
         // CloseTrading directly. ReferencePrice is ignored for every status but the two opening

--- a/Circus/OrderBook/OrderPriceRestriction.cs
+++ b/Circus/OrderBook/OrderPriceRestriction.cs
@@ -19,7 +19,11 @@ namespace Circus.OrderBook
         public RestrictionScope Scope => RestrictionScope.OrderEntry;
         public RestrictionBreachAction OnBreach => RestrictionBreachAction.Reject;
 
-        public bool Allows(long priceTicks) =>
+        // A rejection interrupts nothing, so there is nothing to resume from.
+        public TimeSpan? ResumeAfter => null;
+
+        // Anchored on a single reference rather than a window, so the time is not consulted.
+        public bool Allows(long priceTicks, DateTime time) =>
             !_bandTicks.HasValue || !_referencePriceTicks.HasValue ||
             Math.Abs(priceTicks - _referencePriceTicks.Value) <= _bandTicks.Value;
 

--- a/Circus/OrderBook/StatusChangeReason.cs
+++ b/Circus/OrderBook/StatusChangeReason.cs
@@ -1,0 +1,18 @@
+namespace Circus.OrderBook
+{
+    // Why the book changed status. Distinguishes the transitions a consumer would otherwise have to
+    // infer from context - a session opening looks nothing like a volatility pause on a feed, but
+    // both are just a status. Only what the book itself can tell apart: which restriction fired is
+    // not yet part of this, since the book sees a breach action rather than a named restriction.
+    public enum StatusChangeReason
+    {
+        // Driven from outside - a session schedule, or an operator.
+        Requested,
+
+        // A prospective trade breached a price restriction.
+        PriceRestriction,
+
+        // A timed interruption ran its course and the book returned by itself.
+        InterruptionElapsed
+    }
+}

--- a/Circus/Security.cs
+++ b/Circus/Security.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Circus
 {
     public record Security(
@@ -7,6 +9,10 @@ namespace Circus
         decimal TickValue,
         int MarketOrderProtectionTicks = 10,
         int? PriceBandTicks = null,
-        int? VolatilityAuctionBandTicks = null
+        int? VolatilityAuctionBandTicks = null,
+
+        // How long a volatility auction lasts before the book resumes by itself. Null leaves it
+        // standing until something ends it explicitly.
+        TimeSpan? VolatilityAuctionDuration = null
     );
 }


### PR DESCRIPTION
Finishes step 2 of the price-restriction plan, which #47 started. Everything from step 3 onward — Eurex-shaped volatility pauses, velocity logic, circuit breakers — depends on the machinery here.

## Timed resume

#47 gave a pause a status of its own, but it still stood until something outside ended it. No venue works that way: Eurex times its volatility interruptions, CME's velocity pause lasts seconds.

A breach now carries a duration alongside its consequence (`RestrictionBreach`), so the book records a deadline and returns to whatever it interrupted once it passes.

The check runs at the **top of `Process`**, not only on the new `AdvanceTime` action. Two reasons: a book being fed order flow then resumes on its own without needing anything to poke it, and an order arriving after the deadline meets a resumed book rather than the paused one it would otherwise land in. `AdvanceTime` covers the other case — a caller driving the book off a clock with no order flow — and deliberately carries no time of its own, since the book's `ITimeProvider` is the one authority on what time it is.

Any explicit transition clears a pending resume, so a session closing over a running pause ends it rather than being undone when that pause's deadline arrives. A restriction configured with no duration behaves exactly as before.

Duration comes from `Security.VolatilityAuctionDuration` — another optional parameter on a record that's accumulating them. Step 0 moves this whole set into restriction configs; adding one more here keeps that cleanup in one piece rather than half-doing it.

## Status change reason

`StatusChanged` now carries a `StatusChangeReason`. With `Paused` and `Halted` already distinct, this adds what the status alone cannot: whether the book opened because a schedule said so (`Requested`), because a restriction fired (`PriceRestriction`), or because an interruption ran its course (`InterruptionElapsed`). It defaults to `Requested`, so existing construction sites and assertions are untouched.

It's deliberately only what the book can actually distinguish — *which* restriction fired isn't in there, because the book sees a breach action rather than a named restriction.

## Two smaller step-2 pieces

- **`Allows` takes the moment being judged.** Neither of today's restrictions consults it, but a rolling-window one has to know how much of its history is still in scope — that's what velocity logic and CME's dynamic circuit breakers are made of.
- **Simultaneous breaches resolve by severity, not declaration order**, so a halt can't be shadowed by a pause that happens to be listed first. Ranked explicitly rather than leaning on the enum's declaration order.

## A testing seam

Restrictions can now be supplied to the book directly through an `internal` constructor. It's a seam, not an API: severity precedence is otherwise unverifiable, because no `Security` can yet describe two trade-scoped restrictions that disagree. The test uses it with a fake that always breaches, asserting the halt wins in **both** declaration orders.

## Tests

New `InMemoryOrderBookTimedResumeTests`: resumes once elapsed and not before; an open-ended pause stands however long passes; resuming prints what accumulated rather than resuming mid-sweep; the resume also fires on ordinary order flow, not just `AdvanceTime`; an explicit transition during a pause cancels the pending resume so a closed book can't spring back open; `AdvanceTime` with nothing pending does nothing; and the three reasons land on the right transitions.

The two restriction fixtures gain `ResumeAfter` coverage, and their `Allows` call sites move to the two-argument form.

## Still not in this PR

- `RestrictionBreachAction.Halt` is still unreachable from a real restriction, so the `Halted` breach path is exercised only through the new test seam. It lights up with circuit breakers in step 5.
- A market order rejected while paused still reports `MarketPreOpen` — unchanged from #47, still waiting on your call about renaming the enum member versus moving the reason into the phase table.

## Verification

No .NET SDK in this environment (install host blocked by the sandbox network policy), so CI is the first execution, as with #46 and #47. Hand-traced each new test against the resume path, including the ordering inside `Process` — resume, then action, then indicative quote — and that a re-breach immediately after resuming re-pauses rather than looping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_