### PR TITLE
Band orders against the price the market is actually showing

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
@@ -163,6 +164,135 @@ namespace Circus.Tests.OrderBook
             var buyLevels = book.GetLevels(Side.Buy, 10);
             Assert.AreEqual(1, buyLevels.Count);
             Assert.AreEqual(100, buyLevels[0].Price);
+        }
+
+        // A band of 5 ticks on a tick size of 10 is 50 either side of wherever the reference is.
+        private static Security BandedSecurity() =>
+            new("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+
+        [Test]
+        public void PreOpen_ReferenceMovesFromTheSettlementPriceToTheIndicativePrice()
+        {
+            // arrange - settled at 100, so the band starts out [50, 150]
+            var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen, 100);
+
+            // assert - 200 is outside the band while the settlement price is still the reference
+            var beforeCross = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 200);
+            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (beforeCross[0] as CreateOrderRejected)?.Reason);
+
+            // act - the book crosses at 150, so an indicative price exists and takes over as the
+            // reference, moving the band to [100, 200]
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 10, 150);
+            var crossing = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 10, 150);
+            Assert.AreEqual(150, crossing.OfType<IndicativePriceChanged>().Last().Price);
+
+            // assert - the same price that was rejected a moment ago is now inside the band
+            var afterCross = book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 200);
+            Assert.IsInstanceOf<CreateOrderConfirmed>(afterCross[0]);
+
+            // ...and 90, which the old band allowed, is now outside it
+            var belowNewBand = book.CreateLimitOrder(CompanyId4, "Order5", new OrderValidity.Day(), Side.Buy, 5, 90);
+            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (belowNewBand[0] as CreateOrderRejected)?.Reason);
+        }
+
+        [Test]
+        public void ContinuousTrading_ReferenceReturnsToTheLastTrade_OnceTheQuoteIsWithdrawn()
+        {
+            // arrange - open on an auction that prints at 150, which withdraws the quote
+            var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
+            book.UpdateStatus(OrderBookStatus.PreOpen, 100);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 150);
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            // act - continuous trading prints at 190, which the band [100, 200] allows
+            book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 190);
+            book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 190);
+
+            // assert - the band tracks the last trade, so it is now [140, 240]. Were the withdrawn
+            // indicative price of 150 still the reference, 240 would be well outside it.
+            var atNewEdge = book.CreateLimitOrder(CompanyId1, "Order5", new OrderValidity.Day(), Side.Buy, 5, 240);
+            Assert.IsInstanceOf<CreateOrderConfirmed>(atNewEdge[0]);
+
+            var belowNewBand = book.CreateLimitOrder(CompanyId1, "Order6", new OrderValidity.Day(), Side.Buy, 5, 130);
+            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (belowNewBand[0] as CreateOrderRejected)?.Reason);
+        }
+
+        // Trades at 100 to give stop orders a last traded price, then re-seeds the reference at 200
+        // so the band sits somewhere the last traded price does not. Without that separation the
+        // spread rule cannot be isolated: with the band centred on the last trade, a trigger on the
+        // far side of it can never be more than a band away from a limit price still inside it.
+        private LevelTrackingOrderBook StopSpreadBook(Security security)
+        {
+            var book = new LevelTrackingOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+            book.UpdateStatus(OrderBookStatus.Open, 200);
+            return book;
+        }
+
+        [Test]
+        public void StopLimit_TriggerAndPriceWithinABandOfEachOther_Accepted()
+        {
+            // arrange - band [150, 250] around the re-seeded reference of 200
+            var book = StopSpreadBook(BandedSecurity());
+
+            // act - trigger 160 and limit 210 are 50 apart, exactly the band width
+            var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
+                Side.Buy, 5, 210, 160);
+
+            // assert
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        }
+
+        [Test]
+        public void StopLimit_TriggerAndPriceFurtherApartThanTheBand_Rejected()
+        {
+            // arrange
+            var book = StopSpreadBook(BandedSecurity());
+
+            // act - trigger 160 and limit 250 are 90 apart, beyond the band
+            var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
+                Side.Buy, 5, 250, 160);
+
+            // assert - and note the limit price of 250 sits exactly on the band's own edge, so the
+            // entry band alone would have accepted this order. Only the spread rule catches it.
+            var rejected = events[0] as CreateOrderRejected;
+            Assert.IsNotNull(rejected);
+            Assert.AreEqual(OrderRejectedReason.TriggerPriceTooFarFromPrice, rejected.Reason);
+        }
+
+        [Test]
+        public void UpdateOrder_RepricingAStopBeyondTheBandFromItsTrigger_Rejected()
+        {
+            // arrange - an accepted stop, trigger 160 and limit 210
+            var book = StopSpreadBook(BandedSecurity());
+            book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 210, 160);
+
+            // act - repricing to 250 leaves the limit inside the band but 90 from the trigger
+            var events = book.UpdateOrder(CompanyId3, OrderId4, OrderId3, price: 250);
+
+            // assert
+            var rejected = events[0] as UpdateOrderRejected;
+            Assert.IsNotNull(rejected);
+            Assert.AreEqual(OrderRejectedReason.TriggerPriceTooFarFromPrice, rejected.Reason);
+        }
+
+        [Test]
+        public void NoBandConfigured_StopSpreadUnbounded()
+        {
+            // arrange - nothing to bound the gap with
+            var book = StopSpreadBook(new Security("GCZ6", SecurityType.Future, 10, 10));
+
+            // act
+            var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
+                Side.Buy, 5, 1000, 160);
+
+            // assert
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
         }
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
@@ -228,8 +228,10 @@ namespace Circus.Tests.OrderBook
             public RestrictionBreachAction OnBreach => _action;
             public TimeSpan? ResumeAfter => _resumeAfter;
             public bool Allows(long priceTicks, DateTime time) => false;
+            public bool AllowsStopSpread(long spreadTicks) => true;
             public void OnTrade(long priceTicks, DateTime time) { }
             public void OnSessionChange(long? referencePriceTicks) { }
+            public void OnIndicativePrice(long? priceTicks) { }
         }
     }
 }

--- a/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
@@ -68,5 +68,99 @@ namespace Circus.Tests.OrderBook
             Assert.IsFalse(restriction.Allows(206, default));
             Assert.IsFalse(restriction.Allows(100, default));
         }
+
+        [Test]
+        public void IndicativePrice_OutranksTheLastTrade()
+        {
+            // an auction is quoting, so that is what an order is judged against - CME's banding
+            // reference follows the IOP once one exists
+            var restriction = new OrderPriceRestriction(5);
+            restriction.OnSessionChange(100);
+            restriction.OnTrade(200, default);
+
+            restriction.OnIndicativePrice(300);
+
+            Assert.IsTrue(restriction.Allows(305, default));
+            Assert.IsFalse(restriction.Allows(306, default));
+            Assert.IsFalse(restriction.Allows(200, default), "the last trade no longer decides");
+        }
+
+        [Test]
+        public void IndicativePrice_OutranksTheSessionReference_WithNoTradeYet()
+        {
+            // pre-open on a fresh session: settled at 100, then the book crosses at 300
+            var restriction = new OrderPriceRestriction(5);
+            restriction.OnSessionChange(100);
+
+            restriction.OnIndicativePrice(300);
+
+            Assert.IsTrue(restriction.Allows(300, default));
+            Assert.IsFalse(restriction.Allows(100, default));
+        }
+
+        [Test]
+        public void IndicativePriceWithdrawn_FallsBackToTheLastTrade()
+        {
+            // the auction ends and continuous trading takes over, which quotes nothing
+            var restriction = new OrderPriceRestriction(5);
+            restriction.OnSessionChange(100);
+            restriction.OnTrade(200, default);
+            restriction.OnIndicativePrice(300);
+
+            restriction.OnIndicativePrice(null);
+
+            Assert.IsTrue(restriction.Allows(205, default));
+            Assert.IsFalse(restriction.Allows(300, default));
+        }
+
+        [Test]
+        public void IndicativePriceWithdrawn_NoTradeYet_FallsBackToTheSessionReference()
+        {
+            var restriction = new OrderPriceRestriction(5);
+            restriction.OnSessionChange(100);
+            restriction.OnIndicativePrice(300);
+
+            restriction.OnIndicativePrice(null);
+
+            Assert.IsTrue(restriction.Allows(105, default));
+            Assert.IsFalse(restriction.Allows(300, default));
+        }
+
+        [Test]
+        public void OnSessionChange_ClearsWhatItSupersedes()
+        {
+            // a new session's settlement price has to beat the previous session's last trade, so
+            // an explicit reference clears the anchors above it rather than sitting underneath them
+            var restriction = new OrderPriceRestriction(5);
+            restriction.OnTrade(200, default);
+            restriction.OnIndicativePrice(300);
+
+            restriction.OnSessionChange(100);
+
+            Assert.IsTrue(restriction.Allows(105, default));
+            Assert.IsFalse(restriction.Allows(200, default));
+            Assert.IsFalse(restriction.Allows(300, default));
+        }
+
+        [Test]
+        public void AllowsStopSpread_WithinWidth_AtWidth_BeyondWidth()
+        {
+            var restriction = new OrderPriceRestriction(5);
+
+            Assert.IsTrue(restriction.AllowsStopSpread(0));
+            Assert.IsTrue(restriction.AllowsStopSpread(4));
+            Assert.IsTrue(restriction.AllowsStopSpread(5));
+            Assert.IsFalse(restriction.AllowsStopSpread(6));
+        }
+
+        [Test]
+        public void AllowsStopSpread_DoesNotDependOnAReference()
+        {
+            // it measures a width, not a distance from anywhere
+            var restriction = new OrderPriceRestriction(5);
+
+            Assert.IsTrue(restriction.AllowsStopSpread(5));
+            Assert.IsFalse(restriction.AllowsStopSpread(6));
+        }
     }
 }

--- a/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
@@ -54,6 +54,28 @@ namespace Circus.Tests.OrderBook
         }
 
         [Test]
+        public void IndicativePrice_Ignored()
+        {
+            // volatility is measured against prices that actually traded, not one an auction is
+            // only quoting - the entry band is the restriction that follows the indicative price
+            var restriction = new VolatilityBandRestriction(5);
+            restriction.OnSessionChange(100);
+
+            restriction.OnIndicativePrice(300);
+
+            Assert.IsTrue(restriction.Allows(105, default));
+            Assert.IsFalse(restriction.Allows(300, default));
+        }
+
+        [Test]
+        public void StopSpread_Unconstrained_NotAnEntryRestriction()
+        {
+            var restriction = new VolatilityBandRestriction(5);
+
+            Assert.IsTrue(restriction.AllowsStopSpread(1_000_000));
+        }
+
+        [Test]
         public void OnTrade_MovesReferenceToLastTrade()
         {
             var restriction = new VolatilityBandRestriction(5);

--- a/Circus/OrderBook/IPriceRestriction.cs
+++ b/Circus/OrderBook/IPriceRestriction.cs
@@ -38,9 +38,16 @@ namespace Circus.OrderBook
         // movement over a rolling window has to know how much of its history is still in scope.
         bool Allows(long priceTicks, DateTime time);
 
+        // How far apart a stop order's trigger and limit prices may be. Separate from Allows
+        // because it measures a width rather than a distance from a reference, and CME governs it
+        // with the same band that governs entry prices. Only consulted for Scope == OrderEntry.
+        bool AllowsStopSpread(long spreadTicks);
+
         // Maintain this restriction's own anchor. OnTrade fires on every print; OnSessionChange
-        // fires when an explicit reference price (settlement-style) is supplied at a status change.
+        // fires when an explicit reference price (settlement-style) is supplied at a status change;
+        // OnIndicativePrice fires when the auction quote moves, with null when it is withdrawn.
         void OnTrade(long priceTicks, DateTime time);
         void OnSessionChange(long? referencePriceTicks);
+        void OnIndicativePrice(long? priceTicks);
     }
 }

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -196,6 +196,14 @@ namespace Circus.OrderBook
                 return null;
 
             _indicativeQuote = quote;
+
+            // An anchor for anything banding against the auction price, withdrawn along with the
+            // quote. Reaching restrictions here rather than at order entry means an order is judged
+            // against the quote as it stood before that order - which is the only thing it could be
+            // judged against, since the quote cannot account for an order that has not arrived.
+            foreach (var restriction in _priceRestrictions)
+                restriction.OnIndicativePrice(quote?.PriceTicks);
+
             return new IndicativePriceChanged(_security, Now(),
                 quote.HasValue ? (decimal?) ToDecimal(quote.Value.PriceTicks) : null, quote?.Quantity ?? 0);
         }
@@ -232,6 +240,9 @@ namespace Circus.OrderBook
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanPrice);
             if (triggerTicks != null && priceTicks != null && side == Side.Sell && priceTicks > triggerTicks)
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice);
+            if (triggerTicks != null && priceTicks != null &&
+                !AllowsStopSpread(triggerTicks.Value, priceTicks.Value))
+                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceTooFarFromPrice);
             if (triggerTicks != null && !_lastTradedPrice.HasValue)
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoLastTradedPrice);
             if (triggerTicks != null && side == Side.Buy && triggerTicks <= _lastTradedPrice)
@@ -326,6 +337,13 @@ namespace Circus.OrderBook
             _priceRestrictions.Where(r => r.Scope == RestrictionScope.OrderEntry)
                 .All(r => r.Allows(priceTicks, Now()));
 
+        // A stop elected far from its trigger would rest at a price the band would never have
+        // accepted directly, so CME bounds the gap by the same band. Checked on the pair rather
+        // than on either price, and only where a band exists to bound it.
+        private bool AllowsStopSpread(long triggerTicks, long priceTicks) =>
+            _priceRestrictions.Where(r => r.Scope == RestrictionScope.OrderEntry)
+                .All(r => r.AllowsStopSpread(Math.Abs(priceTicks - triggerTicks)));
+
         // Only ever called on an order currently resting in the working book (a FAK remainder or
         // a self-match-prevention cancel during Match()) - never a still-Hidden stop order.
         private OrderBookEvent CancelRemainder(InternalOrder order, OrderCancelledReason reason)
@@ -388,6 +406,10 @@ namespace Circus.OrderBook
                 if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Sell && newPriceTicks > newTriggerTicks)
                     return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
                         OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, order.ExchangeOrderId);
+                if (newTriggerTicks != null && newPriceTicks != null &&
+                    !AllowsStopSpread(newTriggerTicks.Value, newPriceTicks.Value))
+                    return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
+                        OrderRejectedReason.TriggerPriceTooFarFromPrice, order.ExchangeOrderId);
 
                 if (triggerTicks != null && order.Side == Side.Buy && triggerTicks <= _lastTradedPrice)
                     return RejectUpdate(companyId, clientOrderId, previousClientOrderId,

--- a/Circus/OrderBook/OrderPriceRestriction.cs
+++ b/Circus/OrderBook/OrderPriceRestriction.cs
@@ -2,13 +2,22 @@ using System;
 
 namespace Circus.OrderBook
 {
-    // The hard band checked at order entry, anchored on the last trade and seeded from an explicit
-    // reference price pre-open. Sees only client-supplied resting limit prices - trigger and
-    // Market/MarketLimit prices are governed elsewhere in InMemoryOrderBook.
+    // The hard band checked at order entry. Sees only client-supplied resting limit prices - trigger
+    // and Market/MarketLimit prices are governed elsewhere in InMemoryOrderBook.
+    //
+    // The reference it measures from follows CME's banding reference price, which moves with the
+    // market state: the settlement price pre-open, the indicative price once an auction is quoting
+    // one, and the last trade during continuous trading. Expressed as a precedence between three
+    // anchors rather than as a rule about phases, which comes out the same without this needing to
+    // know what phase the book is in - continuous trading publishes no indicative price, so the top
+    // rung is simply empty there.
     internal sealed class OrderPriceRestriction : IPriceRestriction
     {
         private readonly int _bandTicks;
-        private long? _referencePriceTicks;
+
+        private long? _indicativePriceTicks;
+        private long? _lastTradePriceTicks;
+        private long? _sessionPriceTicks;
 
         internal OrderPriceRestriction(int bandTicks)
         {
@@ -21,18 +30,37 @@ namespace Circus.OrderBook
         // A rejection interrupts nothing, so there is nothing to resume from.
         public TimeSpan? ResumeAfter => null;
 
-        // Inactive until it has a reference to measure from. A band with no width is not modelled
-        // here at all - a security that wants none leaves the restriction out.
-        public bool Allows(long priceTicks, DateTime time) =>
-            !_referencePriceTicks.HasValue ||
-            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _bandTicks;
+        private long? ReferencePriceTicks =>
+            _indicativePriceTicks ?? _lastTradePriceTicks ?? _sessionPriceTicks;
 
-        public void OnTrade(long priceTicks, DateTime time) => _referencePriceTicks = priceTicks;
+        // Inactive until some anchor exists. A band with no width is not modelled here at all - a
+        // security that wants none leaves the restriction out.
+        public bool Allows(long priceTicks, DateTime time)
+        {
+            var reference = ReferencePriceTicks;
+            return !reference.HasValue || Math.Abs(priceTicks - reference.Value) <= _bandTicks;
+        }
 
+        // CME governs the gap between a stop's trigger and limit prices with the same band width
+        // that governs how far an order may be priced from the reference.
+        public bool AllowsStopSpread(long spreadTicks) => spreadTicks <= _bandTicks;
+
+        public void OnTrade(long priceTicks, DateTime time) => _lastTradePriceTicks = priceTicks;
+
+        // Null withdraws the quote, dropping the reference back to the last trade.
+        public void OnIndicativePrice(long? priceTicks) => _indicativePriceTicks = priceTicks;
+
+        // An explicit reference means "start from here", so it clears what it supersedes rather than
+        // sitting underneath it: a new session's settlement price has to beat the previous session's
+        // last trade, and it could never do that from the bottom of the precedence.
         public void OnSessionChange(long? referencePriceTicks)
         {
-            if (referencePriceTicks.HasValue)
-                _referencePriceTicks = referencePriceTicks;
+            if (!referencePriceTicks.HasValue)
+                return;
+
+            _sessionPriceTicks = referencePriceTicks;
+            _lastTradePriceTicks = null;
+            _indicativePriceTicks = null;
         }
     }
 }

--- a/Circus/OrderBook/OrderRejectedReason.cs
+++ b/Circus/OrderBook/OrderRejectedReason.cs
@@ -29,6 +29,12 @@ namespace Circus.OrderBook
         PriceOutsideBands,
         MinQuantityOutOfRange,
         InsufficientLiquidityForMinQuantity,
-        MaxVisibleQuantityOutOfRange
+        MaxVisibleQuantityOutOfRange,
+
+        // The trigger and limit prices are on the right sides of each other but too far apart: a
+        // stop elected this far from its trigger would rest where the band would never have
+        // accepted it directly. Appended rather than filed with the other TriggerPrice reasons, so
+        // that no existing member's numeric value moves.
+        TriggerPriceTooFarFromPrice
     }
 }

--- a/Circus/OrderBook/VolatilityBandRestriction.cs
+++ b/Circus/OrderBook/VolatilityBandRestriction.cs
@@ -32,7 +32,17 @@ namespace Circus.OrderBook
             !_referencePriceTicks.HasValue ||
             Math.Abs(priceTicks - _referencePriceTicks.Value) <= _bandTicks;
 
+        // Not an entry restriction, so it has no say in how a stop is priced.
+        public bool AllowsStopSpread(long spreadTicks) => true;
+
         public void OnTrade(long priceTicks, DateTime time) => _referencePriceTicks = priceTicks;
+
+        // Ignored: CME and Eurex both measure volatility against prices that actually traded, not
+        // against one an auction is only quoting. The entry band does follow it - each restriction
+        // owning its own anchor is what lets the two disagree.
+        public void OnIndicativePrice(long? priceTicks)
+        {
+        }
 
         public void OnSessionChange(long? referencePriceTicks)
         {


### PR DESCRIPTION
Step 1 of the price-restriction plan.

## The reference moves with the market

The entry band measured from one anchor: the last trade, seeded from whatever reference a status change supplied. CME's Banding Reference Price moves with the market state — the **settlement price** pre-open, the **indicative price** once an auction has calculated one, and the **last price** during continuous trading. Following the middle rung only became possible once #45 made the book publish an indicative price.

It's now a precedence between three anchors rather than a rule about phases:

```
indicative price  ->  last trade  ->  session reference (settlement)
```

| Situation | Wins | Why |
|---|---|---|
| Pre-open, nothing crossed | session reference | no IOP yet, no trade yet |
| Pre-open, book crossed | indicative | an auction is quoting |
| Continuous | last trade | nothing quotes, so the top rung is empty |
| Volatility pause | indicative | the pause is an auction and quotes again |

That comes out the same as CME's rule without the restriction needing to know what phase the book is in — which matters, because "nothing outside the phase table names a status" is a rule this codebase already keeps.

An explicit reference now **clears what it supersedes** rather than sitting underneath it. A new session's settlement has to beat the previous session's last trade, and it could never do that from the bottom of the precedence. `OnSessionChange(null)` still changes nothing.

Restrictions learn the quote in `TakeIndicativeQuoteChange`, where the book already computes it and already returns early when unchanged. That's at the end of `Process`, so an order is judged against the quote **as it stood before that order** — which is the only thing it could be judged against, since a quote cannot account for an order that hasn't arrived. It reads like an off-by-one and isn't.

`VolatilityBandRestriction` ignores the indicative price: both CME and Eurex measure volatility against prices that actually traded. The two restrictions disagreeing here is precisely what each owning its own anchor is for.

## Stop trigger/limit spread

CME also rejects a stop-limit whose trigger and limit prices are further apart than the band. That measures a *width* rather than a distance from a reference, so it's a second question (`AllowsStopSpread`) put to the same restriction, asked wherever the existing trigger/price relationship is checked — `CreateOrder` and `UpdateOrder`'s Hidden branch. No new config: CME uses the same band width, so `OrderPriceBand(BandTicks)` already covers it.

Worth recording, because it shaped the tests: **the rule only bites when the band's reference and the last traded price differ.** With the band centred on the last trade and a stop's trigger constrained to the far side of it, a trigger can never be more than a band away from a limit price that is still inside the band. The tests isolate it by re-seeding the reference away from the last trade.

`TriggerPriceTooFarFromPrice` is **appended** to `OrderRejectedReason` rather than filed with the other `TriggerPrice...` members — grouping would have read better but would have silently renumbered ten public enum values, and #47 set the precedent of not doing that. `PriceOutsideBands` is untouched; step 5 adds its own reason when there's code to produce one.

## Tests

Unit, on the restriction: each rung outranking the ones below it, a withdrawn quote falling back correctly with and without a trade, `OnSessionChange` clearing what it supersedes, and the spread at/inside/beyond the width. Plus the mirror on the volatility band — that it ignores the indicative price and doesn't constrain spreads.

End-to-end on the book: an order rejected against the settlement reference and then **accepted at the same price** once the book crosses and the IOP takes over — the case that motivates the whole step; the reference returning to the last trade once continuous trading withdraws the quote; and the spread rule on create, on update, and absent when no band is configured.

## Verification

No .NET SDK in this environment (install host blocked by the sandbox network policy), so CI is the first execution, as with #46–#49. The existing 311 should hold — the reference chain reduces to today's behaviour whenever no auction is quoting, which is every existing band test. A drop would most likely show up in `BandMovesDynamically_AfterATrade_ReanchorsToNewLastTradedPrice`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_