### PR TITLE
Say when a windowed range means velocity logic

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Linq;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // What a velocity limit catches that a range around the last trade does not: a run of steps
+    // each unremarkable next to the one before it, arriving too quickly. The same steps spread out
+    // are ordinary trading, so every test here turns on timing rather than on price.
+    [TestFixture]
+    public class InMemoryOrderBookVelocityLogicTests
+    {
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly TimeSpan Window = TimeSpan.FromSeconds(10);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+
+        private TestTimeProvider TimeProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+        }
+
+        // 5 ticks on a tick size of 10, so 50 of price movement inside ten seconds is too fast.
+        private IOrderBook VelocityBook(TimeSpan? pauseFor = null) =>
+            new InMemoryOrderBook(
+                new Security("GCZ6", SecurityType.Future, 10, 10,
+                    PriceRestrictions: new PriceRestrictionConfig[]
+                    {
+                        new VelocityLimit(5, Window, pauseFor)
+                    }),
+                TimeProvider);
+
+        [Test]
+        public void StepsArrivingTooQuickly_TripTheLimit()
+        {
+            // arrange
+            var book = VelocityBook();
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            // act + assert - nothing has traded, so the first print is unmeasurable and allowed
+            Trade(book, 1, 100);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+
+            // two seconds later, 40 from the first trade and inside the range
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+            Trade(book, 2, 140);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+
+            // two seconds later again. This step is only 40 from the last trade, but the trade at
+            // 100 is still inside the window and 80 away, which is what the limit is watching for
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+            Trade(book, 3, 180);
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        }
+
+        [Test]
+        public void TheSameStepsSpreadOut_DoNot()
+        {
+            // arrange - identical prices to the test above, twenty seconds apart instead of two
+            var book = VelocityBook();
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            Trade(book, 1, 100);
+
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(20));
+            Trade(book, 2, 140);
+
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(40));
+            Trade(book, 3, 180);
+
+            // assert - by the third print the first has long left the window, so nothing measures
+            // the whole 80 of movement and the market simply traded
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        }
+
+        [Test]
+        public void CatchesWhatAWideRangeAroundTheLastTradeMisses()
+        {
+            // arrange - a wide volatility band with no window of its own alongside the velocity
+            // limit. The band is four times the width, so nothing below comes close to it.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new VolatilityBand(20),
+                    new VelocityLimit(5, Window)
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            Trade(book, 1, 100);
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+            Trade(book, 2, 140);
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+            Trade(book, 3, 180);
+
+            // assert - every step was 40, well inside the band's 200, so the band never had an
+            // opinion. Going too fast is the only thing wrong here.
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        }
+
+        [Test]
+        public void PauseIsBriefAndEndsOnItsOwn()
+        {
+            // arrange - velocity pauses are measured in seconds, not minutes
+            var pauseFor = TimeSpan.FromSeconds(5);
+            var book = VelocityBook(pauseFor);
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            Trade(book, 1, 100);
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+            Trade(book, 2, 140);
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+            Trade(book, 3, 180);
+            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+
+            // act - the orders that tripped it are still crossed, so ending the pause prints them
+            TimeProvider.SetCurrentTime(Now1.AddSeconds(4) + pauseFor);
+            var events = book.AdvanceTime();
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+            var matched = events.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(180, matched.Price);
+        }
+
+        private void Trade(IOrderBook book, int n, decimal price)
+        {
+            book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
+            book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
+        }
+    }
+}

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -102,6 +102,11 @@ namespace Circus.OrderBook
                     VolatilityBand band => new VolatilityBandRestriction(band.RangeTicks, band.PauseFor,
                         band.Window, band.ExtendedRangeTicks),
                     StaticPriceRange range => new StaticPriceRangeRestriction(range.RangeTicks, range.PauseFor),
+
+                    // Same adapter as VolatilityBand: a velocity limit is that range at a short
+                    // window, and the two configs exist to say which is meant, not to behave apart.
+                    VelocityLimit limit => new VolatilityBandRestriction(limit.RangeTicks, limit.PauseFor,
+                        limit.Window),
                     _ => throw new ArgumentException($"Unknown price restriction {config.GetType().Name}")
                 }).ToList();
 

--- a/Circus/PriceRestrictionConfig.cs
+++ b/Circus/PriceRestrictionConfig.cs
@@ -32,4 +32,18 @@ namespace Circus
     // catches a whole day's drift that a range following the market never notices. Eurex's static
     // volatility interruption. Anchored only by the reference prices supplied at status changes.
     public sealed record StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null) : PriceRestrictionConfig;
+
+    // "Too far, too fast": the same windowed range a dynamic volatility interruption uses, at the
+    // short timescale that catches a run of steps each unremarkable next to the last. CME's
+    // velocity logic, which it describes as watching what price banding cannot - banding catches a
+    // price that goes too far, this catches one that gets there too quickly.
+    //
+    // Not a different mechanism from VolatilityBand and deliberately not a different adapter: the
+    // window is the whole of what separates them. It is a config of its own so that a product says
+    // which it means, rather than leaving a reader to infer it from how short the window is.
+    //
+    // Window is required, unlike VolatilityBand's - a velocity limit without one would just be a
+    // range around the last trade, which is the other config.
+    public sealed record VelocityLimit(int RangeTicks, TimeSpan Window, TimeSpan? PauseFor = null)
+        : PriceRestrictionConfig;
 }

--- a/Readme.md
+++ b/Readme.md
@@ -39,10 +39,11 @@ Market data
 
 Safety features
 - [x] Banding
-- [x] Volatility interruptions (a trade-price band breach pauses into an auction)
+- [x] Volatility interruptions (dynamic, static and extended ranges)
+- [x] Velocity logic (too far, too fast over a rolling window)
 - [ ] Daily price limits (static, session-long limit up/down)
 - [ ] Circuit breakers
-- [ ] Stop & velocity logic
+- [ ] Stop price logic
 - [x] Self-match prevention
 
 Matching algorithms


### PR DESCRIPTION
Step 4 of the price-restriction plan. Second of the three PRs covering steps 3–5.

## The plan's bet paid off

The plan predicted this step would be near-zero enforcement code, on the reasoning that CME's velocity logic and Eurex's dynamic volatility interruption are the same mechanism at different timescales. CME puts it plainly: velocity logic watches what price banding cannot — *banding catches a price that goes too far, velocity catches one that gets there too quickly.* That is a window and a threshold, which is exactly what #51 built.

So this PR adds **one config record and no enforcement**. `VelocityLimit` maps to the same `VolatilityBandRestriction` a dynamic interruption does:

```csharp
VelocityLimit limit => new VolatilityBandRestriction(limit.RangeTicks, limit.PauseFor, limit.Window),
```

Two configs onto one adapter, rather than one config with a telling parameter, so a product says which mechanism it means instead of leaving a reader to infer it from how short the window happens to be. `Window` is required here, unlike on `VolatilityBand` — a velocity limit without one would just be a range around the last trade, which is the other config.

## Tests turn on timing, not price

That is the whole distinction, so the tests are built to fail if it were otherwise. The same three prints — 100, 140, 180, each step 40 — trip the limit when they arrive two seconds apart and don't when they arrive twenty seconds apart. Nothing about the prices differs between those two tests; only the clock.

The third test puts a wide `VolatilityBand(20)` alongside the `VelocityLimit(5, 10s)` and runs the fast sequence. Every step is 40 against a range of 200, so the band sits through the whole thing with nothing to say — every step being unremarkable next to the one before it is precisely the case a range around the last trade cannot see. Only the velocity limit fires.

The fourth confirms a velocity pause behaves like one: seconds, not minutes, and it ends on its own.

## Readme

`Stop & velocity logic` was one line covering two mechanisms. Split: velocity logic is ticked, stop price logic stays open — it's CME's separate protection against cascading stop-triggered runaway trades, and it isn't built.

## One thing I did not do

`VolatilityBandRestriction` now backs two configs, so its name is narrower than its job. I left it alone rather than rename a class I renamed in #49 — happy to if you'd prefer something neutral like `PriceRangeRestriction`, but repeated renaming of the same file has its own cost and the class comment already spells out both roles.

## Verification

No .NET SDK in this environment (install host blocked by the sandbox network policy), so CI is the first execution, as with #46–#51. Expect **343** to hold plus the four new cases — nothing existing is touched beyond the config mapping gaining an arm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_