### PR TITLE
Cap a market at its daily limit, and break the circuit past it

### DIFF
--- a/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Linq;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // Circuit breakers stop trading rather than capping it, and are configured in levels. What
+    // matters beyond the halt itself is that a price through several levels is served by the one it
+    // actually reached rather than by whichever it passed first.
+    [TestFixture]
+    public class InMemoryOrderBookCircuitBreakerTests
+    {
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly TimeSpan HaltFor = TimeSpan.FromMinutes(15);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+
+        private TestTimeProvider TimeProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+        }
+
+        // CME's equity index levels: halt at 7 and 13 percent, end the trading day at 20. On a
+        // reference of 1000 with a tick size of 10 that is 7, 13 and 20 ticks either side.
+        private IOrderBook LeveledBook()
+        {
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor),
+                    new CircuitBreaker(new PriceLimitWidth.Percent(13), HaltFor),
+                    new CircuitBreaker(new PriceLimitWidth.Percent(20))
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 1000);
+            return book;
+        }
+
+        private static void Trade(IOrderBook book, string n, decimal price)
+        {
+            book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
+            book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
+        }
+
+        [Test]
+        public void FirstLevelBreached_HaltsForItsDuration()
+        {
+            // arrange
+            var book = LeveledBook();
+
+            // act - 1080 is 8 percent away, through the first level and no further
+            Trade(book, "1", 1080);
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+
+            // the orders that tripped it are pulled, so resuming has nothing left to re-trip on
+            book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
+            book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
+
+            TimeProvider.SetCurrentTime(Now1 + HaltFor);
+            var events = book.AdvanceTime();
+
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+            Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
+                events.OfType<StatusChanged>().Single().Reason);
+        }
+
+        [Test]
+        public void PriceThroughEveryLevel_ServedByTheWidestOneItReached()
+        {
+            // arrange
+            var book = LeveledBook();
+
+            // act - 1250 is 25 percent away, through all three levels
+            Trade(book, "1", 1250);
+            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+
+            // act - the two narrower levels would each have ended by now
+            book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
+            book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
+            TimeProvider.SetCurrentTime(Now1 + HaltFor + HaltFor);
+            var events = book.AdvanceTime();
+
+            // assert - still halted, because the level it actually reached never resumes on its own
+            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+            Assert.AreEqual(0, events.Count);
+        }
+
+        [Test]
+        public void HaltOutranksAPauseBreachedAtTheSamePrice()
+        {
+            // arrange - a volatility band far narrower than the breaker, so any price tripping the
+            // breaker trips the band too. The severer consequence has to win.
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new VolatilityBand(2, PauseFor: TimeSpan.FromMinutes(2)),
+                    new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor)
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 1000);
+
+            // act
+            Trade(book, "1", 1080);
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Halted, book.Status, "halting outranks pausing");
+        }
+
+        [Test]
+        public void OrderEntryIsUnaffected_ABreakerGovernsTradesOnly()
+        {
+            // arrange
+            var book = LeveledBook();
+
+            // act - far beyond every level, but resting an order there is not trading there
+            var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 5000);
+
+            // assert
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        }
+    }
+}

--- a/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Linq;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.OrderBook
+{
+    // A daily limit is the one restriction that neither rejects nor interrupts. The market stays
+    // open, keeps quoting, trades at the limit and can trade back inside - so almost every
+    // assertion here is that the book is still Open while refusing to go further.
+    [TestFixture]
+    public class InMemoryOrderBookDailyLimitTests
+    {
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+
+        private static readonly string CompanyId1 = "Company1";
+        private static readonly string CompanyId2 = "Company2";
+
+        private TestTimeProvider TimeProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+        }
+
+        // 5 ticks on a tick size of 10, referenced at 100, so the limits are 50 and 150.
+        private IOrderBook LimitedBook()
+        {
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+            return book;
+        }
+
+        [Test]
+        public void OrderBeyondTheLimit_RejectedOnEntry()
+        {
+            // arrange
+            var book = LimitedBook();
+
+            // act
+            var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 160);
+
+            // assert - its own reason, not the band's: a band moves with the market and would very
+            // likely take this price shortly, a daily limit stands for the session
+            var rejected = events[0] as CreateOrderRejected;
+            Assert.IsNotNull(rejected);
+            Assert.AreEqual(OrderRejectedReason.BeyondDailyPriceLimit, rejected.Reason);
+        }
+
+        [Test]
+        public void TradingAtTheLimitIsAllowed()
+        {
+            // arrange
+            var book = LimitedBook();
+
+            // act - exactly on the limit
+            book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Sell, 5, 150);
+            var events = book.CreateLimitOrder(CompanyId2, "Order2", new OrderValidity.Day(), Side.Buy, 5, 150);
+
+            // assert
+            var matched = events.OfType<OrdersMatched>().Single();
+            Assert.AreEqual(150, matched.Price);
+            Assert.AreEqual(OrderBookStatus.Open, book.Status);
+            Assert.AreEqual(0, events.OfType<LimitStateChanged>().Count(), "trading at the limit is not being stuck");
+        }
+
+        // Because entry and trades face the same limit, an order beyond it cannot simply be sent -
+        // which is the point. Getting one to rest out there means resting it while the limit was
+        // wider and then moving the reference so the limit narrows under it. That leaves a book
+        // whose own resting order is beyond the ceiling, which is exactly the state a sweep has to
+        // refuse: it traded at 200, holds a buy at 240, and is now referenced at 100.
+        private IOrderBook BookWithRestingOrderAboveTheLimit()
+        {
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+
+            book.UpdateStatus(OrderBookStatus.Open, 200);
+            book.CreateLimitOrder(CompanyId1, "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
+            book.CreateLimitOrder(CompanyId2, "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
+            book.CreateLimitOrder(CompanyId2, "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
+
+            book.UpdateStatus(OrderBookStatus.Open, 100);
+            return book;
+        }
+
+        [Test]
+        public void TradeThroughTheLimit_BlockedWithoutHaltingOrPausing()
+        {
+            // arrange
+            var book = BookWithRestingOrderAboveTheLimit();
+
+            // act - a sell at 150 is inside the limit and perfectly enterable, but it crosses the
+            // resting buy at 240, and that is where the trade would print
+            var events = book.CreateLimitOrder(CompanyId1, "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150);
+
+            // assert - nothing printed, and the market is neither paused nor halted
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+            Assert.AreEqual(0, events.OfType<OrdersMatched>().Count());
+            Assert.AreEqual(OrderBookStatus.Open, book.Status, "a limit is not a halt");
+
+            // ...and it says which way it is stuck: the blocked price is above the last trade, so
+            // buyers are the ones who cannot get through
+            var limited = events.OfType<LimitStateChanged>().Single();
+            Assert.AreEqual(Side.Buy, limited.Side);
+            Assert.AreEqual(240, limited.Price);
+        }
+
+        [Test]
+        public void LimitState_PublishedOnceAndReleasedByATrade()
+        {
+            // arrange - already limit locked
+            var book = BookWithRestingOrderAboveTheLimit();
+            book.CreateLimitOrder(CompanyId1, "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150);
+
+            // act - another sweep against the same wall says nothing new
+            var again = book.CreateLimitOrder(CompanyId1, "Sell3", new OrderValidity.Day(), Side.Sell, 5, 140);
+            Assert.AreEqual(0, again.OfType<LimitStateChanged>().Count(), "already said, and still true");
+
+            // act - the order out beyond the ceiling is pulled, and the book trades inside the limit
+            book.CancelOrder(CompanyId2, "Cancel1", "Buy2");
+            var traded = book.CreateLimitOrder(CompanyId2, "Buy3", new OrderValidity.Day(), Side.Buy, 5, 140);
+
+            // assert - trading again, and said so
+            Assert.AreEqual(1, traded.OfType<OrdersMatched>().Count());
+            var released = traded.OfType<LimitStateChanged>().Single();
+            Assert.IsNull(released.Side);
+            Assert.IsNull(released.Price);
+        }
+
+        [Test]
+        public void PercentageWidth_ResolvesAgainstTheReference()
+        {
+            // arrange - 7 percent of a reference of 1000, so 70 either side
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new DailyPriceLimit(new PriceLimitWidth.Percent(7))
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open, 1000);
+
+            // act + assert - 1070 is exactly on the ceiling
+            var atEdge = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 1070);
+            Assert.IsInstanceOf<CreateOrderConfirmed>(atEdge[0]);
+
+            var beyond = book.CreateLimitOrder(CompanyId1, "Order2", new OrderValidity.Day(), Side.Buy, 5, 1080);
+            Assert.AreEqual(OrderRejectedReason.BeyondDailyPriceLimit, (beyond[0] as CreateOrderRejected)?.Reason);
+        }
+
+        [Test]
+        public void NoReferenceYet_LimitInactive()
+        {
+            // arrange - a percentage of nothing is not a width
+            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new DailyPriceLimit(new PriceLimitWidth.Percent(7))
+                });
+            var book = new InMemoryOrderBook(security, TimeProvider);
+            book.UpdateStatus(OrderBookStatus.Open);
+
+            // act
+            var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 1_000_000);
+
+            // assert
+            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        }
+    }
+}

--- a/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
@@ -90,6 +90,12 @@ namespace Circus.Tests.OrderBook
             book.CreateLimitOrder(CompanyId2, "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
             book.CreateLimitOrder(CompanyId2, "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
 
+            // The clock has to move on before whatever the test does next. Matcher.Run picks the
+            // resting side with a strict ModifiedTime comparison, so orders sharing a timestamp
+            // hand it to the sell - and price-time prints at the resting order's price. Left at one
+            // instant, an incoming sell would price the trade at its own limit rather than at the
+            // buy resting above the ceiling, and there would be nothing out of range to refuse.
+            TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
             book.UpdateStatus(OrderBookStatus.Open, 100);
             return book;
         }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
@@ -226,6 +226,7 @@ namespace Circus.Tests.OrderBook
 
             public RestrictionScope Scope => RestrictionScope.Trade;
             public RestrictionBreachAction OnBreach => _action;
+            public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
             public TimeSpan? ResumeAfter => _resumeAfter;
             public bool Allows(long priceTicks, DateTime time) => false;
             public bool AllowsStopSpread(long spreadTicks) => true;

--- a/Circus/OrderBook/CircuitBreakerRestriction.cs
+++ b/Circus/OrderBook/CircuitBreakerRestriction.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Circus.OrderBook
+{
+    // A threshold that stops trading rather than capping it. Set against a settlement price like a
+    // daily limit, and unlike one it halts: no matching, no quote, nothing published until it
+    // resumes or someone intervenes.
+    //
+    // Several are ordinarily configured together, and a price through the widest is through all of
+    // them. The book serves the severest breach, ranking a longer halt above a shorter one and one
+    // that never resumes above both - so the level that ends a trading day wins over the levels it
+    // passed through on the way.
+    internal sealed class CircuitBreakerRestriction : IPriceRestriction
+    {
+        private readonly SessionLimitAnchor _anchor;
+        private readonly TimeSpan? _haltFor;
+
+        internal CircuitBreakerRestriction(PriceLimitWidth width, TimeSpan? haltFor = null)
+        {
+            _anchor = new SessionLimitAnchor(width);
+            _haltFor = haltFor;
+        }
+
+        public RestrictionScope Scope => RestrictionScope.Trade;
+
+        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Halt;
+
+        // Trade-scoped only, so this is never asked.
+        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.BeyondDailyPriceLimit;
+
+        // Null never resumes on its own, which is what the level that ends a trading day wants.
+        public TimeSpan? ResumeAfter => _haltFor;
+
+        public bool Allows(long priceTicks, DateTime time) => _anchor.Allows(priceTicks);
+
+        public bool AllowsStopSpread(long spreadTicks) => true;
+
+        // A halt is ended by its own clock or by whoever drives the book, not by where the auction
+        // would print - so this never holds one open.
+        public bool AllowsResumption(long priceTicks, DateTime time) => true;
+
+        public void OnTrade(long priceTicks, DateTime time)
+        {
+        }
+
+        public void OnIndicativePrice(long? priceTicks)
+        {
+        }
+
+        public void OnSessionChange(long? referencePriceTicks) => _anchor.OnSessionChange(referencePriceTicks);
+    }
+}

--- a/Circus/OrderBook/DailyPriceLimitRestriction.cs
+++ b/Circus/OrderBook/DailyPriceLimitRestriction.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Circus.OrderBook
+{
+    // A session-long ceiling and floor set against a settlement price. The only restriction that
+    // neither rejects nor interrupts: trading continues, at the limit price, and simply cannot go
+    // through it. CME's limit-lock, which is why a limit-up market is still open and still quoting
+    // rather than halted - it can trade back inside at any moment.
+    //
+    // Both scopes, so one anchor answers both questions: an order priced beyond the limit is turned
+    // away at entry, and a prospective trade beyond it does not print. Those have to agree, and the
+    // surest way to make them agree is for them to be the same object.
+    internal sealed class DailyPriceLimitRestriction : IPriceRestriction
+    {
+        private readonly SessionLimitAnchor _anchor;
+
+        internal DailyPriceLimitRestriction(PriceLimitWidth width)
+        {
+            _anchor = new SessionLimitAnchor(width);
+        }
+
+        public RestrictionScope Scope => RestrictionScope.OrderEntry | RestrictionScope.Trade;
+
+        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Block;
+
+        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.BeyondDailyPriceLimit;
+
+        // A limit interrupts nothing, so there is nothing to resume from. It ends when the session
+        // does, or when a new reference price replaces it.
+        public TimeSpan? ResumeAfter => null;
+
+        public bool Allows(long priceTicks, DateTime time) => _anchor.Allows(priceTicks);
+
+        // Not a band: it has no view on how a stop is priced beyond the limit check itself, which
+        // the trigger and limit prices each face on their own.
+        public bool AllowsStopSpread(long spreadTicks) => true;
+
+        public bool AllowsResumption(long priceTicks, DateTime time) => true;
+
+        public void OnTrade(long priceTicks, DateTime time)
+        {
+        }
+
+        public void OnIndicativePrice(long? priceTicks)
+        {
+        }
+
+        public void OnSessionChange(long? referencePriceTicks) => _anchor.OnSessionChange(referencePriceTicks);
+    }
+}

--- a/Circus/OrderBook/IPriceRestriction.cs
+++ b/Circus/OrderBook/IPriceRestriction.cs
@@ -2,33 +2,42 @@ using System;
 
 namespace Circus.OrderBook
 {
+    // Flags, because a daily price limit is both: it refuses an order priced beyond the limit and
+    // refuses to print through it. Everything else governs one or the other.
+    [Flags]
     internal enum RestrictionScope
     {
-        OrderEntry,
-        Trade
+        OrderEntry = 1,
+        Trade = 2
     }
 
     internal enum RestrictionBreachAction
     {
         Reject,
+        Block,
         Pause,
         Halt
     }
 
     // A breached Trade-scoped restriction: what it costs the book, and how long for. ResumeAfter
-    // null leaves the interruption open-ended, waiting for someone to end it explicitly.
+    // null leaves the interruption open-ended, waiting for someone to end it explicitly - and for
+    // Block means nothing at all, since a limit does not interrupt anything to be resumed from.
     internal readonly record struct RestrictionBreach(RestrictionBreachAction Action, TimeSpan? ResumeAfter);
 
-    // A price-restriction adapter: the order-entry price band and the trade-time volatility band
-    // are the two that exist today; velocity limits and circuit breakers are expected future
-    // adapters. Each adapter owns its own reference price - there is no shared anchor - updating
-    // it from OnTrade (last-trade-anchored bands) and/or OnSessionChange (session-fixed limits).
+    // A price-restriction adapter. Each owns its own reference price - there is no shared anchor -
+    // updating it from OnTrade (ranges that follow the market), OnIndicativePrice (the entry band
+    // during an auction) and/or OnSessionChange (limits fixed against a settlement price).
     internal interface IPriceRestriction
     {
         RestrictionScope Scope { get; }
 
-        // Only consulted for Scope == Trade - an OrderEntry breach always means "reject the order".
+        // Only consulted for Scope carrying Trade - an OrderEntry breach always rejects the order.
         RestrictionBreachAction OnBreach { get; }
+
+        // Which rejection an order refused by this restriction earns. Only consulted for Scope
+        // carrying OrderEntry: an order turned away by a band and one turned away by a daily limit
+        // are not the same thing to whoever sent it.
+        OrderRejectedReason EntryRejectionReason { get; }
 
         // How long the interruption this restriction causes lasts before the book returns by
         // itself. Null means it does not end on its own. Only consulted for Scope == Trade.

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -19,6 +19,10 @@ namespace Circus.OrderBook
         private DateTime? _resumeAt;
         private OrderBookStatus _resumeTo;
 
+        // Which way a daily limit currently has the market stuck, so the state is published on the
+        // change rather than on every sweep it turns away. Null is a market free to trade.
+        private Side? _limitState;
+
         // The indicative quote as last published, so only moves in it are emitted.
         private (long PriceTicks, int Quantity)? _indicativeQuote;
 
@@ -107,6 +111,8 @@ namespace Circus.OrderBook
                     // window, and the two configs exist to say which is meant, not to behave apart.
                     VelocityLimit limit => new VolatilityBandRestriction(limit.RangeTicks, limit.PauseFor,
                         limit.Window),
+                    DailyPriceLimit limit => new DailyPriceLimitRestriction(limit.Width),
+                    CircuitBreaker breaker => new CircuitBreakerRestriction(breaker.Width, breaker.HaltFor),
                     _ => throw new ArgumentException($"Unknown price restriction {config.GetType().Name}")
                 }).ToList();
 
@@ -256,8 +262,8 @@ namespace Circus.OrderBook
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice);
             if (triggerTicks != null && side == Side.Sell && triggerTicks >= _lastTradedPrice)
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
-            if (priceTicks.HasValue && !AllowsOrderEntry(priceTicks.Value))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.PriceOutsideBands);
+            if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
+                return RejectCreate(companyId, clientOrderId, entryRefusal);
             if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int minQty } && (minQty < 1 || minQty > quantity))
                 return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MinQuantityOutOfRange);
             if (maxVisibleQuantity.HasValue && (maxVisibleQuantity < 1 || maxVisibleQuantity > quantity))
@@ -340,15 +346,27 @@ namespace Circus.OrderBook
         // Client-supplied resting limit prices only. Trigger prices are governed by the
         // TriggerPriceMustBe... checks above, and Market/MarketLimit prices by
         // MarketOrderProtectionTicks.
-        private bool AllowsOrderEntry(long priceTicks) =>
-            _priceRestrictions.Where(r => r.Scope == RestrictionScope.OrderEntry)
-                .All(r => r.Allows(priceTicks, Now()));
+        // Null when every entry-scoped restriction allows the price, otherwise the rejection the
+        // first refusing one asks for - a band and a daily limit turn an order away for reasons
+        // that read differently to whoever sent it.
+        private OrderRejectedReason? FindOrderEntryRefusal(long priceTicks)
+        {
+            var time = Now();
+            foreach (var restriction in _priceRestrictions)
+            {
+                if (restriction.Scope.HasFlag(RestrictionScope.OrderEntry) &&
+                    !restriction.Allows(priceTicks, time))
+                    return restriction.EntryRejectionReason;
+            }
+
+            return null;
+        }
 
         // A stop elected far from its trigger would rest at a price the band would never have
         // accepted directly, so CME bounds the gap by the same band. Checked on the pair rather
         // than on either price, and only where a band exists to bound it.
         private bool AllowsStopSpread(long triggerTicks, long priceTicks) =>
-            _priceRestrictions.Where(r => r.Scope == RestrictionScope.OrderEntry)
+            _priceRestrictions.Where(r => r.Scope.HasFlag(RestrictionScope.OrderEntry))
                 .All(r => r.AllowsStopSpread(Math.Abs(priceTicks - triggerTicks)));
 
         // Only ever called on an order currently resting in the working book (a FAK remainder or
@@ -385,8 +403,8 @@ namespace Circus.OrderBook
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
             if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (priceTicks.HasValue && !AllowsOrderEntry(priceTicks.Value))
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.PriceOutsideBands);
+            if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
+                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, entryRefusal);
             if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
                 order.ClientOrderId != previousClientOrderId)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
@@ -637,14 +655,30 @@ namespace Circus.OrderBook
 
             foreach (var restriction in _priceRestrictions)
             {
-                if (restriction.Scope != RestrictionScope.Trade || restriction.Allows(priceTicks, time))
+                if (!restriction.Scope.HasFlag(RestrictionScope.Trade) || restriction.Allows(priceTicks, time))
                     continue;
 
-                if (worst == null || Severity(restriction.OnBreach) > Severity(worst.Value.Action))
-                    worst = new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
+                var breach = new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
+                if (worst == null || IsMoreSevere(breach, worst.Value))
+                    worst = breach;
             }
 
             return worst;
+        }
+
+        // Consequence first, then how long it lasts - a price through a circuit breaker's widest
+        // level is through its narrower ones too, and the market should be halted for as long as
+        // the level it actually reached says rather than the one it passed on the way. Never
+        // resuming outranks any duration, which is what the level that ends a trading day is.
+        private static bool IsMoreSevere(RestrictionBreach candidate, RestrictionBreach current)
+        {
+            if (Severity(candidate.Action) != Severity(current.Action))
+                return Severity(candidate.Action) > Severity(current.Action);
+
+            if (!candidate.ResumeAfter.HasValue || !current.ResumeAfter.HasValue)
+                return !candidate.ResumeAfter.HasValue && current.ResumeAfter.HasValue;
+
+            return candidate.ResumeAfter.Value > current.ResumeAfter.Value;
         }
 
         // Whether a restriction refuses to let the interruption the book is in end at the price it
@@ -669,7 +703,7 @@ namespace Circus.OrderBook
             {
                 // First refusal rather than the severest: every restriction refusing here is asking
                 // for the same thing, so there is nothing to rank.
-                if (restriction.Scope == RestrictionScope.Trade &&
+                if (restriction.Scope.HasFlag(RestrictionScope.Trade) &&
                     !restriction.AllowsResumption(priceTicks, time))
                     return new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
             }
@@ -681,8 +715,12 @@ namespace Circus.OrderBook
         // change. Reject never reaches here - it is an order-entry consequence.
         private static int Severity(RestrictionBreachAction action) => action switch
         {
-            RestrictionBreachAction.Halt => 2,
-            RestrictionBreachAction.Pause => 1,
+            RestrictionBreachAction.Halt => 3,
+            RestrictionBreachAction.Pause => 2,
+
+            // Below both: a limit-locked market is still open and still trading, at the limit. It
+            // is the mildest thing that can stop a sweep, not a form of interruption.
+            RestrictionBreachAction.Block => 1,
             _ => 0
         };
 
@@ -700,6 +738,13 @@ namespace Circus.OrderBook
 
                 case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity, var usesFullRemainingQuantity):
                     ApplyTrade(resting, aggressor, priceTicks, quantity, usesFullRemainingQuantity, events, time);
+                    break;
+
+                // A limit stops the sweep and nothing else: the market is open, quoting, and can
+                // trade at the limit and back inside it. Only the status is spared - the run has
+                // already ended, since Matcher.Run stops on any breach.
+                case TradeRestrictionBreached(var blockedTicks, {Action: RestrictionBreachAction.Block}):
+                    TakeLimitStateChange(blockedTicks, events);
                     break;
 
                 // Assigned directly rather than routed through UpdateStatus: this runs inside the
@@ -721,6 +766,39 @@ namespace Circus.OrderBook
                     TriggerStops(orders, time, events, pendingImmediateOrCancelStops);
                     break;
             }
+        }
+
+        // Which way the market is stuck, and only when that changes - a limit-locked book refuses
+        // every sweep that follows, and saying so once is enough. Direction comes from where the
+        // blocked price sits against the last one that traded; with nothing traded yet there is
+        // nothing to compare it to, and the price alone says where the limit is.
+        private void TakeLimitStateChange(long blockedTicks, List<OrderBookEvent> events)
+        {
+            var side = _lastTradedPrice switch
+            {
+                null => (Side?) null,
+                var last when blockedTicks > last => Side.Buy,
+                var last when blockedTicks < last => Side.Sell,
+                _ => _limitState
+            };
+
+            if (_limitState == side)
+                return;
+
+            _limitState = side;
+            events.Add(new LimitStateChanged(_security, Now(), side, ToDecimal(blockedTicks)));
+        }
+
+        // A print means the market is trading again, wherever it is trading. Releasing on any trade
+        // rather than on one strictly inside the limits is deliberate: trading at the limit is the
+        // market working, not the market stuck.
+        private void ReleaseLimitState(List<OrderBookEvent> events)
+        {
+            if (_limitState == null)
+                return;
+
+            _limitState = null;
+            events.Add(new LimitStateChanged(_security, Now(), null, null));
         }
 
         private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
@@ -760,6 +838,8 @@ namespace Circus.OrderBook
                 events.Add(restingReplenish);
             if (aggressorReplenish != null)
                 events.Add(aggressorReplenish);
+
+            ReleaseLimitState(events);
 
             if (_lastTradedPrice != priceTicks)
             {

--- a/Circus/OrderBook/OrderBookEvent.cs
+++ b/Circus/OrderBook/OrderBookEvent.cs
@@ -85,4 +85,15 @@ namespace Circus.OrderBook
     // no such price and so publishes none.
     public record IndicativePriceChanged(Security Security, DateTime Time, decimal? Price, int Quantity)
         : OrderBookEvent(Security, Time);
+
+    // The market has reached a daily price limit and cannot trade through it, or has come back
+    // inside one. Side is which way it is stuck: Buy for limit up, where buyers cannot push higher,
+    // Sell for limit down. Null with a null Price releases it, and is what a print inside the
+    // limits emits.
+    //
+    // Not a status change - a limit-locked market is open, quoting, and trading at the limit. That
+    // is the whole difference between a limit and a circuit breaker, so it gets an event of its own
+    // rather than a status that would claim otherwise. Emitted only on a change.
+    public record LimitStateChanged(Security Security, DateTime Time, Side? Side, decimal? Price)
+        : OrderBookEvent(Security, Time);
 }

--- a/Circus/OrderBook/OrderPriceRestriction.cs
+++ b/Circus/OrderBook/OrderPriceRestriction.cs
@@ -27,6 +27,8 @@ namespace Circus.OrderBook
         public RestrictionScope Scope => RestrictionScope.OrderEntry;
         public RestrictionBreachAction OnBreach => RestrictionBreachAction.Reject;
 
+        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
+
         // A rejection interrupts nothing, so there is nothing to resume from.
         public TimeSpan? ResumeAfter => null;
 

--- a/Circus/OrderBook/OrderRejectedReason.cs
+++ b/Circus/OrderBook/OrderRejectedReason.cs
@@ -35,6 +35,11 @@ namespace Circus.OrderBook
         // stop elected this far from its trigger would rest where the band would never have
         // accepted it directly. Appended rather than filed with the other TriggerPrice reasons, so
         // that no existing member's numeric value moves.
-        TriggerPriceTooFarFromPrice
+        TriggerPriceTooFarFromPrice,
+
+        // Beyond the session's ceiling or floor. Distinct from PriceOutsideBands because the two
+        // mean different things to whoever sent the order: a band moves with the market and will
+        // very likely accept the same price shortly, a daily limit stands for the session.
+        BeyondDailyPriceLimit
     }
 }

--- a/Circus/OrderBook/SessionLimitAnchor.cs
+++ b/Circus/OrderBook/SessionLimitAnchor.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Circus.OrderBook
+{
+    // The reference and resolved width shared by the two restrictions set against a settlement
+    // price rather than against a moving market. Both are inert until a reference arrives, because
+    // a percentage width has no size until there is something to take a percentage of.
+    //
+    // Deaf to trades by construction: a limit that followed the market would never be reached.
+    internal sealed class SessionLimitAnchor
+    {
+        private readonly PriceLimitWidth _width;
+
+        private long? _referencePriceTicks;
+        private long _widthTicks;
+
+        internal SessionLimitAnchor(PriceLimitWidth width)
+        {
+            _width = width;
+        }
+
+        internal bool Allows(long priceTicks) =>
+            !_referencePriceTicks.HasValue || Math.Abs(priceTicks - _referencePriceTicks.Value) <= _widthTicks;
+
+        // How far beyond the limit this width reaches, for ranking one against another. Zero until
+        // a reference resolves it.
+        internal long WidthTicks => _referencePriceTicks.HasValue ? _widthTicks : 0;
+
+        internal void OnSessionChange(long? referencePriceTicks)
+        {
+            if (!referencePriceTicks.HasValue)
+                return;
+
+            _referencePriceTicks = referencePriceTicks;
+            _widthTicks = Resolve(referencePriceTicks.Value);
+        }
+
+        // A percentage of the reference in ticks is a percentage of it in price, so the tick size
+        // never enters into it. Rounded to the nearest tick - a limit lands on a tradable price.
+        private long Resolve(long referencePriceTicks) => _width switch
+        {
+            PriceLimitWidth.Ticks ticks => ticks.Count,
+            PriceLimitWidth.Percent percent =>
+                (long) Math.Round(Math.Abs(referencePriceTicks) * percent.Value / 100m, MidpointRounding.AwayFromZero),
+            _ => throw new ArgumentException($"Unknown price limit width {_width.GetType().Name}")
+        };
+    }
+}

--- a/Circus/OrderBook/StaticPriceRangeRestriction.cs
+++ b/Circus/OrderBook/StaticPriceRangeRestriction.cs
@@ -23,6 +23,9 @@ namespace Circus.OrderBook
         public RestrictionScope Scope => RestrictionScope.Trade;
         public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
 
+        // Trade-scoped only, so this is never asked.
+        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
+
         public TimeSpan? ResumeAfter => _resumeAfter;
 
         // Inactive until a reference exists - nothing but a status change can supply one.

--- a/Circus/OrderBook/VolatilityBandRestriction.cs
+++ b/Circus/OrderBook/VolatilityBandRestriction.cs
@@ -38,6 +38,9 @@ namespace Circus.OrderBook
         public RestrictionScope Scope => RestrictionScope.Trade;
         public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
 
+        // Trade-scoped only, so this is never asked.
+        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
+
         // Eurex times its volatility interruptions rather than leaving them open; configuring no
         // duration leaves the pause standing until someone ends it.
         public TimeSpan? ResumeAfter => _resumeAfter;

--- a/Circus/PriceRestrictionConfig.cs
+++ b/Circus/PriceRestrictionConfig.cs
@@ -46,4 +46,29 @@ namespace Circus
     // range around the last trade, which is the other config.
     public sealed record VelocityLimit(int RangeTicks, TimeSpan Window, TimeSpan? PauseFor = null)
         : PriceRestrictionConfig;
+
+    // How wide a limit is. Every restriction above measures in ticks because it tracks a market
+    // that has already moved; the ones below are set against a settlement price before the day
+    // starts, and CME states those as percentages - 7, 13 and 20 percent for equity index. Resolved
+    // to ticks the moment a reference exists, since a percentage of nothing is not a width.
+    public abstract record PriceLimitWidth
+    {
+        public sealed record Ticks(int Count) : PriceLimitWidth;
+
+        public sealed record Percent(decimal Value) : PriceLimitWidth;
+    }
+
+    // A session-long ceiling and floor. Trading continues at the limit price but nothing prints
+    // through it and no order may be entered beyond it - CME's limit-lock, which is not a halt: the
+    // market stays open, quotes, and can trade back inside.
+    public sealed record DailyPriceLimit(PriceLimitWidth Width) : PriceRestrictionConfig;
+
+    // A threshold that stops trading outright rather than capping it. Several are ordinarily
+    // configured together - CME's equity index breakers halt at 7 and 13 percent and end the day at
+    // 20 - and the widest one breached is the one served, so a price through all three halts for
+    // however long the 20 percent level says rather than the 7 percent level.
+    //
+    // HaltFor null never resumes on its own, which is what the level that ends a trading day wants:
+    // whoever drives the book closes it.
+    public sealed record CircuitBreaker(PriceLimitWidth Width, TimeSpan? HaltFor = null) : PriceRestrictionConfig;
 }

--- a/Readme.md
+++ b/Readme.md
@@ -41,8 +41,8 @@ Safety features
 - [x] Banding
 - [x] Volatility interruptions (dynamic, static and extended ranges)
 - [x] Velocity logic (too far, too fast over a rolling window)
-- [ ] Daily price limits (static, session-long limit up/down)
-- [ ] Circuit breakers
+- [x] Daily price limits (static, session-long limit up/down)
+- [x] Circuit breakers (levelled, widest breached level wins)
 - [ ] Stop price logic
 - [x] Self-match prevention
 


### PR DESCRIPTION
Step 5, the last of the three restriction families and the last of your three original asks. Third of the three PRs covering steps 3–5.

## Widths that aren't tick counts

These are the first restrictions set against a settlement price *before* a day starts, rather than against a market that has already moved — and CME states them as percentages (7, 13, 20% for equity index). So a width is now either `Ticks` or `Percent`, resolved to ticks the moment a reference exists. A percentage of nothing isn't a width, so both restrictions are inert until one arrives.

A percentage of the reference *in ticks* is a percentage of it *in price*, so tick size never enters the calculation.

## Daily limits: the restriction that neither rejects nor interrupts

Trading continues, at the limit price, and simply cannot go through it. The market stays open, keeps quoting, and can come back inside at any moment — that's CME's limit-lock, and it's why it can't be modelled as a halt.

That needed a third breach consequence: **`Block` stops the sweep and touches nothing else.** `Matcher.Run` already ends on any breach, so the only thing to get right was leaving the status alone.

It's also the first restriction to govern **both** order entry and trades, so `RestrictionScope` became `[Flags]` and one anchor answers both questions. Those two answers have to agree, and the surest way to make them agree is for them to be the same object.

Which rejection an order earns moved onto the restriction with it (`EntryRejectionReason`), and `BeyondDailyPriceLimit` joins `PriceOutsideBands` — appended, so no existing value moves. They aren't the same thing to whoever sent the order: a band moves with the market and will very likely take the price shortly; a daily limit stands for the session.

## Circuit breakers, and a severity tiebreak

Breakers halt, reusing the timed machinery from #48, and come in levels. A price through the widest is through all of them — so **severity now breaks ties on duration**: a longer halt outranks a shorter one, and one that never resumes outranks both. Without that, the order the levels happen to be declared in would decide how long a market stayed shut, which is the same class of bug the severity ranking itself fixed in #48.

The level that ends a trading day is configured with no `HaltFor`. As flagged in the plan, it lands on `Halted` with no resume and leaves closing to whoever drives the book, rather than expiring orders from inside the `Run`/`Apply` loop — which would re-enter the matcher.

## Limit state as an event, not a status

A limit-locked market is open and trading, so a status would claim something false. `LimitStateChanged` says which way it's stuck — `Buy` for limit up, where buyers can't push higher — once, and again when a print releases it. Not on every sweep it turns away in between.

## A note on the tests

Because entry and trades face the same limit, **an order beyond it can't simply be sent** — which is the point, and which makes the `Block` path awkward to reach. My first two attempts at these tests never got there: the incoming order was rejected at entry, so the sweep never ran and the assertions passed for the wrong reason.

The setup that actually works: rest an order out there while the limit is *wider*, then move the reference so the limit narrows under it. The book then holds its own resting buy above the ceiling, and a perfectly enterable sell crossing into it is what the sweep has to refuse. That's the state the `Block` path exists for.

The circuit-breaker levels are declared narrowest-first and the volatility band is declared before the breaker, so both ordering-sensitive tests would pass trivially if reversed.

## Verification

No .NET SDK in this environment (install host blocked by the sandbox network policy), so CI is the first execution, as with #46–#52. **This is the largest of the six PRs** and the one most likely to disturb something: `RestrictionScope` changing to flags moves `OrderEntry` from 0 to 1 and touches all four scope tests, and the entry-rejection path changed shape. Expect **347** to hold plus the new cases; a drop in the price-band or auction fixtures is where I'd look first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_