### PR TITLE
Give the repository a single place to set build conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,203 @@
+# EditorConfig - https://editorconfig.org
+#
+# Codifies the conventions the codebase already follows, so an IDE applies them without being
+# asked and `dotnet format` can check them. Style rules are IDE/`dotnet format` diagnostics only:
+# EnforceCodeStyleInBuild is deliberately left off, so nothing here can turn a clean build noisy.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+# Two trailing spaces are a hard line break in Markdown.
+trim_trailing_whitespace = false
+
+[*.{csproj,props,targets}]
+indent_size = 4
+
+[*.cs]
+max_line_length = 120
+
+#### Using directives ####
+
+# Both match current practice: usings sit above the namespace, System first.
+csharp_using_directive_placement = outside_namespace:warning
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+dotnet_style_prefer_simplified_using_statement = true:suggestion
+
+#### Namespaces ####
+
+# Aspirational, and the reason this is a suggestion rather than a warning: every file is still
+# block-scoped. Flip to `:warning` once the file-scoped conversion has been done.
+csharp_style_namespace_declarations = file_scoped:suggestion
+
+#### Layout and braces ####
+
+# Allman, as used throughout.
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+#### Modifiers ####
+
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+#### Expression-bodied members ####
+
+# Single-line expression bodies are used heavily for methods and properties; multi-line members
+# keep a block body.
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = when_possible:suggestion
+csharp_style_expression_bodied_indexers = when_possible:suggestion
+csharp_style_expression_bodied_accessors = when_possible:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas = when_possible:suggestion
+csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
+
+#### var ####
+
+# `var` throughout, whatever the type. Silent because the existing code is already consistent and
+# this is not worth a diagnostic either way.
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+
+#### Language features the codebase already uses ####
+
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+# Silent: the codebase is genuinely mixed here (PriceLadder uses one, InMemoryOrderBook does not),
+# and that looks like a per-type judgement rather than a convention waiting to be enforced.
+csharp_style_prefer_primary_constructors = true:silent
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#### Naming ####
+
+# Interfaces: IPascalCase
+dotnet_naming_rule.interfaces_are_prefixed.severity = warning
+dotnet_naming_rule.interfaces_are_prefixed.symbols = interface_symbols
+dotnet_naming_rule.interfaces_are_prefixed.style = i_prefixed_pascal_case
+dotnet_naming_symbols.interface_symbols.applicable_kinds = interface
+dotnet_naming_style.i_prefixed_pascal_case.required_prefix = I
+dotnet_naming_style.i_prefixed_pascal_case.capitalization = pascal_case
+
+# Types and type-like members: PascalCase
+dotnet_naming_rule.types_are_pascal_case.severity = warning
+dotnet_naming_rule.types_are_pascal_case.symbols = type_symbols
+dotnet_naming_rule.types_are_pascal_case.style = pascal_case
+dotnet_naming_symbols.type_symbols.applicable_kinds = class,struct,enum,delegate,type_parameter
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_rule.members_are_pascal_case.severity = warning
+dotnet_naming_rule.members_are_pascal_case.symbols = member_symbols
+dotnet_naming_rule.members_are_pascal_case.style = pascal_case
+dotnet_naming_symbols.member_symbols.applicable_kinds = property,method,event,namespace
+
+# Constants and static readonly fields: PascalCase (MaxClientOrderIdLength, MaxLevels, Sec)
+dotnet_naming_rule.constants_are_pascal_case.severity = warning
+dotnet_naming_rule.constants_are_pascal_case.symbols = constant_symbols
+dotnet_naming_rule.constants_are_pascal_case.style = pascal_case
+dotnet_naming_symbols.constant_symbols.applicable_kinds = field
+dotnet_naming_symbols.constant_symbols.required_modifiers = const
+
+dotnet_naming_rule.static_readonly_fields_are_pascal_case.severity = warning
+dotnet_naming_rule.static_readonly_fields_are_pascal_case.symbols = static_readonly_field_symbols
+dotnet_naming_rule.static_readonly_fields_are_pascal_case.style = pascal_case
+dotnet_naming_symbols.static_readonly_field_symbols.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_field_symbols.required_modifiers = static,readonly
+
+# Instance fields: _camelCase (_security, _timeProvider, _matcher)
+dotnet_naming_rule.instance_fields_are_underscore_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_are_underscore_camel_case.symbols = instance_field_symbols
+dotnet_naming_rule.instance_fields_are_underscore_camel_case.style = underscore_camel_case
+dotnet_naming_symbols.instance_field_symbols.applicable_kinds = field
+dotnet_naming_symbols.instance_field_symbols.applicable_accessibilities = private,protected,internal,protected_internal,private_protected
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
+# Locals: camelCase.
+#
+# Deliberately not `parameter`: a positional record's parameters are syntactically parameters but
+# become public properties, so they are PascalCase here and everywhere else. Circus is built out of
+# positional records, and a parameter rule would flag every one of them.
+dotnet_naming_rule.locals_are_camel_case.severity = warning
+dotnet_naming_rule.locals_are_camel_case.symbols = local_symbols
+dotnet_naming_rule.locals_are_camel_case.style = camel_case
+dotnet_naming_symbols.local_symbols.applicable_kinds = local
+dotnet_naming_style.camel_case.capitalization = camel_case

--- a/Circus.Benchmarks/Circus.Benchmarks.csproj
+++ b/Circus.Benchmarks/Circus.Benchmarks.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- TargetFramework, Nullable and IsPackable=false come from Directory.Build.props. -->
+
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Circus.Examples/Circus.Examples.csproj
+++ b/Circus.Examples/Circus.Examples.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- TargetFramework, Nullable and IsPackable=false come from Directory.Build.props. -->
+
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Circus.Simulator/Circus.Simulator.csproj
+++ b/Circus.Simulator/Circus.Simulator.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+    <!-- TargetFramework, Nullable and IsPackable=false come from Directory.Build.props. -->
 
     <ItemGroup>
       <ProjectReference Include="..\Circus\Circus.csproj" />

--- a/Circus.Tests/Circus.Tests.csproj
+++ b/Circus.Tests/Circus.Tests.csproj
@@ -1,9 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+    <!-- TargetFramework and IsPackable=false come from Directory.Build.props. -->
 
-        <IsPackable>false</IsPackable>
+    <PropertyGroup>
+        <!--
+            The one project that does not inherit Nullable=enable. It has never been built with
+            nullable analysis on, and the `events[0] as SomeEvent` + Assert.IsNotNull pattern used
+            throughout the assertions is exactly what it flags. Turning it on is a change worth
+            making on its own, with the resulting diagnostics in front of you.
+        -->
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Circus/Circus.csproj
+++ b/Circus/Circus.csproj
@@ -1,22 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- TargetFramework, Nullable and the shared package metadata come from Directory.Build.props. -->
+
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageVersion>0.6.0</PackageVersion>
         <Title>Circus</Title>
-        <Authors>seanoflynn</Authors>
         <Description>Financial exchange simulator.</Description>
-        <Copyright>Copyright 2021</Copyright>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/seanoflynn/circus</PackageProjectUrl>
         <PackageTags>finance financial exchange orderbook trading simulator simulation backtest</PackageTags>
+    </PropertyGroup>
+
+    <!-- Ship sources and symbols alongside the package. -->
+    <PropertyGroup>
         <IncludeSource>true</IncludeSource>
         <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,38 @@
+<Project>
+
+    <!--
+        Settings shared by every project in the repository. MSBuild imports this automatically
+        before each .csproj, so anything here can still be overridden by an individual project.
+    -->
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <!--
+        Circus is the only project that ships to NuGet, and it opts back in. Defaulting to false
+        means a new project has to ask to be packed rather than being packed by accident - which is
+        what would happen to Circus.Examples today.
+    -->
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <!-- Package metadata belonging to the repository rather than to any one package. -->
+    <PropertyGroup>
+        <Authors>seanoflynn</Authors>
+        <Copyright>Copyright 2021</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/seanoflynn/circus</PackageProjectUrl>
+    </PropertyGroup>
+
+    <!--
+        Deterministic paths in the symbols Circus already publishes. Only on CI, so a local build
+        keeps the absolute paths a debugger wants.
+    -->
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Adds the three repo-level config files the solution was missing, and thins the five `.csproj` files down to what is actually unique about each. No source file changes, no behaviour change.

## `Directory.Build.props`

`TargetFramework` and `Nullable` were restated in every project, and `Circus.Tests` was the one that forgot `Nullable` — the kind of drift a shared props file exists to prevent. Both now live in one place, along with the package metadata that belongs to the repository (`Authors`, `Copyright`, license, project URL) rather than to any one package.

`IsPackable` now defaults to **false**, and `Circus` opts back in. Three projects each said `IsPackable=false` individually; `Circus.Examples` didn't, so it was packable purely by omission. Inverting the default means a project is packed because it asked to be.

Also sets `ContinuousIntegrationBuild` on CI only, which gives deterministic paths in the symbol packages `Circus` already publishes, while local builds keep the absolute paths a debugger wants.

## `.editorconfig`

Writes down the conventions the code already follows — LF, four spaces, Allman braces, `using` directives above the namespace with `System` first, `_camelCase` instance fields, PascalCase constants and static readonly fields — so an IDE applies them unprompted and `dotnet format` has something to check against.

`EnforceCodeStyleInBuild` is deliberately **not** enabled, so nothing in this file can turn a clean build noisy. Two rules were tuned down after looking at the code rather than pasted in from a template:

- **No `parameter` naming rule.** A positional record's parameters are syntactically parameters but become public properties, so they're PascalCase. Circus is built almost entirely out of positional records, and a parameter rule would flag every one of them.
- **`csharp_style_prefer_primary_constructors` is silent.** The codebase is genuinely mixed here — `PriceLadder` uses one, `InMemoryOrderBook` doesn't — which reads as a per-type judgement rather than a convention waiting to be enforced.

The file-scoped namespace rule is a `suggestion` rather than a `warning` because every file is still block-scoped. It becomes a warning once that conversion happens.

## `global.json`

Pins the SDK to `10.0.100` with `rollForward: latestMinor`, so any 10.x SDK satisfies it — matching the `10.0.x` that CI already installs — while a newer major can't be picked up silently.

## Notes

- **`Circus.Tests` keeps `Nullable` disabled**, now explicitly and with a comment rather than by omission. Its assertions lean on `events[0] as SomeEvent` followed by `Assert.IsNotNull(...)`, which is exactly the pattern nullable analysis flags, so enabling it is a change worth making on its own with the diagnostics in front of you.
- **I could not build or test locally** — the sandbox's network policy blocks the .NET SDK download (`builds.dotnet.microsoft.com` returns 403), so there's no dotnet on the machine. The XML and JSON are validated as well-formed and the MSBuild property precedence is checked by hand, but **CI is the first real build of this change.**
- `Copyright 2021` was moved as-is; it may want updating separately.
- Follow-ups this enables: a `dotnet format --verify-no-changes` step in CI, a `.gitattributes` with `eol=lf` to pair with the `end_of_line` setting, and `Directory.Packages.props` for central package version management.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEKDDgTNbJM6jE8gRcQbZn)_