### PR TITLE
Give volatility interruptions their Eurex shape

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
@@ -229,6 +229,7 @@ namespace Circus.Tests.OrderBook
             public TimeSpan? ResumeAfter => _resumeAfter;
             public bool Allows(long priceTicks, DateTime time) => false;
             public bool AllowsStopSpread(long spreadTicks) => true;
+            public bool AllowsResumption(long priceTicks, DateTime time) => true;
             public void OnTrade(long priceTicks, DateTime time) { }
             public void OnSessionChange(long? referencePriceTicks) { }
             public void OnIndicativePrice(long? priceTicks) { }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Linq;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // The two things a volatility interruption does beyond pausing: it can refuse to end at a price
+    // still too far out, and a range anchored on the session catches drift that one following the
+    // market never sees.
+    [TestFixture]
+    public class InMemoryOrderBookVolatilityInterruptionTests
+    {
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+
+        private static readonly string OrderId1 = "Order1";
+        private static readonly string OrderId2 = "Order2";
+
+        private TestTimeProvider TimeProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+        }
+
+        // Ordinary range 5 ticks, extended range 8, pausing for two minutes. On a tick size of 10
+        // that is 50 and 80 either side of the reference.
+        private static Security ExtendingSecurity() =>
+            new("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new VolatilityBand(5, PauseFor: PauseFor, ExtendedRangeTicks: 8)
+                });
+
+        [Test]
+        public void InterruptionExtends_WhenItWouldEndBeyondTheExtendedRange()
+        {
+            // arrange - referenced at 100, then a trade at 200 breaches the ordinary range and
+            // pauses the book, leaving the two orders crossed and unfilled
+            var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+
+            // act - the pause runs out, but the auction would still print at 200, which is 100 from
+            // the reference and so outside the extended range of 80
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            var events = book.AdvanceTime();
+
+            // assert - the interruption keeps running rather than resolving out there
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+            Assert.AreEqual(0, events.OfType<OrdersMatched>().Count(), "nothing printed");
+
+            var stillPaused = events.OfType<StatusChanged>().Single();
+            Assert.AreEqual(OrderBookStatus.Paused, stillPaused.Status);
+            Assert.AreEqual(StatusChangeReason.PriceRestriction, stillPaused.Reason);
+        }
+
+        [Test]
+        public void InterruptionEnds_OnceItWouldPrintInsideTheExtendedRange()
+        {
+            // arrange - as above, paused with a would-be print at 200
+            var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            book.AdvanceTime();
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status, "extended once");
+
+            // act - the orders that would have printed out there are pulled, and a cross at 180
+            // takes their place. 180 is 80 from the reference: outside the ordinary range that
+            // caused the interruption, but exactly on the edge of the extended one.
+            book.CancelOrder(CompanyId1, "Cancel1", OrderId1);
+            book.CancelOrder(CompanyId2, "Cancel2", OrderId2);
+            book.CreateLimitOrder(CompanyId1, "Order3", new OrderValidity.Day(), Side.Sell, 5, 180);
+            book.CreateLimitOrder(CompanyId2, "Order4", new OrderValidity.Day(), Side.Buy, 5, 180);
+
+            TimeProvider.SetCurrentTime(Now1 + PauseFor + PauseFor);
+            var events = book.AdvanceTime();
+
+            // assert - the interruption resolves, printing at a price the ordinary range would
+            // never have allowed to trade continuously
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+            var matched = events.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(180, matched.Price);
+            Assert.AreEqual(5, matched.Quantity);
+        }
+
+        [Test]
+        public void StaticRange_CatchesDriftThatTheDynamicRangeDoesNot()
+        {
+            // arrange - a dynamic range of 3 ticks alongside a static range of 5, referenced at 100.
+            // Each step below is well inside the dynamic range; it is the distance from where the
+            // day started that eventually trips.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new VolatilityBand(3),
+                    new StaticPriceRange(5)
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+
+            // act + assert - 120 is 2 ticks from the reference, inside both
+            Trade(book, 1, 120);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+
+            // 140 is 2 ticks from the last trade and 4 from the reference, still inside both
+            Trade(book, 2, 140);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+
+            // 160 is 2 ticks from the last trade - the dynamic range is content - but 6 from the
+            // reference, which the static range is not
+            Trade(book, 3, 160);
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        }
+
+        private void Trade(IOrderBook book, int n, decimal price)
+        {
+            book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
+            book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
+        }
+    }
+}

--- a/Circus.Tests/OrderBook/StaticPriceRangeRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/StaticPriceRangeRestrictionTests.cs
@@ -1,0 +1,85 @@
+using System;
+using Circus.OrderBook;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    [TestFixture]
+    public class StaticPriceRangeRestrictionTests
+    {
+        private static readonly DateTime T = new(2000, 1, 1, 12, 0, 0);
+
+        [Test]
+        public void Scope_IsTrade_OnBreach_IsPause()
+        {
+            var restriction = new StaticPriceRangeRestriction(5);
+
+            Assert.AreEqual(RestrictionScope.Trade, restriction.Scope);
+            Assert.AreEqual(RestrictionBreachAction.Pause, restriction.OnBreach);
+        }
+
+        [Test]
+        public void NoReferenceYet_AlwaysAllows()
+        {
+            var restriction = new StaticPriceRangeRestriction(5);
+
+            Assert.IsTrue(restriction.Allows(1_000_000, T));
+        }
+
+        [Test]
+        public void WithinRange_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
+        {
+            var restriction = new StaticPriceRangeRestriction(5);
+            restriction.OnSessionChange(100);
+
+            Assert.IsTrue(restriction.Allows(105, T));
+            Assert.IsTrue(restriction.Allows(95, T));
+            Assert.IsFalse(restriction.Allows(106, T));
+            Assert.IsFalse(restriction.Allows(94, T));
+        }
+
+        [Test]
+        public void TradesDoNotMoveIt()
+        {
+            // the whole point: a range that followed the market could be walked anywhere over a day
+            // without ever being breached, because every step is small next to the last one
+            var restriction = new StaticPriceRangeRestriction(5);
+            restriction.OnSessionChange(100);
+
+            restriction.OnTrade(105, T);
+            restriction.OnTrade(110, T.AddSeconds(1));
+
+            Assert.IsFalse(restriction.Allows(111, T.AddSeconds(2)),
+                "still measured from 100, however far the market has walked");
+        }
+
+        [Test]
+        public void IndicativePrice_Ignored()
+        {
+            var restriction = new StaticPriceRangeRestriction(5);
+            restriction.OnSessionChange(100);
+
+            restriction.OnIndicativePrice(300);
+
+            Assert.IsFalse(restriction.Allows(300, T));
+        }
+
+        [Test]
+        public void HasNoOpinionOnResumptionOrStopSpreads()
+        {
+            var restriction = new StaticPriceRangeRestriction(5);
+            restriction.OnSessionChange(100);
+
+            Assert.IsTrue(restriction.AllowsResumption(1_000_000, T));
+            Assert.IsTrue(restriction.AllowsStopSpread(1_000_000));
+        }
+
+        [Test]
+        public void DurationConfigured_IsWhatThePauseResumesAfter()
+        {
+            var restriction = new StaticPriceRangeRestriction(5, TimeSpan.FromMinutes(2));
+
+            Assert.AreEqual(TimeSpan.FromMinutes(2), restriction.ResumeAfter);
+        }
+    }
+}

--- a/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
@@ -7,6 +7,8 @@ namespace Circus.Tests.OrderBook
     [TestFixture]
     public class VolatilityBandRestrictionTests
     {
+        private static readonly DateTime T = new(2000, 1, 1, 12, 0, 0);
+
         [Test]
         public void Scope_IsTrade_OnBreach_IsPause()
         {
@@ -14,6 +16,100 @@ namespace Circus.Tests.OrderBook
 
             Assert.AreEqual(RestrictionScope.Trade, restriction.Scope);
             Assert.AreEqual(RestrictionBreachAction.Pause, restriction.OnBreach);
+        }
+
+        [Test]
+        public void Window_MeasuresAgainstEveryTradeStillInIt()
+        {
+            // arrange - two trades 10 seconds apart, both inside a 30-second window
+            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+            restriction.OnTrade(100, T);
+            restriction.OnTrade(103, T.AddSeconds(10));
+
+            // assert - 107 is within range of the newer trade but not of the older one, and the
+            // older one still counts
+            Assert.IsTrue(restriction.Allows(105, T.AddSeconds(11)), "in range of both");
+            Assert.IsFalse(restriction.Allows(107, T.AddSeconds(11)), "in range of 103 but not of 100");
+        }
+
+        [Test]
+        public void Window_TradesAgeOutOfIt()
+        {
+            // arrange - the same pair
+            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+            restriction.OnTrade(100, T);
+            restriction.OnTrade(103, T.AddSeconds(10));
+
+            // act - far enough on that only the newer trade is still inside the window
+            var laterOn = T.AddSeconds(31);
+
+            // assert - the price refused a moment ago is allowed now, purely because time passed
+            Assert.IsTrue(restriction.Allows(107, laterOn));
+        }
+
+        [Test]
+        public void Window_NeverEmptiesCompletely()
+        {
+            // arrange - a market that has gone quiet is still measured against where it last
+            // traded, not against nothing at all
+            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+            restriction.OnTrade(100, T);
+
+            // assert
+            Assert.IsTrue(restriction.Allows(105, T.AddDays(1)));
+            Assert.IsFalse(restriction.Allows(106, T.AddDays(1)));
+        }
+
+        [Test]
+        public void NoWindow_MeasuresAgainstTheLastTradeAlone()
+        {
+            // arrange - the older trade is discarded outright rather than kept and aged
+            var restriction = new VolatilityBandRestriction(5);
+            restriction.OnTrade(100, T);
+            restriction.OnTrade(103, T.AddSeconds(10));
+
+            // assert - 107 is out of range of 100, which no longer counts for anything
+            Assert.IsTrue(restriction.Allows(107, T.AddSeconds(11)));
+        }
+
+        [Test]
+        public void OnSessionChange_ClearsTheWindow()
+        {
+            // arrange - an explicit reference supersedes what the market did before it
+            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+            restriction.OnTrade(200, T);
+
+            restriction.OnSessionChange(100);
+
+            // assert - measured from the new reference, with the trade at 200 forgotten
+            Assert.IsTrue(restriction.Allows(105, T.AddSeconds(1)));
+            Assert.IsFalse(restriction.Allows(200, T.AddSeconds(1)));
+        }
+
+        [Test]
+        public void NoExtendedRange_AnInterruptionAlwaysEnds()
+        {
+            var restriction = new VolatilityBandRestriction(5);
+            restriction.OnTrade(100, T);
+
+            Assert.IsFalse(restriction.Allows(1_000, T), "well outside the ordinary range");
+            Assert.IsTrue(restriction.AllowsResumption(1_000, T), "but nothing holds the resumption back");
+        }
+
+        [Test]
+        public void ExtendedRange_HoldsTheClosingPriceToAWiderRange()
+        {
+            // arrange - ordinary range 5, extended range 10
+            var restriction = new VolatilityBandRestriction(5, extendedRangeTicks: 10);
+            restriction.OnTrade(100, T);
+
+            // assert - between the two ranges: enough to have caused the interruption, not enough
+            // to keep it running
+            Assert.IsFalse(restriction.Allows(106, T));
+            Assert.IsTrue(restriction.AllowsResumption(106, T));
+
+            // beyond the extended range: the interruption keeps running
+            Assert.IsFalse(restriction.AllowsResumption(111, T));
         }
 
         [Test]

--- a/Circus/OrderBook/IPriceRestriction.cs
+++ b/Circus/OrderBook/IPriceRestriction.cs
@@ -43,6 +43,12 @@ namespace Circus.OrderBook
         // with the same band that governs entry prices. Only consulted for Scope == OrderEntry.
         bool AllowsStopSpread(long spreadTicks);
 
+        // Whether an interruption may end with a print at this price. Eurex holds the closing price
+        // of a volatility interruption to a wider range than the one that caused it, and extends
+        // the interruption rather than resolving it outside that range. A restriction with no such
+        // range says yes and lets the interruption end. Only consulted for Scope == Trade.
+        bool AllowsResumption(long priceTicks, DateTime time);
+
         // Maintain this restriction's own anchor. OnTrade fires on every print; OnSessionChange
         // fires when an explicit reference price (settlement-style) is supplied at a status change;
         // OnIndicativePrice fires when the auction quote moves, with null when it is withdrawn.

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -99,7 +99,9 @@ namespace Circus.OrderBook
                 : configs.Select<PriceRestrictionConfig, IPriceRestriction>(config => config switch
                 {
                     OrderPriceBand band => new OrderPriceRestriction(band.BandTicks),
-                    VolatilityBand band => new VolatilityBandRestriction(band.BandTicks, band.PauseFor),
+                    VolatilityBand band => new VolatilityBandRestriction(band.RangeTicks, band.PauseFor,
+                        band.Window, band.ExtendedRangeTicks),
+                    StaticPriceRange range => new StaticPriceRangeRestriction(range.RangeTicks, range.PauseFor),
                     _ => throw new ArgumentException($"Unknown price restriction {config.GetType().Name}")
                 }).ToList();
 
@@ -640,6 +642,36 @@ namespace Circus.OrderBook
             return worst;
         }
 
+        // Whether a restriction refuses to let the interruption the book is in end at the price it
+        // would end at. Eurex extends a volatility interruption rather than resolving it at a price
+        // still too far out; without a restriction configured for that, this always declines to
+        // interfere and every transition goes ahead.
+        //
+        // Only where a print is what would end it: a phase leaving for one that does not trade
+        // abandons its orders rather than crossing them, so there is no price to hold to anything -
+        // and a close must never be blocked by a price range.
+        private RestrictionBreach? CheckResumptionRefusal(OrderBookStatus arrivingStatus)
+        {
+            var departing = CurrentPhase;
+            if (!departing.PrintsOnExit || !_phases[arrivingStatus].MatchesContinuously)
+                return null;
+
+            if (!departing.Algorithm!.TryQuoteIndicative(_matcher.Working, out var priceTicks, out _))
+                return null;
+
+            var time = Now();
+            foreach (var restriction in _priceRestrictions)
+            {
+                // First refusal rather than the severest: every restriction refusing here is asking
+                // for the same thing, so there is nothing to rank.
+                if (restriction.Scope == RestrictionScope.Trade &&
+                    !restriction.AllowsResumption(priceTicks, time))
+                    return new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
+            }
+
+            return null;
+        }
+
         // Ranked explicitly rather than leaning on the enum's declaration order, which is free to
         // change. Reject never reaches here - it is an order-entry consequence.
         private static int Severity(RestrictionBreachAction action) => action switch
@@ -807,6 +839,17 @@ namespace Circus.OrderBook
 
             if (!_phases.ContainsKey(status))
                 throw new ArgumentOutOfRangeException(nameof(status), status, "no phase configured for this status");
+
+            var extension = CheckResumptionRefusal(status);
+            if (extension != null)
+            {
+                // Nothing has moved yet, so refusing simply leaves the book where it was. The status
+                // is unchanged and re-reported: what a subscriber needs to know is that the
+                // interruption is still running and why, which is the same thing a fresh one says.
+                _resumeAt = extension.Value.ResumeAfter.HasValue ? Now() + extension.Value.ResumeAfter.Value : null;
+                return new List<OrderBookEvent>
+                    {new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction)};
+            }
 
             // Any transition supersedes a pending one, so a session closing over a running pause
             // ends it rather than being undone when that pause's deadline arrives.

--- a/Circus/OrderBook/OrderPriceRestriction.cs
+++ b/Circus/OrderBook/OrderPriceRestriction.cs
@@ -45,6 +45,10 @@ namespace Circus.OrderBook
         // that governs how far an order may be priced from the reference.
         public bool AllowsStopSpread(long spreadTicks) => spreadTicks <= _bandTicks;
 
+        // An entry band rejects orders; it never interrupts trading, so it has nothing to say about
+        // when an interruption should end.
+        public bool AllowsResumption(long priceTicks, DateTime time) => true;
+
         public void OnTrade(long priceTicks, DateTime time) => _lastTradePriceTicks = priceTicks;
 
         // Null withdraws the quote, dropping the reference back to the last trade.

--- a/Circus/OrderBook/StaticPriceRangeRestriction.cs
+++ b/Circus/OrderBook/StaticPriceRangeRestriction.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Circus.OrderBook
+{
+    // A range measured from a fixed reference rather than from recent trades. Eurex's static
+    // volatility interruption, which exists because a range that follows the market can be walked
+    // anywhere over a day without ever being breached - every step is small next to the last one.
+    //
+    // Deliberately deaf to trades. That is the whole difference between this and the dynamic range,
+    // and it is why the two are separate adapters rather than one with a mode: each owns its anchor.
+    internal sealed class StaticPriceRangeRestriction : IPriceRestriction
+    {
+        private readonly int _rangeTicks;
+        private readonly TimeSpan? _resumeAfter;
+        private long? _referencePriceTicks;
+
+        internal StaticPriceRangeRestriction(int rangeTicks, TimeSpan? resumeAfter = null)
+        {
+            _rangeTicks = rangeTicks;
+            _resumeAfter = resumeAfter;
+        }
+
+        public RestrictionScope Scope => RestrictionScope.Trade;
+        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
+
+        public TimeSpan? ResumeAfter => _resumeAfter;
+
+        // Inactive until a reference exists - nothing but a status change can supply one.
+        public bool Allows(long priceTicks, DateTime time) =>
+            !_referencePriceTicks.HasValue ||
+            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _rangeTicks;
+
+        // No wider range of its own: a static range is already the outer bound, so it never has an
+        // opinion about whether an interruption should keep running.
+        public bool AllowsResumption(long priceTicks, DateTime time) => true;
+
+        public bool AllowsStopSpread(long spreadTicks) => true;
+
+        // Static: where the market has traded since is exactly what this is measuring away from.
+        public void OnTrade(long priceTicks, DateTime time)
+        {
+        }
+
+        public void OnIndicativePrice(long? priceTicks)
+        {
+        }
+
+        public void OnSessionChange(long? referencePriceTicks)
+        {
+            if (referencePriceTicks.HasValue)
+                _referencePriceTicks = referencePriceTicks;
+        }
+    }
+}

--- a/Circus/OrderBook/VolatilityBandRestriction.cs
+++ b/Circus/OrderBook/VolatilityBandRestriction.cs
@@ -1,22 +1,38 @@
 using System;
+using System.Collections.Generic;
 
 namespace Circus.OrderBook
 {
-    // A band checked against the prospective trade price rather than the submitted one. A breach
+    // A range checked against the prospective trade price rather than the submitted one. A breach
     // interrupts continuous trading into an auction rather than rejecting, Eurex-style.
     //
     // Named for what it is - a volatility interruption - which leaves "daily limit" free for the
     // thing that actually is one: a session-long ceiling trading stops at rather than pauses on.
+    //
+    // Measured against the trades inside a lookback window, which is Eurex's dynamic range and, at
+    // a shorter window, CME's velocity logic. With no window it keeps only the newest trade, which
+    // is the plain "within range of the last trade" check.
     internal sealed class VolatilityBandRestriction : IPriceRestriction
     {
-        private readonly int _bandTicks;
+        private readonly int _rangeTicks;
+        private readonly TimeSpan? _window;
         private readonly TimeSpan? _resumeAfter;
-        private long? _referencePriceTicks;
+        private readonly int? _extendedRangeTicks;
 
-        internal VolatilityBandRestriction(int bandTicks, TimeSpan? resumeAfter = null)
+        // Oldest first, so ageing out is a walk from the front. Holds at most one entry when no
+        // window is configured.
+        private readonly Queue<(long PriceTicks, DateTime Time)> _recentTrades = new();
+
+        // Used only before anything has traded, or after a status change re-seeds the anchor.
+        private long? _sessionPriceTicks;
+
+        internal VolatilityBandRestriction(int rangeTicks, TimeSpan? resumeAfter = null,
+            TimeSpan? window = null, int? extendedRangeTicks = null)
         {
-            _bandTicks = bandTicks;
+            _rangeTicks = rangeTicks;
             _resumeAfter = resumeAfter;
+            _window = window;
+            _extendedRangeTicks = extendedRangeTicks;
         }
 
         public RestrictionScope Scope => RestrictionScope.Trade;
@@ -26,16 +42,23 @@ namespace Circus.OrderBook
         // duration leaves the pause standing until someone ends it.
         public TimeSpan? ResumeAfter => _resumeAfter;
 
-        // Inactive until it has a reference to measure from. A band with no width is not modelled
-        // here at all - a security that wants none leaves the restriction out.
-        public bool Allows(long priceTicks, DateTime time) =>
-            !_referencePriceTicks.HasValue ||
-            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _bandTicks;
+        public bool Allows(long priceTicks, DateTime time) => Within(priceTicks, time, _rangeTicks);
+
+        // The wider range an interruption's would-be closing price is held to. Without one
+        // configured an interruption simply ends when its time is up.
+        public bool AllowsResumption(long priceTicks, DateTime time) =>
+            !_extendedRangeTicks.HasValue || Within(priceTicks, time, _extendedRangeTicks.Value);
 
         // Not an entry restriction, so it has no say in how a stop is priced.
         public bool AllowsStopSpread(long spreadTicks) => true;
 
-        public void OnTrade(long priceTicks, DateTime time) => _referencePriceTicks = priceTicks;
+        public void OnTrade(long priceTicks, DateTime time)
+        {
+            if (!_window.HasValue)
+                _recentTrades.Clear();
+
+            _recentTrades.Enqueue((priceTicks, time));
+        }
 
         // Ignored: CME and Eurex both measure volatility against prices that actually traded, not
         // against one an auction is only quoting. The entry band does follow it - each restriction
@@ -44,10 +67,52 @@ namespace Circus.OrderBook
         {
         }
 
+        // An explicit reference supersedes what the market did before it, so the window goes with
+        // it - otherwise a fresh settlement price would be measured against yesterday's trades.
         public void OnSessionChange(long? referencePriceTicks)
         {
-            if (referencePriceTicks.HasValue)
-                _referencePriceTicks = referencePriceTicks;
+            if (!referencePriceTicks.HasValue)
+                return;
+
+            _sessionPriceTicks = referencePriceTicks;
+            _recentTrades.Clear();
+        }
+
+        // Within range of every trade still in the window, or of the session reference when nothing
+        // has traded yet. Inactive until one or the other exists.
+        //
+        // The window cannot come to span more than the range allows, because a trade only prints if
+        // it was itself in range of everything then inside it. An interruption is the one thing that
+        // can move the price further than that in one go, and one lasting longer than the window -
+        // which is the usual configuration - has aged the whole window out before trading resumes.
+        private bool Within(long priceTicks, DateTime time, int rangeTicks)
+        {
+            Evict(time);
+
+            if (_recentTrades.Count == 0)
+                return !_sessionPriceTicks.HasValue ||
+                       Math.Abs(priceTicks - _sessionPriceTicks.Value) <= rangeTicks;
+
+            foreach (var (tradePriceTicks, _) in _recentTrades)
+            {
+                if (Math.Abs(priceTicks - tradePriceTicks) > rangeTicks)
+                    return false;
+            }
+
+            return true;
+        }
+
+        // Never empties the queue when a window is configured: the newest trade is kept whatever its
+        // age, so a market that has gone quiet is still measured against where it last traded rather
+        // than falling back to a stale session reference.
+        private void Evict(DateTime time)
+        {
+            if (!_window.HasValue)
+                return;
+
+            var cutoff = time - _window.Value;
+            while (_recentTrades.Count > 1 && _recentTrades.Peek().Time < cutoff)
+                _recentTrades.Dequeue();
         }
     }
 }

--- a/Circus/PriceRestrictionConfig.cs
+++ b/Circus/PriceRestrictionConfig.cs
@@ -13,8 +13,23 @@ namespace Circus
     // Rejects an order priced too far from the reference, at entry. CME's price banding.
     public sealed record OrderPriceBand(int BandTicks) : PriceRestrictionConfig;
 
-    // Interrupts trading when a prospective trade price falls too far from the reference, rather
-    // than rejecting the order that would have caused it. Eurex's volatility interruption.
+    // Interrupts trading when a prospective trade price falls too far from where the market has
+    // recently traded, rather than rejecting the order that would have caused it. Eurex's dynamic
+    // volatility interruption.
+    //
+    // Window is the lookback: the price must be within RangeTicks of every trade inside it. Unset
+    // measures against the last trade alone. ExtendedRangeTicks is the wider range Eurex checks an
+    // interruption's would-be closing price against - outside it, the interruption is extended
+    // rather than allowed to resolve. Unset means an interruption always ends when its time is up.
     // PauseFor null leaves the interruption standing until something ends it explicitly.
-    public sealed record VolatilityBand(int BandTicks, TimeSpan? PauseFor = null) : PriceRestrictionConfig;
+    public sealed record VolatilityBand(
+        int RangeTicks,
+        TimeSpan? PauseFor = null,
+        TimeSpan? Window = null,
+        int? ExtendedRangeTicks = null) : PriceRestrictionConfig;
+
+    // Interrupts trading on distance from a fixed reference rather than from recent trades, so it
+    // catches a whole day's drift that a range following the market never notices. Eurex's static
+    // volatility interruption. Anchored only by the reference prices supplied at status changes.
+    public sealed record StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null) : PriceRestrictionConfig;
 }


### PR DESCRIPTION
Step 3 of the price-restriction plan. Three PRs cover steps 3–5; this is the first.

Three things a real volatility interruption does that one range around the last trade did not.

## It measures against a window, not a point

Eurex's dynamic interruption checks a prospective price "against all prices of previously executed trades in the same instrument within configured lookback time windows" — not just the newest. That's what stops a market being walked anywhere in small steps, each one small next to the last.

The window is why `Allows` takes a `DateTime`, added in #48 and unused until now. **With no window configured only the newest trade is kept, which is exactly the old check**, so nothing that doesn't ask for a window changes behaviour.

Two properties worth stating, both commented in the code:

- The window can't come to span more than the range allows, because a trade only prints if it was in range of everything then inside it. An interruption is the one thing that can move price further in one go — and one lasting longer than the window, the usual configuration, has aged the whole window out before trading resumes. So there's no explicit reset needed on resumption.
- Eviction never empties the queue. A market that has gone quiet is still measured against where it last traded rather than falling back to a stale session reference.

## It can be anchored on the session instead of the market

`StaticPriceRange` measures from a fixed reference and ignores trades entirely — Eurex's static volatility interruption, live since July 2024, which exists precisely because a range that follows the market never notices a whole day's drift.

Its own adapter rather than a mode flag on the dynamic one: the two differ only in which anchor they follow, and each restriction owning its anchor is the distinction `IPriceRestriction` already documents.

The test that shows the point: with a dynamic range of 3 ticks alongside a static range of 5, prices walk 120 → 140 → 160. Every step is 2 ticks from the last and the dynamic range is content throughout; the third trade is 6 from where the day started, and the static range isn't.

## It can refuse to end

Today `Auction.ChecksTradeRestrictions => false`, so a pause that ends prints whatever the auction struck, however far out. Eurex holds the would-be closing price to a **wider** range and extends the call rather than resolving it out there.

Asked where the book decides to resume rather than inside the match loop: `UpdateStatus` already knows whether the phase it's leaving prints on exit, and the departing algorithm can answer `TryQuoteIndicative` before anything moves. So a refusal simply leaves the book where it was, and no second threshold has to be threaded through `Matcher.Run`. A close is never subject to it — a phase leaving for one that doesn't trade abandons its orders rather than crossing them, so there's no price to hold to anything.

**This is the behaviour change**, and it only bites for a security configuring `ExtendedRangeTicks`, which is none of them today.

## Config

```csharp
VolatilityBand(int RangeTicks, TimeSpan? PauseFor = null,
               TimeSpan? Window = null, int? ExtendedRangeTicks = null)
StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null)
```

`PauseFor` deliberately stays in second position. Moving `Window` there would have silently rebound the one positional call site (`new VolatilityBand(5, duration)` in `InMemoryOrderBookTimedResumeTests`) from a pause duration to a lookback window — compiling cleanly and meaning something entirely different.

## Tests

Unit: a price in range of the newest trade but not of an older one still in the window is refused, and allowed once that older trade ages out — the same price, decided by nothing but elapsed time; the queue never emptying; `OnSessionChange` clearing the window; and the extended range accepting a resumption the ordinary range rejects.

New fixture for the static range, including that trades don't move it.

End-to-end: an interruption whose deadline elapses while the auction would still print outside the extended range stays paused and re-arms; once orders move the would-be price inside, it resumes and prints — at a price the ordinary range would never have allowed to trade continuously, which is the whole point of the extended range being wider.

## Verification

No .NET SDK in this environment (install host blocked by the sandbox network policy), so CI is the first execution, as with #46–#50. The number to watch is **326** holding: the windowed range collapses to today's check when no window is configured, and `AllowsResumption` returns true for every restriction without an extended range, so every existing test should be indifferent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_