### PR TITLE
Publish what state an instrument is in

### DIFF
--- a/Circus.Examples/DataProducerExample.cs
+++ b/Circus.Examples/DataProducerExample.cs
@@ -18,53 +18,48 @@ namespace Circus.Examples
             IOrderBook book1 = new InMemoryOrderBook(sec1, time);
             IOrderBook book2 = new InMemoryOrderBook(sec2, time);
 
-            // LevelDataProducer maintains its own per-book state, so each book needs its own
-            // instances (one per data tier) rather than sharing a single producer across books.
-            var tradeDataProducer1 = new TradeDataProducer();
-            var bboDataProducer1 = new LevelDataProducer(1);
-            var top10DataProducer1 = new LevelDataProducer(10);
-            var fullBookDataProducer1 = new FullBookDataProducer();
-            var indicativeDataProducer1 = new IndicativePriceDataProducer();
-
-            var tradeDataProducer2 = new TradeDataProducer();
-            var bboDataProducer2 = new LevelDataProducer(1);
-            var top10DataProducer2 = new LevelDataProducer(10);
-            var fullBookDataProducer2 = new FullBookDataProducer();
-            var indicativeDataProducer2 = new IndicativePriceDataProducer();
-
-            void Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> events, TradeDataProducer tradeDataProducer,
-                LevelDataProducer bboDataProducer, LevelDataProducer top10DataProducer,
-                FullBookDataProducer fullBookDataProducer, IndicativePriceDataProducer indicativeDataProducer)
-            {
-                Print(tradeDataProducer.Process(book, events));
-                Print(bboDataProducer.Process(book, events));
-                Print(top10DataProducer.Process(book, events));
-                Print(fullBookDataProducer.Process(book, events));
-                Print(indicativeDataProducer.Process(book, events));
-            }
+            var feed1 = new BookFeed();
+            var feed2 = new BookFeed();
 
             // book1 opens on an auction: orders accumulate in pre-open with the indicative quote
             // tracking them, and the print happens on the way out - the same orders as book2, which
             // opens first and trades them continuously.
-            Publish(book1, book1.UpdateStatus(OrderBookStatus.PreOpen), tradeDataProducer1, bboDataProducer1,
-                top10DataProducer1, fullBookDataProducer1, indicativeDataProducer1);
-            Publish(book1, book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100),
-                tradeDataProducer1, bboDataProducer1, top10DataProducer1, fullBookDataProducer1,
-                indicativeDataProducer1);
-            Publish(book1, book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100),
-                tradeDataProducer1, bboDataProducer1, top10DataProducer1, fullBookDataProducer1,
-                indicativeDataProducer1);
-            Publish(book1, book1.UpdateStatus(OrderBookStatus.Open), tradeDataProducer1, bboDataProducer1,
-                top10DataProducer1, fullBookDataProducer1, indicativeDataProducer1);
+            feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.PreOpen));
+            feed1.Publish(book1,
+                book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+            feed1.Publish(book1,
+                book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+            feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.Open));
 
-            Publish(book2, book2.UpdateStatus(OrderBookStatus.Open), tradeDataProducer2, bboDataProducer2,
-                top10DataProducer2, fullBookDataProducer2, indicativeDataProducer2);
-            Publish(book2, book2.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100),
-                tradeDataProducer2, bboDataProducer2, top10DataProducer2, fullBookDataProducer2,
-                indicativeDataProducer2);
-            Publish(book2, book2.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100),
-                tradeDataProducer2, bboDataProducer2, top10DataProducer2, fullBookDataProducer2,
-                indicativeDataProducer2);
+            feed2.Publish(book2, book2.UpdateStatus(OrderBookStatus.Open));
+            feed2.Publish(book2,
+                book2.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+            feed2.Publish(book2,
+                book2.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+        }
+
+        // One set of producers per book. The level and status producers each build their own view
+        // of a single book out of its event stream alone, so a set cannot be shared across two -
+        // and there is no way to resync one that missed an event, which is why they are created
+        // before the book they follow processes anything.
+        private sealed class BookFeed
+        {
+            private readonly TradeDataProducer _trades = new();
+            private readonly LevelDataProducer _bbo = new(1);
+            private readonly LevelDataProducer _top10 = new(10);
+            private readonly FullBookDataProducer _fullBook = new();
+            private readonly IndicativePriceDataProducer _indicative = new();
+            private readonly SecurityStatusDataProducer _status = new();
+
+            public void Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+            {
+                Print(_trades.Process(book, events));
+                Print(_bbo.Process(book, events));
+                Print(_top10.Process(book, events));
+                Print(_fullBook.Process(book, events));
+                Print(_indicative.Process(book, events));
+                Print(_status.Process(book, events));
+            }
         }
 
         private static void Print(IEnumerable<TradedDataEvent> events)
@@ -93,6 +88,14 @@ namespace Circus.Examples
         }
 
         private static void Print(IEnumerable<OrderBookDeltaEvent> events)
+        {
+            foreach (var @event in events)
+            {
+                Console.WriteLine(@event);
+            }
+        }
+
+        private static void Print(IEnumerable<SecurityStatusDataEvent> events)
         {
             foreach (var @event in events)
             {

--- a/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Circus.DataProducers;
+using Circus.OrderBook;
+using Circus.TimeProviders;
+using NUnit.Framework;
+
+namespace Circus.Tests.DataProducers
+{
+    public class SecurityStatusDataProducerTests
+    {
+        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+        private TestTimeProvider TimeProvider;
+        private SecurityStatusDataProducer Producer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TimeProvider = new TestTimeProvider(Now1);
+            Producer = new SecurityStatusDataProducer();
+        }
+
+        private IList<SecurityStatusDataEvent> Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> bookEvents) =>
+            Producer.Process(book, bookEvents);
+
+        private IOrderBook PlainBook() =>
+            new InMemoryOrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), TimeProvider);
+
+        // A 5-tick volatility range on a reference of 100, pausing for two minutes.
+        private IOrderBook PausingBook() =>
+            new InMemoryOrderBook(
+                new Security("GCZ6", SecurityType.Future, 10, 10,
+                    PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)}),
+                TimeProvider);
+
+        [Test]
+        public void OrdinaryOpen_PublishesTheStatusAndNothingPending()
+        {
+            // arrange
+            var book = PlainBook();
+
+            // act
+            var events = Publish(book, book.UpdateStatus(OrderBookStatus.Open));
+
+            // assert
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(Now1, events[0].Time);
+            Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
+            Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason);
+            Assert.IsNull(events[0].ResumesAt);
+            Assert.IsNull(events[0].LimitState);
+        }
+
+        [Test]
+        public void OrderFlowChangingNeitherStatusNorLimit_PublishesNothing()
+        {
+            // arrange
+            var book = PlainBook();
+            Publish(book, book.UpdateStatus(OrderBookStatus.Open));
+
+            // act
+            var events = Publish(book,
+                book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+
+            // assert
+            Assert.AreEqual(0, events.Count);
+        }
+
+        [Test]
+        public void VolatilityPause_PublishesTheReasonAndWhenItIsDueBack()
+        {
+            // arrange - referenced at 100, so a trade at 200 breaches the range
+            var book = PausingBook();
+            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+            Publish(book, book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200));
+
+            // act
+            var events = Publish(book,
+                book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
+
+            // assert - the moment it is due back is the thing a halt notification is for, and it
+            // could not be published at all before this producer existed
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(OrderBookStatus.Paused, events[0].Status);
+            Assert.AreEqual(StatusChangeReason.PriceRestriction, events[0].Reason);
+            Assert.AreEqual(Now1 + PauseFor, events[0].ResumesAt);
+        }
+
+        [Test]
+        public void PauseElapsing_PublishesTheResumptionWithNothingPending()
+        {
+            // arrange - paused, due back in two minutes
+            var book = PausingBook();
+            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
+            Publish(book, book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
+
+            // act
+            TimeProvider.SetCurrentTime(Now1 + PauseFor);
+            var events = Publish(book, book.AdvanceTime());
+
+            // assert
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
+            Assert.AreEqual(StatusChangeReason.InterruptionElapsed, events[0].Reason);
+            Assert.IsNull(events[0].ResumesAt, "back to trading, so nothing is pending");
+        }
+
+        [Test]
+        public void OpenEndedInterruption_PublishesNoResumeTime()
+        {
+            // arrange - a range with no duration configured stands until something ends it
+            var book = new InMemoryOrderBook(
+                new Security("GCZ6", SecurityType.Future, 10, 10,
+                    PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)}),
+                TimeProvider);
+            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
+
+            // act
+            var events = Publish(book,
+                book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Paused, events[0].Status);
+            Assert.IsNull(events[0].ResumesAt);
+        }
+
+        [Test]
+        public void LimitLock_PublishesTheSideWhileTheStatusStaysOpen()
+        {
+            // arrange - a book holding a buy above the ceiling, reached by resting it while the
+            // limit was wider and then moving the reference so the limit narrows under it. The
+            // clock moves on so that buy is genuinely the older order when the sell arrives.
+            var book = new InMemoryOrderBook(
+                new Security("GCZ6", SecurityType.Future, 10, 10,
+                    PriceRestrictions: new PriceRestrictionConfig[]
+                    {
+                        new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
+                    }),
+                TimeProvider);
+
+            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 200));
+            book.CreateLimitOrder("Company1", "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
+            book.CreateLimitOrder("Company2", "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
+            book.CreateLimitOrder("Company2", "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
+
+            TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
+            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+
+            // act - a sell inside the limit, crossing into the buy that is not
+            var events = Publish(book,
+                book.CreateLimitOrder("Company1", "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150));
+
+            // assert - stuck, and still open. That a limit is not a status is the whole reason it
+            // needs assembling with one.
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(Side.Buy, events[0].LimitState);
+            Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
+            Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason,
+                "the last status change is still what put it here");
+
+            // act - the order out beyond the ceiling is pulled and the book trades inside the limit
+            book.CancelOrder("Company2", "Cancel1", "Buy2");
+            var released = Publish(book,
+                book.CreateLimitOrder("Company2", "Buy3", new OrderValidity.Day(), Side.Buy, 5, 150));
+
+            // assert
+            Assert.AreEqual(1, released.Count);
+            Assert.IsNull(released[0].LimitState);
+            Assert.AreEqual(OrderBookStatus.Open, released[0].Status);
+        }
+
+        [Test]
+        public void StatusCarriesForwardAcrossALimitChange()
+        {
+            // arrange - a status the limit event must not disturb
+            var book = PlainBook();
+            var opened = Publish(book, book.UpdateStatus(OrderBookStatus.Paused));
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Paused, opened.Single().Status);
+
+            // act - a limit event arriving on its own carries the remembered status with it, which
+            // is what holding state is for
+            var events = Producer.Process(book,
+                new OrderBookEvent[] {new LimitStateChanged(book.Security, Now1, Side.Sell, 90)});
+
+            // assert
+            Assert.AreEqual(OrderBookStatus.Paused, events.Single().Status);
+            Assert.AreEqual(Side.Sell, events.Single().LimitState);
+        }
+    }
+}

--- a/Circus/DataProducers/SecurityStatusDataProducer.cs
+++ b/Circus/DataProducers/SecurityStatusDataProducer.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Circus.OrderBook;
+
+namespace Circus.DataProducers
+{
+    // What state an instrument is in, as one thing - CME's Security Status message, Eurex's
+    // instrument state. The book publishes the parts separately because they are separate: a status
+    // change and a limit lock are different events, and a limit-locked market is open. A subscriber
+    // wanting to render "what is happening to this instrument" wants them together, and assembling
+    // them is this producer's whole job.
+    //
+    // Stateful, like the level producers and unlike the trade and indicative ones: each incoming
+    // event carries only its own part, so the rest has to be remembered. That means one instance per
+    // IOrderBook, created before that book processes its first action, with no way to resync after a
+    // missed event.
+    //
+    // Starts where a book starts - closed, nothing pending, no limit - so the first status change
+    // is a change from something true rather than from a guess.
+    public class SecurityStatusDataProducer : IDataProducer<SecurityStatusDataEvent>
+    {
+        private OrderBookStatus _status = OrderBookStatus.Closed;
+        private StatusChangeReason _reason = StatusChangeReason.Requested;
+        private DateTime? _resumesAt;
+        private Side? _limitState;
+
+        public IList<SecurityStatusDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+        {
+            List<SecurityStatusDataEvent>? output = null;
+
+            foreach (var ev in events)
+            {
+                switch (ev)
+                {
+                    case StatusChanged status:
+                        _status = status.Status;
+                        _reason = status.Reason;
+                        _resumesAt = status.ResumesAt;
+                        break;
+
+                    // A limit says nothing about the status, and must not disturb it: the market is
+                    // open, and stuck.
+                    case LimitStateChanged limit:
+                        _limitState = limit.Side;
+                        break;
+
+                    default:
+                        continue;
+                }
+
+                // One per contributing event, carrying that event's own time rather than a time
+                // chosen for a batch. Each is a complete picture, so a consumer never needs two.
+                output ??= new List<SecurityStatusDataEvent>();
+                output.Add(new SecurityStatusDataEvent(ev.Time, _status, _reason, _resumesAt, _limitState));
+            }
+
+            return output ?? (IList<SecurityStatusDataEvent>) Array.Empty<SecurityStatusDataEvent>();
+        }
+    }
+
+    // ResumesAt is when a timed interruption is due back, null when nothing is pending. LimitState
+    // is which way a daily limit has the market stuck - Buy for limit up, where buyers cannot push
+    // higher - and null when it is free to trade.
+    public record SecurityStatusDataEvent(DateTime Time, OrderBookStatus Status, StatusChangeReason Reason,
+        DateTime? ResumesAt, Side? LimitState);
+}

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -759,7 +759,8 @@ namespace Circus.OrderBook
                         ? OrderBookStatus.Halted
                         : OrderBookStatus.Paused;
                     _resumeAt = breach.ResumeAfter.HasValue ? Now() + breach.ResumeAfter.Value : null;
-                    events.Add(new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction));
+                    events.Add(new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction,
+                        _resumeAt));
                     break;
 
                 case StopsTriggered(var orders):
@@ -933,7 +934,7 @@ namespace Circus.OrderBook
                 // interruption is still running and why, which is the same thing a fresh one says.
                 _resumeAt = extension.Value.ResumeAfter.HasValue ? Now() + extension.Value.ResumeAfter.Value : null;
                 return new List<OrderBookEvent>
-                    {new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction)};
+                    {new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction, _resumeAt)};
             }
 
             // Any transition supersedes a pending one, so a session closing over a running pause
@@ -958,7 +959,9 @@ namespace Circus.OrderBook
                 _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
             }
 
-            var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status, reason)};
+            // _resumeAt was cleared above, so this reports nothing pending - which is what an
+            // explicit transition means, having just superseded whatever was.
+            var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status, reason, _resumeAt)};
 
             // A quoting phase has been accumulating orders for a print, and leaving it is where
             // that print happens - so a second auction phase would need nothing changed here.

--- a/Circus/OrderBook/OrderBookEvent.cs
+++ b/Circus/OrderBook/OrderBookEvent.cs
@@ -6,8 +6,12 @@ namespace Circus.OrderBook
     public record OrderBookEvent(Security Security, DateTime Time);
 
     // Reason defaults to Requested, which is what every externally driven transition is.
+    //
+    // ResumesAt is when a timed interruption is due to end, and is null for everything else - which
+    // includes an interruption configured to last until told otherwise, and every ordinary
+    // transition, since an explicit one supersedes whatever was pending.
     public record StatusChanged(Security Security, DateTime Time, OrderBookStatus Status,
-            StatusChangeReason Reason = StatusChangeReason.Requested)
+            StatusChangeReason Reason = StatusChangeReason.Requested, DateTime? ResumesAt = null)
         : OrderBookEvent(Security, Time);
 
     public record OrderEvent(Security Security, DateTime Time, string CompanyId, string ClientOrderId,

--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,7 @@ Market data
 - [x] Price/qty/count for x levels
 - [x] All order updates
 - [x] Indicative open
+- [x] Security status (trading state, why, when it resumes, limit up/down)
 
 Safety features
 - [x] Banding


### PR DESCRIPTION
Step 6, the last of the price-restriction plan.

## The gap

Five restriction families can pause a book, halt it, or lock it at a daily limit — and none of it reached a consumer as one thing. The parts were published separately because they *are* separate: a status change and a limit lock are different events, and a limit-locked market is open. But a subscriber wanting to render "what is happening to this instrument" wants them together, and assembling them is what every other market-data tier already has a producer for.

## One thing the book had to start publishing

`_resumeAt` never left the book, so a halt could be announced but **not its duration** — the most useful thing about announcing one. `StatusChanged` now carries `ResumesAt`, null wherever nothing is pending, which includes every ordinary transition since an explicit one supersedes whatever was.

All three construction sites pass `_resumeAt` uniformly: set immediately before at the breach and extended-interruption sites, cleared a few lines earlier on the ordinary path. Defaulted and positional-last, so nothing existing moves.

## The producer

```csharp
SecurityStatusDataEvent(DateTime Time, OrderBookStatus Status, StatusChangeReason Reason,
                        DateTime? ResumesAt, Side? LimitState)
```

Stateful, unlike the trade and indicative producers, because each event carries only its own part and the rest has to be remembered — same one-instance-per-book rule the level producers already document. It starts at `Closed`/`Requested`, matching the book's own initial status, so the first change is a change from something true rather than from a guess.

**One complete picture per contributing event, carrying that event's own time** rather than one per batch. Each snapshot stands alone, so a consumer never needs two, and it avoids `LevelDataProducer`'s wart of stamping a batch with `events[0].Time`.

It keeps this codebase's vocabulary rather than a wire format's — `OrderBookStatus` already says more than CME's `SecurityTradingStatus` integer codes would, and the venues are cited in comments as everywhere else.

## A departure from the plan

I said I'd wire the new producer into `DataProducerExample` alongside the other five. Doing that literally meant a seventh parameter on a local `Publish` helper already threading five producers through six call sites — making a straining signature worse to demonstrate an addition.

Instead the example now gathers its producers into a `BookFeed` per book. The calls go from three wrapped lines each to one, and the set *is* what the existing per-book comment was describing. It's a slightly larger diff in that file than "add a producer" implies, so worth knowing it's deliberate.

## Tests

Driving a real book, following `IndicativePriceDataProducerTests`. The two carrying the weight:

- a volatility breach publishing `Paused`/`PriceRestriction` **and the moment it's due back** — which couldn't be published at all before this step;
- a daily limit lock publishing the side **while the status stays `Open`**, which is the whole reason limit state isn't a status, and a print releasing it.

Plus an open-ended interruption publishing no resume time, order flow that changes neither publishing nothing, and status carrying forward across a limit-only event — the one test that hand-builds an event, because a paused book won't produce a limit change on its own.

That limit-lock test reuses the setup from #53: rest an order above the ceiling while the limit is wider, move the reference so the limit narrows under it, and advance the clock so the resting order is genuinely older. All three are needed or the `Block` path isn't reached — the lesson from #53's CI failure.

## Verification

No .NET SDK in this environment (install host blocked by the sandbox network policy), so CI is the first execution, as with #46–#53. Expect **357** to hold plus the new cases: `ResumesAt` is additive and defaulted, and no existing test constructs a `StatusChanged`. The example is compiled by CI but not run, so its refactor is checked for compilation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNLiwdynULrZ4sy7NhCgbe)_