### PR TITLE
Take a level of indentation off every file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,9 +37,7 @@ dotnet_style_prefer_simplified_using_statement = true:suggestion
 
 #### Namespaces ####
 
-# Aspirational, and the reason this is a suggestion rather than a warning: every file is still
-# block-scoped. Flip to `:warning` once the file-scoped conversion has been done.
-csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_namespace_declarations = file_scoped:warning
 
 #### Layout and braces ####
 

--- a/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
+++ b/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
@@ -1,43 +1,40 @@
-using System;
-using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Circus.OrderBook;
 using Circus.Simulator;
 using Circus.TimeProviders;
 
-namespace Circus.Benchmarks
+namespace Circus.Benchmarks;
+
+// Replays a fixed, seeded trace of realistic order flow against a fresh order book each
+// invocation. This is the headline number: throughput/allocations for a whole session's
+// worth of activity, rather than any single operation in isolation.
+[MemoryDiagnoser]
+public class OrderBookThroughputBenchmarks
 {
-    // Replays a fixed, seeded trace of realistic order flow against a fresh order book each
-    // invocation. This is the headline number: throughput/allocations for a whole session's
-    // worth of activity, rather than any single operation in isolation.
-    [MemoryDiagnoser]
-    public class OrderBookThroughputBenchmarks
+    [Params(1_000, 10_000, 100_000)]
+    public int ActionCount;
+
+    private Security _security = null!;
+    private IReadOnlyList<OrderBookAction> _trace = null!;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        [Params(1_000, 10_000, 100_000)]
-        public int ActionCount;
+        _security = new Security("BENCH", SecurityType.Future, 1m, 10m);
+        var simulator = new OrderFlowSimulator(_security, seed: 12345);
+        _trace = simulator.Generate(ActionCount);
+    }
 
-        private Security _security = null!;
-        private IReadOnlyList<OrderBookAction> _trace = null!;
+    [Benchmark]
+    public int ReplayTrace()
+    {
+        var book = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
+        book.UpdateStatus(OrderBookStatus.Open);
 
-        [GlobalSetup]
-        public void Setup()
-        {
-            _security = new Security("BENCH", SecurityType.Future, 1m, 10m);
-            var simulator = new OrderFlowSimulator(_security, seed: 12345);
-            _trace = simulator.Generate(ActionCount);
-        }
+        var eventCount = 0;
+        foreach (var action in _trace)
+            eventCount += book.Process(action).Count;
 
-        [Benchmark]
-        public int ReplayTrace()
-        {
-            var book = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
-            book.UpdateStatus(OrderBookStatus.Open);
-
-            var eventCount = 0;
-            foreach (var action in _trace)
-                eventCount += book.Process(action).Count;
-
-            return eventCount;
-        }
+        return eventCount;
     }
 }

--- a/Circus.Examples/DataProducerExample.cs
+++ b/Circus.Examples/DataProducerExample.cs
@@ -1,106 +1,103 @@
-using System;
-using System.Collections.Generic;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 
-namespace Circus.Examples
+namespace Circus.Examples;
+
+public class MarketDataProducerExample
 {
-    public class MarketDataProducerExample
+    public static void Run()
     {
-        public static void Run()
+        var time = new UtcTimeProvider();
+
+        var sec1 = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var sec2 = new Security("SIZ6", SecurityType.Future, 10, 10);
+
+        IOrderBook book1 = new InMemoryOrderBook(sec1, time);
+        IOrderBook book2 = new InMemoryOrderBook(sec2, time);
+
+        var feed1 = new BookFeed();
+        var feed2 = new BookFeed();
+
+        // book1 opens on an auction: orders accumulate in pre-open with the indicative quote
+        // tracking them, and the print happens on the way out - the same orders as book2, which
+        // opens first and trades them continuously.
+        feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.PreOpen));
+        feed1.Publish(book1,
+            book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+        feed1.Publish(book1,
+            book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+        feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.Open));
+
+        feed2.Publish(book2, book2.UpdateStatus(OrderBookStatus.Open));
+        feed2.Publish(book2,
+            book2.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+        feed2.Publish(book2,
+            book2.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+    }
+
+    // One set of producers per book. The level and status producers each build their own view
+    // of a single book out of its event stream alone, so a set cannot be shared across two -
+    // and there is no way to resync one that missed an event, which is why they are created
+    // before the book they follow processes anything.
+    private sealed class BookFeed
+    {
+        private readonly TradeDataProducer _trades = new();
+        private readonly LevelDataProducer _bbo = new(1);
+        private readonly LevelDataProducer _top10 = new(10);
+        private readonly FullBookDataProducer _fullBook = new();
+        private readonly IndicativePriceDataProducer _indicative = new();
+        private readonly SecurityStatusDataProducer _status = new();
+
+        public void Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
         {
-            var time = new UtcTimeProvider();
-
-            var sec1 = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var sec2 = new Security("SIZ6", SecurityType.Future, 10, 10);
-
-            IOrderBook book1 = new InMemoryOrderBook(sec1, time);
-            IOrderBook book2 = new InMemoryOrderBook(sec2, time);
-
-            var feed1 = new BookFeed();
-            var feed2 = new BookFeed();
-
-            // book1 opens on an auction: orders accumulate in pre-open with the indicative quote
-            // tracking them, and the print happens on the way out - the same orders as book2, which
-            // opens first and trades them continuously.
-            feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.PreOpen));
-            feed1.Publish(book1,
-                book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
-            feed1.Publish(book1,
-                book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
-            feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.Open));
-
-            feed2.Publish(book2, book2.UpdateStatus(OrderBookStatus.Open));
-            feed2.Publish(book2,
-                book2.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
-            feed2.Publish(book2,
-                book2.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+            Print(_trades.Process(book, events));
+            Print(_bbo.Process(book, events));
+            Print(_top10.Process(book, events));
+            Print(_fullBook.Process(book, events));
+            Print(_indicative.Process(book, events));
+            Print(_status.Process(book, events));
         }
+    }
 
-        // One set of producers per book. The level and status producers each build their own view
-        // of a single book out of its event stream alone, so a set cannot be shared across two -
-        // and there is no way to resync one that missed an event, which is why they are created
-        // before the book they follow processes anything.
-        private sealed class BookFeed
+    private static void Print(IEnumerable<TradedDataEvent> events)
+    {
+        foreach (var @event in events)
         {
-            private readonly TradeDataProducer _trades = new();
-            private readonly LevelDataProducer _bbo = new(1);
-            private readonly LevelDataProducer _top10 = new(10);
-            private readonly FullBookDataProducer _fullBook = new();
-            private readonly IndicativePriceDataProducer _indicative = new();
-            private readonly SecurityStatusDataProducer _status = new();
-
-            public void Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
-            {
-                Print(_trades.Process(book, events));
-                Print(_bbo.Process(book, events));
-                Print(_top10.Process(book, events));
-                Print(_fullBook.Process(book, events));
-                Print(_indicative.Process(book, events));
-                Print(_status.Process(book, events));
-            }
+            Console.WriteLine(@event);
         }
+    }
 
-        private static void Print(IEnumerable<TradedDataEvent> events)
+    private static void Print(IEnumerable<LevelsDataEvent> events)
+    {
+        foreach (var @event in events)
         {
-            foreach (var @event in events)
-            {
-                Console.WriteLine(@event);
-            }
+            Console.WriteLine(
+                $"LevelsDataEvent {{ Bids = [{string.Join(", ", @event.Bids)}], Offers = [{string.Join(", ", @event.Offers)}] }}");
         }
+    }
 
-        private static void Print(IEnumerable<LevelsDataEvent> events)
+    private static void Print(IEnumerable<IndicativePriceDataEvent> events)
+    {
+        foreach (var @event in events)
         {
-            foreach (var @event in events)
-            {
-                Console.WriteLine(
-                    $"LevelsDataEvent {{ Bids = [{string.Join(", ", @event.Bids)}], Offers = [{string.Join(", ", @event.Offers)}] }}");
-            }
+            Console.WriteLine(@event);
         }
+    }
 
-        private static void Print(IEnumerable<IndicativePriceDataEvent> events)
+    private static void Print(IEnumerable<OrderBookDeltaEvent> events)
+    {
+        foreach (var @event in events)
         {
-            foreach (var @event in events)
-            {
-                Console.WriteLine(@event);
-            }
+            Console.WriteLine(@event);
         }
+    }
 
-        private static void Print(IEnumerable<OrderBookDeltaEvent> events)
+    private static void Print(IEnumerable<SecurityStatusDataEvent> events)
+    {
+        foreach (var @event in events)
         {
-            foreach (var @event in events)
-            {
-                Console.WriteLine(@event);
-            }
-        }
-
-        private static void Print(IEnumerable<SecurityStatusDataEvent> events)
-        {
-            foreach (var @event in events)
-            {
-                Console.WriteLine(@event);
-            }
+            Console.WriteLine(@event);
         }
     }
 }

--- a/Circus.Examples/Example.cs
+++ b/Circus.Examples/Example.cs
@@ -1,35 +1,32 @@
-using System;
-using System.Collections.Generic;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 
-namespace Circus.Examples
+namespace Circus.Examples;
+
+public class Example
 {
-    public class Example
+    public static void Run()
     {
-        public static void Run()
+        var time = new UtcTimeProvider();
+
+        var producer = new TradeDataProducer();
+
+        var sec1 = new Security("GCZ6", SecurityType.Future, 10, 10);
+        IOrderBook book1 = new InMemoryOrderBook(sec1, time);
+
+        Print(producer.Process(book1,
+            book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100)));
+
+        Print(producer.Process(book1,
+            book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100)));
+    }
+
+    private static void Print(IEnumerable<TradedDataEvent> events)
+    {
+        foreach (var @event in events)
         {
-            var time = new UtcTimeProvider();
-
-            var producer = new TradeDataProducer();
-
-            var sec1 = new Security("GCZ6", SecurityType.Future, 10, 10);
-            IOrderBook book1 = new InMemoryOrderBook(sec1, time);
-
-            Print(producer.Process(book1,
-                book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100)));
-
-            Print(producer.Process(book1,
-                book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100)));
-        }
-
-        private static void Print(IEnumerable<TradedDataEvent> events)
-        {
-            foreach (var @event in events)
-            {
-                Console.WriteLine(@event);
-            }
+            Console.WriteLine(@event);
         }
     }
 }

--- a/Circus.Examples/OrderBookExample.cs
+++ b/Circus.Examples/OrderBookExample.cs
@@ -1,101 +1,96 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Circus.OrderBook;
 using Circus.SessionProviders;
 using Circus.TimeProviders;
 
-namespace Circus.Examples
+namespace Circus.Examples;
+
+public static class OrderBookExample
 {
-    public static class OrderBookExample
+    public static void TestExample()
     {
-        public static void TestExample()
+        var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
+
+        var timeProvider = new TestTimeProvider(DateTime.Now);
+        IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
+
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        sessionProvider.Changed += (_, args) =>
+            book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
+        sessionProvider.Update(new DateTime(2020, 1, 1, 1, 30, 0));
+
+        Print(book.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+        Print(book.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+    }
+
+    public static void BackTestExample()
+    {
+        var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
+
+        var timeProvider = new TestTimeProvider(DateTime.Now);
+        IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
+
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        sessionProvider.Changed += (_, args) =>
         {
-            var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
+            timeProvider.SetCurrentTime(args.Time);
+            book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
+        };
 
-            var timeProvider = new TestTimeProvider(DateTime.Now);
-            IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
+        // loop through data
+        for (var i = 0; i < 100; i++)
+        {
+            var time = new DateTime(2020, 1, 1, 1, 30, 0);
 
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Changed += (_, args) =>
-                book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
-            sessionProvider.Update(new DateTime(2020, 1, 1, 1, 30, 0));
-
-            Print(book.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
-            Print(book.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+            // update status with correct time
+            sessionProvider.Update(time);
+            // set data time
+            timeProvider.SetCurrentTime(time);
+            // pass in data - each order needs its own ClientOrderId, since Buyer's ids are
+            // permanently reserved once used
+            Print(book.CreateLimitOrder("Buyer", $"Order{i}", new OrderValidity.Day(), Side.Buy, 3, 100));
         }
+    }
 
-        public static void BackTestExample()
+    public static void LiveExample()
+    {
+        var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
+
+        var timeProvider = new UtcTimeProvider();
+        IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
+
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        sessionProvider.Changed += (_, args) =>
+            book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
+        Task.Run(() =>
         {
-            var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
-
-            var timeProvider = new TestTimeProvider(DateTime.Now);
-            IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
-
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Changed += (_, args) =>
+            var i = 0;
+            while (i < 100)
             {
-                timeProvider.SetCurrentTime(args.Time);
-                book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
-            };
-
-            // loop through data
-            for (var i = 0; i < 100; i++)
-            {
-                var time = new DateTime(2020, 1, 1, 1, 30, 0);
-
-                // update status with correct time
-                sessionProvider.Update(time);
-                // set data time
-                timeProvider.SetCurrentTime(time);
-                // pass in data - each order needs its own ClientOrderId, since Buyer's ids are
-                // permanently reserved once used
-                Print(book.CreateLimitOrder("Buyer", $"Order{i}", new OrderValidity.Day(), Side.Buy, 3, 100));
+                // this needs to happen on same thread as book is updated
+                sessionProvider.Update(timeProvider.GetCurrentTime());
+                Thread.Sleep(100);
+                i++;
             }
-        }
+        });
 
-        public static void LiveExample()
+        Print(book.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+        Print(book.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
+    }
+
+    private static void Print(IEnumerable<OrderBookEvent> events)
+    {
+        foreach (var @event in events)
         {
-            var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
-
-            var timeProvider = new UtcTimeProvider();
-            IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
-
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Changed += (_, args) =>
-                book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
-            Task.Run(() =>
-            {
-                var i = 0;
-                while (i < 100)
-                {
-                    // this needs to happen on same thread as book is updated   
-                    sessionProvider.Update(timeProvider.GetCurrentTime());
-                    Thread.Sleep(100);
-                    i++;
-                }
-            });
-
-            Print(book.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
-            Print(book.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
-        }
-
-        private static void Print(IEnumerable<OrderBookEvent> events)
-        {
-            foreach (var @event in events)
-            {
-                Console.WriteLine(@event);
-            }
+            Console.WriteLine(@event);
         }
     }
 }

--- a/Circus.Examples/Program.cs
+++ b/Circus.Examples/Program.cs
@@ -1,12 +1,9 @@
-﻿using System;
+namespace Circus.Examples;
 
-namespace Circus.Examples
+class Program
 {
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            OrderBookExample.TestExample();
-        }
+        OrderBookExample.TestExample();
     }
 }

--- a/Circus.Simulator/OrderFlowSimulator.cs
+++ b/Circus.Simulator/OrderFlowSimulator.cs
@@ -1,288 +1,285 @@
-using System;
-using System.Collections.Generic;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 
-namespace Circus.Simulator
+namespace Circus.Simulator;
+
+// Generates a plausible, replayable stream of order book actions (create/cancel/update,
+// limit/market) for a single security. Drives a private "shadow" order book purely to keep
+// track of which orders are currently live, so that generated cancels/updates always target
+// a real resting order instead of a random, possibly-already-filled id.
+//
+// Pass a seed for a deterministic, reproducible trace (e.g. a committed benchmark baseline);
+// omit it to get a fresh random trace each run (e.g. fuzzing).
+public sealed class OrderFlowSimulator
 {
-    // Generates a plausible, replayable stream of order book actions (create/cancel/update,
-    // limit/market) for a single security. Drives a private "shadow" order book purely to keep
-    // track of which orders are currently live, so that generated cancels/updates always target
-    // a real resting order instead of a random, possibly-already-filled id.
-    //
-    // Pass a seed for a deterministic, reproducible trace (e.g. a committed benchmark baseline);
-    // omit it to get a fresh random trace each run (e.g. fuzzing).
-    public sealed class OrderFlowSimulator
+    private readonly Security _security;
+    private readonly SimulatorOptions _options;
+    private readonly Random _random;
+    private readonly int _seed;
+
+    private readonly InMemoryOrderBook _shadowBook;
+
+    // The touch, rebuilt from the shadow book's events the same way any market data consumer
+    // would - the book itself answers no questions about its levels.
+    private readonly LevelDataProducer _touch = new(1);
+    private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
+
+    // Keyed by ClientOrderId, not ExchangeOrderId - the latter no longer stays constant for
+    // an order's whole life (a reprice, a quantity increase, or an iceberg peak refilling
+    // from its hidden reserve all mint a fresh one), so it can't be used as a stable tracking
+    // key here. ClientOrderId changes too (a new one is chosen on every update/cancel), but
+    // this class is itself the one choosing each new value, so it renames its own tracking
+    // entries in lockstep rather than needing a truly immutable id.
+    private readonly List<string> _liveIds = new();
+    private readonly Dictionary<string, int> _liveIndex = new();
+    private readonly Dictionary<string, LiveOrderInfo> _liveInfo = new();
+
+    // deterministic (derived from the seeded action sequence, not Guid.NewGuid()) so traces
+    // stay reproducible for a given seed
+    private long _nextId;
+
+    public OrderFlowSimulator(Security security, SimulatorOptions? options = null, int? seed = null)
     {
-        private readonly Security _security;
-        private readonly SimulatorOptions _options;
-        private readonly Random _random;
-        private readonly int _seed;
+        _security = security;
+        _options = options ?? new SimulatorOptions();
+        _seed = seed ?? Random.Shared.Next();
+        _random = new Random(_seed);
 
-        private readonly InMemoryOrderBook _shadowBook;
+        _shadowBook = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
+        _shadowBook.UpdateStatus(OrderBookStatus.Open);
+    }
 
-        // The touch, rebuilt from the shadow book's events the same way any market data consumer
-        // would - the book itself answers no questions about its levels.
-        private readonly LevelDataProducer _touch = new(1);
-        private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
+    public int Seed => _seed;
 
-        // Keyed by ClientOrderId, not ExchangeOrderId - the latter no longer stays constant for
-        // an order's whole life (a reprice, a quantity increase, or an iceberg peak refilling
-        // from its hidden reserve all mint a fresh one), so it can't be used as a stable tracking
-        // key here. ClientOrderId changes too (a new one is chosen on every update/cancel), but
-        // this class is itself the one choosing each new value, so it renames its own tracking
-        // entries in lockstep rather than needing a truly immutable id.
-        private readonly List<string> _liveIds = new();
-        private readonly Dictionary<string, int> _liveIndex = new();
-        private readonly Dictionary<string, LiveOrderInfo> _liveInfo = new();
+    // Generates the next `actionCount` actions, continuing from wherever the internal
+    // shadow book currently is (i.e. calling this repeatedly extends the same session
+    // rather than restarting it). The returned list contains only the newly generated
+    // batch, not the full history.
+    public IReadOnlyList<OrderBookAction> Generate(int actionCount)
+    {
+        var actions = new List<OrderBookAction>(actionCount);
 
-        // deterministic (derived from the seeded action sequence, not Guid.NewGuid()) so traces
-        // stay reproducible for a given seed
-        private long _nextId;
-
-        public OrderFlowSimulator(Security security, SimulatorOptions? options = null, int? seed = null)
+        for (var i = 0; i < actionCount; i++)
         {
-            _security = security;
-            _options = options ?? new SimulatorOptions();
-            _seed = seed ?? Random.Shared.Next();
-            _random = new Random(_seed);
-
-            _shadowBook = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
-            _shadowBook.UpdateStatus(OrderBookStatus.Open);
+            var action = NextAction();
+            actions.Add(action);
+            Apply(action);
         }
 
-        public int Seed => _seed;
+        return actions;
+    }
 
-        // Generates the next `actionCount` actions, continuing from wherever the internal
-        // shadow book currently is (i.e. calling this repeatedly extends the same session
-        // rather than restarting it). The returned list contains only the newly generated
-        // batch, not the full history.
-        public IReadOnlyList<OrderBookAction> Generate(int actionCount)
+    private void Apply(OrderBookAction action)
+    {
+        var events = _shadowBook.Process(action);
+
+        foreach (var levels in _touch.Process(_shadowBook, events))
+            _levels = levels;
+
+        foreach (var e in events)
         {
-            var actions = new List<OrderBookAction>(actionCount);
-
-            for (var i = 0; i < actionCount; i++)
+            switch (e)
             {
-                var action = NextAction();
-                actions.Add(action);
-                Apply(action);
-            }
-
-            return actions;
-        }
-
-        private void Apply(OrderBookAction action)
-        {
-            var events = _shadowBook.Process(action);
-
-            foreach (var levels in _touch.Process(_shadowBook, events))
-                _levels = levels;
-
-            foreach (var e in events)
-            {
-                switch (e)
-                {
-                    case CreateOrderConfirmed c:
-                        Track(c.Order, previousClientOrderId: null);
-                        break;
-                    case UpdateOrderConfirmed u:
-                        Track(u.Order, u.PreviousClientOrderId);
-                        break;
-                    case CancelOrderConfirmed cancel:
-                        RemoveLive(cancel.PreviousClientOrderId);
-                        break;
-                    case ExpireOrderConfirmed expire:
-                        RemoveLive(expire.Order.ClientOrderId);
-                        break;
-                    case OrdersMatched matched:
-                        foreach (var fill in matched.Fills)
-                        {
-                            if (fill.Order.RemainingQuantity == 0)
-                                RemoveLive(fill.Order.ClientOrderId);
-                        }
-                        break;
-                }
+                case CreateOrderConfirmed c:
+                    Track(c.Order, previousClientOrderId: null);
+                    break;
+                case UpdateOrderConfirmed u:
+                    Track(u.Order, u.PreviousClientOrderId);
+                    break;
+                case CancelOrderConfirmed cancel:
+                    RemoveLive(cancel.PreviousClientOrderId);
+                    break;
+                case ExpireOrderConfirmed expire:
+                    RemoveLive(expire.Order.ClientOrderId);
+                    break;
+                case OrdersMatched matched:
+                    foreach (var fill in matched.Fills)
+                    {
+                        if (fill.Order.RemainingQuantity == 0)
+                            RemoveLive(fill.Order.ClientOrderId);
+                    }
+                    break;
             }
         }
+    }
 
-        // previousClientOrderId is null for a fresh Create, and the id being renamed from for an
-        // Update - renaming (rather than remove-then-add under whatever key happens to already
-        // be there) keeps a single live entry across the chain of client order ids one logical
-        // resting order accumulates over its life.
-        private void Track(Order order, string? previousClientOrderId)
+    // previousClientOrderId is null for a fresh Create, and the id being renamed from for an
+    // Update - renaming (rather than remove-then-add under whatever key happens to already
+    // be there) keeps a single live entry across the chain of client order ids one logical
+    // resting order accumulates over its life.
+    private void Track(Order order, string? previousClientOrderId)
+    {
+        if (order.RemainingQuantity == 0)
         {
-            if (order.RemainingQuantity == 0)
-            {
-                RemoveLive(previousClientOrderId ?? order.ClientOrderId);
-                return;
-            }
-
-            if (previousClientOrderId != null && previousClientOrderId != order.ClientOrderId)
-                RemoveLive(previousClientOrderId);
-
-            if (!_liveIndex.ContainsKey(order.ClientOrderId))
-            {
-                _liveIndex[order.ClientOrderId] = _liveIds.Count;
-                _liveIds.Add(order.ClientOrderId);
-            }
-
-            _liveInfo[order.ClientOrderId] = new LiveOrderInfo(order.CompanyId, order.ClientOrderId, order.Side,
-                order.Price, order.TriggerPrice);
+            RemoveLive(previousClientOrderId ?? order.ClientOrderId);
+            return;
         }
 
-        private void RemoveLive(string clientOrderId)
+        if (previousClientOrderId != null && previousClientOrderId != order.ClientOrderId)
+            RemoveLive(previousClientOrderId);
+
+        if (!_liveIndex.ContainsKey(order.ClientOrderId))
         {
-            if (!_liveIndex.TryGetValue(clientOrderId, out var index))
-                return;
-
-            var lastIndex = _liveIds.Count - 1;
-            var lastId = _liveIds[lastIndex];
-            _liveIds[index] = lastId;
-            _liveIndex[lastId] = index;
-            _liveIds.RemoveAt(lastIndex);
-
-            _liveIndex.Remove(clientOrderId);
-            _liveInfo.Remove(clientOrderId);
+            _liveIndex[order.ClientOrderId] = _liveIds.Count;
+            _liveIds.Add(order.ClientOrderId);
         }
 
-        private bool TryPickLive(out string clientOrderId, out LiveOrderInfo info)
-        {
-            if (_liveIds.Count == 0)
-            {
-                clientOrderId = default!;
-                info = default!;
-                return false;
-            }
+        _liveInfo[order.ClientOrderId] = new LiveOrderInfo(order.CompanyId, order.ClientOrderId, order.Side,
+            order.Price, order.TriggerPrice);
+    }
 
-            clientOrderId = _liveIds[_random.Next(_liveIds.Count)];
-            info = _liveInfo[clientOrderId];
-            return true;
+    private void RemoveLive(string clientOrderId)
+    {
+        if (!_liveIndex.TryGetValue(clientOrderId, out var index))
+            return;
+
+        var lastIndex = _liveIds.Count - 1;
+        var lastId = _liveIds[lastIndex];
+        _liveIds[index] = lastId;
+        _liveIndex[lastId] = index;
+        _liveIds.RemoveAt(lastIndex);
+
+        _liveIndex.Remove(clientOrderId);
+        _liveInfo.Remove(clientOrderId);
+    }
+
+    private bool TryPickLive(out string clientOrderId, out LiveOrderInfo info)
+    {
+        if (_liveIds.Count == 0)
+        {
+            clientOrderId = default!;
+            info = default!;
+            return false;
         }
 
-        private string NextCompanyId() => $"c{_nextId++}";
-        private string NextClientOrderId() => $"o{_nextId++}";
+        clientOrderId = _liveIds[_random.Next(_liveIds.Count)];
+        info = _liveInfo[clientOrderId];
+        return true;
+    }
 
-        private OrderBookAction NextAction()
+    private string NextCompanyId() => $"c{_nextId++}";
+    private string NextClientOrderId() => $"o{_nextId++}";
+
+    private OrderBookAction NextAction()
+    {
+        var hasLive = _liveIds.Count > 0;
+        var roll = _random.NextDouble();
+
+        if (hasLive)
         {
-            var hasLive = _liveIds.Count > 0;
-            var roll = _random.NextDouble();
+            if (roll < _options.CancelWeight)
+                return BuildCancel();
+            roll -= _options.CancelWeight;
 
-            if (hasLive)
-            {
-                if (roll < _options.CancelWeight)
-                    return BuildCancel();
-                roll -= _options.CancelWeight;
-
-                if (roll < _options.UpdateWeight)
-                    return BuildUpdate();
-                roll -= _options.UpdateWeight;
-            }
-
-            if (roll < _options.MarketOrderWeight)
-                return BuildCreateMarket();
-
-            return BuildCreateLimit();
+            if (roll < _options.UpdateWeight)
+                return BuildUpdate();
+            roll -= _options.UpdateWeight;
         }
 
-        private CreateLimitOrder BuildCreateLimit()
+        if (roll < _options.MarketOrderWeight)
+            return BuildCreateMarket();
+
+        return BuildCreateLimit();
+    }
+
+    private CreateLimitOrder BuildCreateLimit()
+    {
+        var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
+        var price = ComputePrice(side);
+        var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
+
+        return new CreateLimitOrder
         {
-            var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
-            var price = ComputePrice(side);
+            Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
+            OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity, Price = price
+        };
+    }
+
+    private CreateMarketOrder BuildCreateMarket()
+    {
+        var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
+        var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
+
+        return new CreateMarketOrder
+        {
+            Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
+            OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity
+        };
+    }
+
+    private CancelOrder BuildCancel()
+    {
+        TryPickLive(out _, out var info);
+        return new CancelOrder
+        {
+            Security = _security, CompanyId = info.CompanyId, ClientOrderId = NextClientOrderId(),
+            PreviousClientOrderId = info.ClientOrderId
+        };
+    }
+
+    private UpdateOrder BuildUpdate()
+    {
+        TryPickLive(out _, out var info);
+        var newClientOrderId = NextClientOrderId();
+
+        // stop orders keep a Price/TriggerPrice relationship that a blind tweak could
+        // violate, so only ever adjust their quantity.
+        var updateQuantityOnly = info.TriggerPrice.HasValue;
+        if (updateQuantityOnly || _random.NextDouble() < 0.5)
+        {
             var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
-
-            return new CreateLimitOrder
-            {
-                Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
-                OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity, Price = price
-            };
-        }
-
-        private CreateMarketOrder BuildCreateMarket()
-        {
-            var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
-            var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
-
-            return new CreateMarketOrder
-            {
-                Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
-                OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity
-            };
-        }
-
-        private CancelOrder BuildCancel()
-        {
-            TryPickLive(out _, out var info);
-            return new CancelOrder
-            {
-                Security = _security, CompanyId = info.CompanyId, ClientOrderId = NextClientOrderId(),
-                PreviousClientOrderId = info.ClientOrderId
-            };
-        }
-
-        private UpdateOrder BuildUpdate()
-        {
-            TryPickLive(out _, out var info);
-            var newClientOrderId = NextClientOrderId();
-
-            // stop orders keep a Price/TriggerPrice relationship that a blind tweak could
-            // violate, so only ever adjust their quantity.
-            var updateQuantityOnly = info.TriggerPrice.HasValue;
-            if (updateQuantityOnly || _random.NextDouble() < 0.5)
-            {
-                var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
-                return new UpdateOrder
-                {
-                    Security = _security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
-                    PreviousClientOrderId = info.ClientOrderId, NewTotalQuantity = quantity
-                };
-            }
-
-            var tick = _security.TickSize;
-            var direction = info.Side == Side.Buy ? -1 : 1; // move away from touch, staying passive
-            var reference = info.Price ?? AlignToTick(_options.StartingPrice);
-            var newPrice = reference + direction * _random.Next(1, 4) * tick;
-
             return new UpdateOrder
             {
                 Security = _security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
-                PreviousClientOrderId = info.ClientOrderId, Price = newPrice
+                PreviousClientOrderId = info.ClientOrderId, NewTotalQuantity = quantity
             };
         }
 
-        private decimal ComputePrice(Side side)
+        var tick = _security.TickSize;
+        var direction = info.Side == Side.Buy ? -1 : 1; // move away from touch, staying passive
+        var reference = info.Price ?? AlignToTick(_options.StartingPrice);
+        var newPrice = reference + direction * _random.Next(1, 4) * tick;
+
+        return new UpdateOrder
         {
-            var tick = _security.TickSize;
-            var bestBuy = _levels.Bids;
-            var bestSell = _levels.Offers;
-
-            if (bestBuy.Count == 0 && bestSell.Count == 0)
-                return AlignToTick(_options.StartingPrice);
-
-            var opposite = side == Side.Buy ? bestSell : bestBuy;
-            var own = side == Side.Buy ? bestBuy : bestSell;
-
-            if (opposite.Count > 0 && _random.NextDouble() < _options.CrossProbability)
-            {
-                var throughTicks = _random.Next(0, 3);
-                return side == Side.Buy
-                    ? opposite[0].Price + throughTicks * tick
-                    : opposite[0].Price - throughTicks * tick;
-            }
-
-            var reference = own.Count > 0 ? own[0].Price : opposite[0].Price;
-            var offsetTicks = _random.Next(0, _options.PriceRangeTicks + 1);
-
-            return side == Side.Buy ? reference - offsetTicks * tick : reference + offsetTicks * tick;
-        }
-
-        private decimal AlignToTick(decimal price)
-        {
-            var tick = _security.TickSize;
-            return Math.Round(price / tick) * tick;
-        }
-
-        private readonly record struct LiveOrderInfo(string CompanyId, string ClientOrderId, Side Side,
-            decimal? Price, decimal? TriggerPrice);
+            Security = _security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
+            PreviousClientOrderId = info.ClientOrderId, Price = newPrice
+        };
     }
+
+    private decimal ComputePrice(Side side)
+    {
+        var tick = _security.TickSize;
+        var bestBuy = _levels.Bids;
+        var bestSell = _levels.Offers;
+
+        if (bestBuy.Count == 0 && bestSell.Count == 0)
+            return AlignToTick(_options.StartingPrice);
+
+        var opposite = side == Side.Buy ? bestSell : bestBuy;
+        var own = side == Side.Buy ? bestBuy : bestSell;
+
+        if (opposite.Count > 0 && _random.NextDouble() < _options.CrossProbability)
+        {
+            var throughTicks = _random.Next(0, 3);
+            return side == Side.Buy
+                ? opposite[0].Price + throughTicks * tick
+                : opposite[0].Price - throughTicks * tick;
+        }
+
+        var reference = own.Count > 0 ? own[0].Price : opposite[0].Price;
+        var offsetTicks = _random.Next(0, _options.PriceRangeTicks + 1);
+
+        return side == Side.Buy ? reference - offsetTicks * tick : reference + offsetTicks * tick;
+    }
+
+    private decimal AlignToTick(decimal price)
+    {
+        var tick = _security.TickSize;
+        return Math.Round(price / tick) * tick;
+    }
+
+    private readonly record struct LiveOrderInfo(string CompanyId, string ClientOrderId, Side Side,
+        decimal? Price, decimal? TriggerPrice);
 }

--- a/Circus.Simulator/SimulatorOptions.cs
+++ b/Circus.Simulator/SimulatorOptions.cs
@@ -1,15 +1,14 @@
-namespace Circus.Simulator
-{
-    // Weights are threshold cut-offs evaluated in order (cancel, then update, then market),
-    // not probabilities that must sum to 1 — whatever mass is left over produces a limit order.
-    public record SimulatorOptions(
-        decimal StartingPrice = 1000m,
-        int MinQuantity = 1,
-        int MaxQuantity = 10,
-        int PriceRangeTicks = 100,
-        double CancelWeight = 0.2,
-        double UpdateWeight = 0.1,
-        double MarketOrderWeight = 0.05,
-        double CrossProbability = 0.15
-    );
-}
+namespace Circus.Simulator;
+
+// Weights are threshold cut-offs evaluated in order (cancel, then update, then market),
+// not probabilities that must sum to 1 — whatever mass is left over produces a limit order.
+public record SimulatorOptions(
+    decimal StartingPrice = 1000m,
+    int MinQuantity = 1,
+    int MaxQuantity = 10,
+    int PriceRangeTicks = 100,
+    double CancelWeight = 0.2,
+    double UpdateWeight = 0.1,
+    double MarketOrderWeight = 0.05,
+    double CrossProbability = 0.15
+);

--- a/Circus.Tests/DataProducers/FullBookDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/FullBookDataProducerTests.cs
@@ -1,228 +1,225 @@
-using System;
-using System.Linq;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers
+namespace Circus.Tests.DataProducers;
+
+public class FullBookDataProducerTests
 {
-    public class FullBookDataProducerTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+    private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
+    private static readonly DateTime Now6 = new(2000, 1, 1, 12, 5, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+    private static readonly string CompanyId4 = "Company4";
+    private static readonly string CompanyId5 = "Company5";
+    private static readonly string CompanyId6 = "Company6";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+    private static readonly string OrderId6 = "Order6";
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
-        private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
-        private static readonly DateTime Now6 = new(2000, 1, 1, 12, 5, 0);
+    [Test]
+    public void Create_ProducesAddedDelta()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-        private static readonly string CompanyId4 = "Company4";
-        private static readonly string CompanyId5 = "Company5";
-        private static readonly string CompanyId6 = "Company6";
+        var bookEvents = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        var deltas = producer.Process(Book, bookEvents);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
-        private static readonly string OrderId6 = "Order6";
+        Assert.AreEqual(1, deltas.Count);
+        Assert.AreEqual(Side.Buy, deltas[0].Side);
+        Assert.AreEqual(100, deltas[0].Price);
+        Assert.AreEqual(3, deltas[0].Quantity);
+        Assert.AreEqual(OrderBookDeltaAction.Added, deltas[0].Action);
+    }
 
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+    [Test]
+    public void Iceberg_AddedDelta_ShowsOnlyDisplayedPeak_NotHiddenReserve()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+        // total 20, only 5 displayed at a time
+        var bookEvents = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
+            maxVisibleQuantity: 5);
+        var deltas = producer.Process(Book, bookEvents);
 
-        [Test]
-        public void Create_ProducesAddedDelta()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
+        Assert.AreEqual(1, deltas.Count);
+        Assert.AreEqual(5, deltas[0].Quantity, "only the displayed peak, never the hidden reserve");
+        Assert.AreEqual(OrderBookDeltaAction.Added, deltas[0].Action);
+    }
 
-            var bookEvents = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            var deltas = producer.Process(Book, bookEvents);
+    [Test]
+    public void IcebergReplenish_ProducesRemovedThenAddedWithNewId()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
+                maxVisibleQuantity: 5)
+            .OfType<CreateOrderConfirmed>().Single();
+        producer.Process(Book, new OrderBookEvent[] {created});
 
-            Assert.AreEqual(1, deltas.Count);
-            Assert.AreEqual(Side.Buy, deltas[0].Side);
-            Assert.AreEqual(100, deltas[0].Price);
-            Assert.AreEqual(3, deltas[0].Quantity);
-            Assert.AreEqual(OrderBookDeltaAction.Added, deltas[0].Action);
-        }
+        // aggressor larger than the peak - exhausts and replenishes the iceberg mid-match
+        var bookEvents = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+        var deltas = producer.Process(Book, bookEvents);
 
-        [Test]
-        public void Iceberg_AddedDelta_ShowsOnlyDisplayedPeak_NotHiddenReserve()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
+        // one Filled delta per leg of the match (the iceberg resting, and the aggressor)
+        var filled = deltas.Where(d => d.Action == OrderBookDeltaAction.Filled).ToList();
+        Assert.AreEqual(2, filled.Count);
+        Assert.IsTrue(filled.Any(d => d.ExchangeOrderId == created.Order.ExchangeOrderId),
+            "the iceberg's fill happened against its pre-replenish id");
 
-            // total 20, only 5 displayed at a time
-            var bookEvents = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
-                maxVisibleQuantity: 5);
-            var deltas = producer.Process(Book, bookEvents);
+        var removed = deltas.Single(d => d.Action == OrderBookDeltaAction.Removed);
+        Assert.AreEqual(created.Order.ExchangeOrderId, removed.ExchangeOrderId);
 
-            Assert.AreEqual(1, deltas.Count);
-            Assert.AreEqual(5, deltas[0].Quantity, "only the displayed peak, never the hidden reserve");
-            Assert.AreEqual(OrderBookDeltaAction.Added, deltas[0].Action);
-        }
+        // Side.Sell, not Side.Buy - the aggressor itself also produces its own Added delta
+        // (its CreateOrderConfirmed), distinct from the iceberg's replenish arrival
+        var added = deltas.Single(d => d.Action == OrderBookDeltaAction.Added && d.Side == Side.Sell);
+        Assert.AreNotEqual(created.Order.ExchangeOrderId, added.ExchangeOrderId);
+        Assert.AreEqual(5, added.Quantity, "replenished back to the full peak");
+    }
 
-        [Test]
-        public void IcebergReplenish_ProducesRemovedThenAddedWithNewId()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
-                    maxVisibleQuantity: 5)
-                .OfType<CreateOrderConfirmed>().Single();
-            producer.Process(Book, new OrderBookEvent[] {created});
+    [Test]
+    public void Reprice_LosesPriority_ProducesRemovedThenAddedWithNewId()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
+            .OfType<CreateOrderConfirmed>().Single();
 
-            // aggressor larger than the peak - exhausts and replenishes the iceberg mid-match
-            var bookEvents = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
-            var deltas = producer.Process(Book, bookEvents);
+        var bookEvents = Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 110);
+        var deltas = producer.Process(Book, bookEvents);
 
-            // one Filled delta per leg of the match (the iceberg resting, and the aggressor)
-            var filled = deltas.Where(d => d.Action == OrderBookDeltaAction.Filled).ToList();
-            Assert.AreEqual(2, filled.Count);
-            Assert.IsTrue(filled.Any(d => d.ExchangeOrderId == created.Order.ExchangeOrderId),
-                "the iceberg's fill happened against its pre-replenish id");
+        Assert.AreEqual(2, deltas.Count);
+        Assert.AreEqual(created.Order.ExchangeOrderId, deltas[0].ExchangeOrderId);
+        Assert.AreEqual(100, deltas[0].Price);
+        Assert.AreEqual(OrderBookDeltaAction.Removed, deltas[0].Action);
 
-            var removed = deltas.Single(d => d.Action == OrderBookDeltaAction.Removed);
-            Assert.AreEqual(created.Order.ExchangeOrderId, removed.ExchangeOrderId);
+        Assert.AreNotEqual(created.Order.ExchangeOrderId, deltas[1].ExchangeOrderId);
+        Assert.AreEqual(110, deltas[1].Price);
+        Assert.AreEqual(OrderBookDeltaAction.Added, deltas[1].Action);
+    }
 
-            // Side.Sell, not Side.Buy - the aggressor itself also produces its own Added delta
-            // (its CreateOrderConfirmed), distinct from the iceberg's replenish arrival
-            var added = deltas.Single(d => d.Action == OrderBookDeltaAction.Added && d.Side == Side.Sell);
-            Assert.AreNotEqual(created.Order.ExchangeOrderId, added.ExchangeOrderId);
-            Assert.AreEqual(5, added.Quantity, "replenished back to the full peak");
-        }
+    [Test]
+    public void QuantityDecrease_PreservesPriority_ProducesModifiedWithSameId()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100)
+            .OfType<CreateOrderConfirmed>().Single();
 
-        [Test]
-        public void Reprice_LosesPriority_ProducesRemovedThenAddedWithNewId()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
-                .OfType<CreateOrderConfirmed>().Single();
+        var bookEvents = Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, newTotalQuantity: 3);
+        var deltas = producer.Process(Book, bookEvents);
 
-            var bookEvents = Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 110);
-            var deltas = producer.Process(Book, bookEvents);
+        Assert.AreEqual(1, deltas.Count);
+        Assert.AreEqual(created.Order.ExchangeOrderId, deltas[0].ExchangeOrderId);
+        Assert.AreEqual(3, deltas[0].Quantity);
+        Assert.AreEqual(OrderBookDeltaAction.Modified, deltas[0].Action);
+    }
 
-            Assert.AreEqual(2, deltas.Count);
-            Assert.AreEqual(created.Order.ExchangeOrderId, deltas[0].ExchangeOrderId);
-            Assert.AreEqual(100, deltas[0].Price);
-            Assert.AreEqual(OrderBookDeltaAction.Removed, deltas[0].Action);
+    [Test]
+    public void Cancel_ProducesRemovedDelta_WithPreCancelQuantity()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
-            Assert.AreNotEqual(created.Order.ExchangeOrderId, deltas[1].ExchangeOrderId);
-            Assert.AreEqual(110, deltas[1].Price);
-            Assert.AreEqual(OrderBookDeltaAction.Added, deltas[1].Action);
-        }
+        var bookEvents = Book.CancelOrder(CompanyId1, OrderId2, OrderId1);
+        var deltas = producer.Process(Book, bookEvents);
 
-        [Test]
-        public void QuantityDecrease_PreservesPriority_ProducesModifiedWithSameId()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100)
-                .OfType<CreateOrderConfirmed>().Single();
+        Assert.AreEqual(1, deltas.Count);
+        Assert.AreEqual(100, deltas[0].Price);
+        Assert.AreEqual(3, deltas[0].Quantity);
+        Assert.AreEqual(OrderBookDeltaAction.Removed, deltas[0].Action);
+    }
 
-            var bookEvents = Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, newTotalQuantity: 3);
-            var deltas = producer.Process(Book, bookEvents);
+    [Test]
+    public void PartialFill_ProducesFilledDeltaPerLeg_WithFillQuantityNotRemaining()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
-            Assert.AreEqual(1, deltas.Count);
-            Assert.AreEqual(created.Order.ExchangeOrderId, deltas[0].ExchangeOrderId);
-            Assert.AreEqual(3, deltas[0].Quantity);
-            Assert.AreEqual(OrderBookDeltaAction.Modified, deltas[0].Action);
-        }
+        var bookEvents = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+        var deltas = producer.Process(Book, bookEvents);
 
-        [Test]
-        public void Cancel_ProducesRemovedDelta_WithPreCancelQuantity()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        var filled = deltas.Where(d => d.Action == OrderBookDeltaAction.Filled).ToList();
+        Assert.AreEqual(2, filled.Count, "expected one Filled delta per leg of the match");
+        Assert.IsTrue(filled.All(d => d.Quantity == 3), "fill quantity is the traded amount, not the resting order's total or remaining size");
+    }
 
-            var bookEvents = Book.CancelOrder(CompanyId1, OrderId2, OrderId1);
-            var deltas = producer.Process(Book, bookEvents);
+    [Test]
+    public void CompanyAndClientOrderIdNeverAppearOnOrderBookDeltaEvent()
+    {
+        var properties = typeof(OrderBookDeltaEvent).GetProperties().Select(p => p.Name).ToList();
 
-            Assert.AreEqual(1, deltas.Count);
-            Assert.AreEqual(100, deltas[0].Price);
-            Assert.AreEqual(3, deltas[0].Quantity);
-            Assert.AreEqual(OrderBookDeltaAction.Removed, deltas[0].Action);
-        }
+        Assert.IsFalse(properties.Contains("CompanyId"), "a public depth feed must never carry the originating client's CompanyId");
+        Assert.IsFalse(properties.Contains("ClientOrderId"), "a public depth feed must never carry the originating client's ClientOrderId");
+    }
 
-        [Test]
-        public void PartialFill_ProducesFilledDeltaPerLeg_WithFillQuantityNotRemaining()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+    [Test]
+    public void StillHiddenStopOrder_Create_ProducesNoDelta()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500);
 
-            var bookEvents = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-            var deltas = producer.Process(Book, bookEvents);
+        var bookEvents =
+            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
+        var deltas = producer.Process(Book, bookEvents);
 
-            var filled = deltas.Where(d => d.Action == OrderBookDeltaAction.Filled).ToList();
-            Assert.AreEqual(2, filled.Count, "expected one Filled delta per leg of the match");
-            Assert.IsTrue(filled.All(d => d.Quantity == 3), "fill quantity is the traded amount, not the resting order's total or remaining size");
-        }
+        Assert.IsEmpty(deltas, "a stop order that hasn't triggered yet isn't part of the displayed order book");
+    }
 
-        [Test]
-        public void CompanyAndClientOrderIdNeverAppearOnOrderBookDeltaEvent()
-        {
-            var properties = typeof(OrderBookDeltaEvent).GetProperties().Select(p => p.Name).ToList();
+    [Test]
+    public void StopOrderActivation_ProducesAddedDelta_NotModified()
+    {
+        var producer = new FullBookDataProducer();
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500);
 
-            Assert.IsFalse(properties.Contains("CompanyId"), "a public depth feed must never carry the originating client's CompanyId");
-            Assert.IsFalse(properties.Contains("ClientOrderId"), "a public depth feed must never carry the originating client's ClientOrderId");
-        }
+        TimeProvider.SetCurrentTime(Now3);
+        Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520);
 
-        [Test]
-        public void StillHiddenStopOrder_Create_ProducesNoDelta()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500);
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
 
-            var bookEvents =
-                Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
-            var deltas = producer.Process(Book, bookEvents);
+        TimeProvider.SetCurrentTime(Now5);
+        Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510);
 
-            Assert.IsEmpty(deltas, "a stop order that hasn't triggered yet isn't part of the displayed order book");
-        }
+        // act - trade at the trigger price, converting the stop into a working limit order
+        TimeProvider.SetCurrentTime(Now6);
+        var bookEvents = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
+        var deltas = producer.Process(Book, bookEvents);
 
-        [Test]
-        public void StopOrderActivation_ProducesAddedDelta_NotModified()
-        {
-            var producer = new FullBookDataProducer();
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500);
-
-            TimeProvider.SetCurrentTime(Now3);
-            Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520);
-
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
-
-            TimeProvider.SetCurrentTime(Now5);
-            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510);
-
-            // act - trade at the trigger price, converting the stop into a working limit order
-            TimeProvider.SetCurrentTime(Now6);
-            var bookEvents = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
-            var deltas = producer.Process(Book, bookEvents);
-
-            var activation = deltas.SingleOrDefault(d => d.Price == 530 && d.Action != OrderBookDeltaAction.Filled);
-            Assert.IsNotNull(activation, "expected the triggered order's arrival into the working book");
-            Assert.AreEqual(OrderBookDeltaAction.Added, activation.Action,
-                "it has no prior working-book presence, so it's an arrival, not a move");
-        }
+        var activation = deltas.SingleOrDefault(d => d.Price == 530 && d.Action != OrderBookDeltaAction.Filled);
+        Assert.IsNotNull(activation, "expected the triggered order's arrival into the working book");
+        Assert.AreEqual(OrderBookDeltaAction.Added, activation.Action,
+            "it has no prior working-book presence, so it's an arrival, not a move");
     }
 }

--- a/Circus.Tests/DataProducers/IndicativePriceDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/IndicativePriceDataProducerTests.cs
@@ -1,89 +1,86 @@
-using System;
-using System.Collections.Generic;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers
+namespace Circus.Tests.DataProducers;
+
+public class IndicativePriceDataProducerTests
 {
-    public class IndicativePriceDataProducerTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static IList<IndicativePriceDataEvent> Publish(IndicativePriceDataProducer producer,
+        IReadOnlyList<OrderBookEvent> bookEvents) =>
+        producer.Process(Book, bookEvents);
 
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+    [Test]
+    public void CrossedPreOpenBook_PublishesTheQuote()
+    {
+        var producer = new IndicativePriceDataProducer();
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+        Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+        var events = Publish(producer,
+            Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
 
-        private static IList<IndicativePriceDataEvent> Publish(IndicativePriceDataProducer producer,
-            IReadOnlyList<OrderBookEvent> bookEvents) =>
-            producer.Process(Book, bookEvents);
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(Now1, events[0].Time);
+        Assert.AreEqual(100, events[0].Price);
+        Assert.AreEqual(3, events[0].Quantity);
+    }
 
-        [Test]
-        public void CrossedPreOpenBook_PublishesTheQuote()
-        {
-            var producer = new IndicativePriceDataProducer();
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
-            Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+    [Test]
+    public void UncrossedBook_PublishesNothing()
+    {
+        var producer = new IndicativePriceDataProducer();
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
 
-            var events = Publish(producer,
-                Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
+        var events = Publish(producer,
+            Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            Assert.AreEqual(1, events.Count);
-            Assert.AreEqual(Now1, events[0].Time);
-            Assert.AreEqual(100, events[0].Price);
-            Assert.AreEqual(3, events[0].Quantity);
-        }
+        Assert.IsEmpty(events);
+    }
 
-        [Test]
-        public void UncrossedBook_PublishesNothing()
-        {
-            var producer = new IndicativePriceDataProducer();
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+    [Test]
+    public void ContinuousTrading_PublishesNothing()
+    {
+        var producer = new IndicativePriceDataProducer();
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            var events = Publish(producer,
-                Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+        var events = Publish(producer,
+            Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
 
-            Assert.IsEmpty(events);
-        }
+        Assert.IsEmpty(events, "price-time has no single price it would print at");
+    }
 
-        [Test]
-        public void ContinuousTrading_PublishesNothing()
-        {
-            var producer = new IndicativePriceDataProducer();
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+    [Test]
+    public void AuctionPrints_WithdrawsTheQuote()
+    {
+        var producer = new IndicativePriceDataProducer();
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+        Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+        Publish(producer, Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
 
-            var events = Publish(producer,
-                Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
+        TimeProvider.SetCurrentTime(Now2);
+        var events = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
 
-            Assert.IsEmpty(events, "price-time has no single price it would print at");
-        }
-
-        [Test]
-        public void AuctionPrints_WithdrawsTheQuote()
-        {
-            var producer = new IndicativePriceDataProducer();
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
-            Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
-            Publish(producer, Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
-
-            TimeProvider.SetCurrentTime(Now2);
-            var events = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-
-            Assert.AreEqual(1, events.Count);
-            Assert.AreEqual(Now2, events[0].Time);
-            Assert.IsNull(events[0].Price, "there is no auction left to quote once it has printed");
-            Assert.AreEqual(0, events[0].Quantity);
-        }
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(Now2, events[0].Time);
+        Assert.IsNull(events[0].Price, "there is no auction left to quote once it has printed");
+        Assert.AreEqual(0, events[0].Quantity);
     }
 }

--- a/Circus.Tests/DataProducers/LevelDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/LevelDataProducerTests.cs
@@ -1,337 +1,334 @@
-using System;
-using System.Collections.Generic;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers
+namespace Circus.Tests.DataProducers;
+
+// LevelDataProducer maintains its own state purely from the OrderConfirmedEvent stream, so
+// every test must route every book action through the same producer instance, in order -
+// never feed it only the final action's events after driving earlier actions directly
+// through the book.
+public class LevelDataProducerTests
 {
-    // LevelDataProducer maintains its own state purely from the OrderConfirmedEvent stream, so
-    // every test must route every book action through the same producer instance, in order -
-    // never feed it only the final action's events after driving earlier actions directly
-    // through the book.
-    public class LevelDataProducerTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+    private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
+    private static readonly DateTime Now6 = new(2000, 1, 1, 12, 5, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+    private static readonly string CompanyId4 = "Company4";
+    private static readonly string CompanyId5 = "Company5";
+    private static readonly string CompanyId6 = "Company6";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+    private static readonly string OrderId6 = "Order6";
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
-        private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
-        private static readonly DateTime Now6 = new(2000, 1, 1, 12, 5, 0);
+    private static LevelsDataEvent Publish(LevelDataProducer producer, IReadOnlyList<OrderBookEvent> bookEvents)
+    {
+        var events = producer.Process(Book, bookEvents);
+        Assert.AreEqual(1, events.Count);
+        return events[0];
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-        private static readonly string CompanyId4 = "Company4";
-        private static readonly string CompanyId5 = "Company5";
-        private static readonly string CompanyId6 = "Company6";
+    [Test]
+    public void SingleOrder_AppearsOnItsSide()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
-        private static readonly string OrderId6 = "Order6";
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100));
 
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        Assert.IsEmpty(level.Bids);
+        Assert.AreEqual(1, level.Offers.Count);
+        Assert.AreEqual(100, level.Offers[0].Price);
+        Assert.AreEqual(3, level.Offers[0].Quantity);
+        Assert.AreEqual(1, level.Offers[0].Count);
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+    [Test]
+    public void MultipleOrders_SamePrice_Aggregates()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100));
 
-        private static LevelsDataEvent Publish(LevelDataProducer producer, IReadOnlyList<OrderBookEvent> bookEvents)
-        {
-            var events = producer.Process(Book, bookEvents);
-            Assert.AreEqual(1, events.Count);
-            return events[0];
-        }
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100));
 
-        [Test]
-        public void SingleOrder_AppearsOnItsSide()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Assert.AreEqual(1, level.Offers.Count);
+        Assert.AreEqual(100, level.Offers[0].Price);
+        Assert.AreEqual(8, level.Offers[0].Quantity);
+        Assert.AreEqual(2, level.Offers[0].Count);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100));
+    [Test]
+    public void MultipleOffers_DifferentPrice_OrderedBestFirst()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 110));
 
-            Assert.IsEmpty(level.Bids);
-            Assert.AreEqual(1, level.Offers.Count);
-            Assert.AreEqual(100, level.Offers[0].Price);
-            Assert.AreEqual(3, level.Offers[0].Quantity);
-            Assert.AreEqual(1, level.Offers[0].Count);
-        }
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100));
 
-        [Test]
-        public void MultipleOrders_SamePrice_Aggregates()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100));
+        Assert.AreEqual(2, level.Offers.Count);
+        Assert.AreEqual(100, level.Offers[0].Price);
+        Assert.AreEqual(3, level.Offers[0].Quantity);
+        Assert.AreEqual(110, level.Offers[1].Price);
+        Assert.AreEqual(5, level.Offers[1].Quantity);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100));
+    [Test]
+    public void MultipleBids_DifferentPrice_OrderedBestFirst()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            Assert.AreEqual(1, level.Offers.Count);
-            Assert.AreEqual(100, level.Offers[0].Price);
-            Assert.AreEqual(8, level.Offers[0].Quantity);
-            Assert.AreEqual(2, level.Offers[0].Count);
-        }
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3, 110));
 
-        [Test]
-        public void MultipleOffers_DifferentPrice_OrderedBestFirst()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 110));
+        Assert.AreEqual(2, level.Bids.Count);
+        Assert.AreEqual(110, level.Bids[0].Price);
+        Assert.AreEqual(3, level.Bids[0].Quantity);
+        Assert.AreEqual(100, level.Bids[1].Price);
+        Assert.AreEqual(5, level.Bids[1].Quantity);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100));
+    [Test]
+    public void OppositeSides_TrackedIndependently()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            Assert.AreEqual(2, level.Offers.Count);
-            Assert.AreEqual(100, level.Offers[0].Price);
-            Assert.AreEqual(3, level.Offers[0].Quantity);
-            Assert.AreEqual(110, level.Offers[1].Price);
-            Assert.AreEqual(5, level.Offers[1].Quantity);
-        }
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 110));
 
-        [Test]
-        public void MultipleBids_DifferentPrice_OrderedBestFirst()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
+        Assert.AreEqual(1, level.Bids.Count);
+        Assert.AreEqual(100, level.Bids[0].Price);
+        Assert.AreEqual(1, level.Offers.Count);
+        Assert.AreEqual(110, level.Offers[0].Price);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3, 110));
+    [Test]
+    public void MoreLevelsThanMax_LimitedToMaxLevels()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110));
+        Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 120));
 
-            Assert.AreEqual(2, level.Bids.Count);
-            Assert.AreEqual(110, level.Bids[0].Price);
-            Assert.AreEqual(3, level.Bids[0].Quantity);
-            Assert.AreEqual(100, level.Bids[1].Price);
-            Assert.AreEqual(5, level.Bids[1].Quantity);
-        }
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 130));
 
-        [Test]
-        public void OppositeSides_TrackedIndependently()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
+        Assert.AreEqual(2, level.Bids.Count);
+        Assert.AreEqual(130, level.Bids[0].Price);
+        Assert.AreEqual(120, level.Bids[1].Price);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 110));
+    [Test]
+    public void PartialFill_ReducesQuantity_KeepsLevel()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            Assert.AreEqual(1, level.Bids.Count);
-            Assert.AreEqual(100, level.Bids[0].Price);
-            Assert.AreEqual(1, level.Offers.Count);
-            Assert.AreEqual(110, level.Offers[0].Price);
-        }
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 100));
 
-        [Test]
-        public void MoreLevelsThanMax_LimitedToMaxLevels()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110));
-            Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 120));
+        Assert.AreEqual(1, level.Bids.Count);
+        Assert.AreEqual(100, level.Bids[0].Price);
+        Assert.AreEqual(3, level.Bids[0].Quantity);
+        Assert.AreEqual(1, level.Bids[0].Count);
+        Assert.IsEmpty(level.Offers);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 130));
+    [Test]
+    public void FullFill_RemovesLevel()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110));
+        Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 120));
 
-            Assert.AreEqual(2, level.Bids.Count);
-            Assert.AreEqual(130, level.Bids[0].Price);
-            Assert.AreEqual(120, level.Bids[1].Price);
-        }
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 100));
 
-        [Test]
-        public void PartialFill_ReducesQuantity_KeepsLevel()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
+        // the 120 bid (best) fully fills against 4 of the sell order's 5; the remaining 1
+        // partially fills the 110 bid down to 2
+        Assert.AreEqual(1, level.Bids.Count);
+        Assert.AreEqual(110, level.Bids[0].Price);
+        Assert.AreEqual(2, level.Bids[0].Quantity);
+        Assert.IsEmpty(level.Offers);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 100));
+    [Test]
+    public void Cancel_RemovesFromLevel()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
+        Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3, 100));
 
-            Assert.AreEqual(1, level.Bids.Count);
-            Assert.AreEqual(100, level.Bids[0].Price);
-            Assert.AreEqual(3, level.Bids[0].Quantity);
-            Assert.AreEqual(1, level.Bids[0].Count);
-            Assert.IsEmpty(level.Offers);
-        }
+        var level = Publish(producer, Book.CancelOrder(CompanyId1, OrderId4, OrderId1));
 
-        [Test]
-        public void FullFill_RemovesLevel()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110));
-            Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 120));
+        Assert.AreEqual(1, level.Bids.Count);
+        Assert.AreEqual(100, level.Bids[0].Price);
+        Assert.AreEqual(3, level.Bids[0].Quantity);
+        Assert.AreEqual(1, level.Bids[0].Count);
+    }
 
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 100));
+    [Test]
+    public void Cancel_LastOrderAtLevel_RemovesLevelEntirely()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            // the 120 bid (best) fully fills against 4 of the sell order's 5; the remaining 1
-            // partially fills the 110 bid down to 2
-            Assert.AreEqual(1, level.Bids.Count);
-            Assert.AreEqual(110, level.Bids[0].Price);
-            Assert.AreEqual(2, level.Bids[0].Quantity);
-            Assert.IsEmpty(level.Offers);
-        }
+        var level = Publish(producer, Book.CancelOrder(CompanyId1, OrderId4, OrderId1));
 
-        [Test]
-        public void Cancel_RemovesFromLevel()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
-            Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3, 100));
+        Assert.IsEmpty(level.Bids);
+    }
 
-            var level = Publish(producer, Book.CancelOrder(CompanyId1, OrderId4, OrderId1));
+    [Test]
+    public void Reprice_MovesBetweenLevels()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            Assert.AreEqual(1, level.Bids.Count);
-            Assert.AreEqual(100, level.Bids[0].Price);
-            Assert.AreEqual(3, level.Bids[0].Quantity);
-            Assert.AreEqual(1, level.Bids[0].Count);
-        }
+        var level = Publish(producer, Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 110));
 
-        [Test]
-        public void Cancel_LastOrderAtLevel_RemovesLevelEntirely()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
+        Assert.IsEmpty(level.Offers);
+        Assert.AreEqual(1, level.Bids.Count);
+        Assert.AreEqual(110, level.Bids[0].Price);
+        Assert.AreEqual(5, level.Bids[0].Quantity);
+    }
 
-            var level = Publish(producer, Book.CancelOrder(CompanyId1, OrderId4, OrderId1));
+    [Test]
+    public void QuantityOnlyUpdate_SameLevel_QuantityChangesInPlace()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
 
-            Assert.IsEmpty(level.Bids);
-        }
+        var level = Publish(producer, Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, newTotalQuantity: 8));
 
-        [Test]
-        public void Reprice_MovesBetweenLevels()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
+        Assert.AreEqual(1, level.Bids.Count);
+        Assert.AreEqual(100, level.Bids[0].Price);
+        Assert.AreEqual(8, level.Bids[0].Quantity);
+        Assert.AreEqual(1, level.Bids[0].Count);
+    }
 
-            var level = Publish(producer, Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 110));
+    [Test]
+    public void Iceberg_ShowsOnlyDisplayedPeak_NotHiddenReserve()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
 
-            Assert.IsEmpty(level.Offers);
-            Assert.AreEqual(1, level.Bids.Count);
-            Assert.AreEqual(110, level.Bids[0].Price);
-            Assert.AreEqual(5, level.Bids[0].Quantity);
-        }
+        // total 20, only 5 displayed at a time
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
+                maxVisibleQuantity: 5));
 
-        [Test]
-        public void QuantityOnlyUpdate_SameLevel_QuantityChangesInPlace()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100));
+        Assert.AreEqual(1, level.Offers.Count);
+        Assert.AreEqual(100, level.Offers[0].Price);
+        Assert.AreEqual(5, level.Offers[0].Quantity, "only the displayed peak, never the hidden reserve");
+        Assert.AreEqual(1, level.Offers[0].Count);
+    }
 
-            var level = Publish(producer, Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, newTotalQuantity: 8));
+    [Test]
+    public void Iceberg_Reprice_MovesOnlyDisplayedPeak()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer,
+            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
+                maxVisibleQuantity: 5));
 
-            Assert.AreEqual(1, level.Bids.Count);
-            Assert.AreEqual(100, level.Bids[0].Price);
-            Assert.AreEqual(8, level.Bids[0].Quantity);
-            Assert.AreEqual(1, level.Bids[0].Count);
-        }
+        var level = Publish(producer, Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 110));
 
-        [Test]
-        public void Iceberg_ShowsOnlyDisplayedPeak_NotHiddenReserve()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Assert.IsEmpty(level.Bids);
+        Assert.AreEqual(1, level.Offers.Count);
+        Assert.AreEqual(110, level.Offers[0].Price);
+        Assert.AreEqual(5, level.Offers[0].Quantity, "still only the displayed peak after moving levels");
+    }
 
-            // total 20, only 5 displayed at a time
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
-                    maxVisibleQuantity: 5));
+    [Test]
+    public void AuctionPrint_TradesThroughIcebergPeak_LevelShowsTheRefreshedPeak()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
 
-            Assert.AreEqual(1, level.Offers.Count);
-            Assert.AreEqual(100, level.Offers[0].Price);
-            Assert.AreEqual(5, level.Offers[0].Quantity, "only the displayed peak, never the hidden reserve");
-            Assert.AreEqual(1, level.Offers[0].Count);
-        }
+        // total 100, only 10 displayed - but an auction sizes its print off full remaining
+        // quantity, so this trades 45, far more than the order was ever showing
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
+            maxVisibleQuantity: 10));
+        TimeProvider.SetCurrentTime(Now2);
+        Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100));
 
-        [Test]
-        public void Iceberg_Reprice_MovesOnlyDisplayedPeak()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer,
-                Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
-                    maxVisibleQuantity: 5));
+        var level = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
 
-            var level = Publish(producer, Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 110));
+        Assert.IsEmpty(level.Offers);
+        Assert.AreEqual(1, level.Bids.Count);
+        Assert.AreEqual(100, level.Bids[0].Price);
+        Assert.AreEqual(10, level.Bids[0].Quantity,
+            "a fresh peak, not the traded quantity taken off the peak it was showing");
+        Assert.AreEqual(1, level.Bids[0].Count);
+    }
 
-            Assert.IsEmpty(level.Bids);
-            Assert.AreEqual(1, level.Offers.Count);
-            Assert.AreEqual(110, level.Offers[0].Price);
-            Assert.AreEqual(5, level.Offers[0].Quantity, "still only the displayed peak after moving levels");
-        }
+    [Test]
+    public void StopOrderActivation_ReportedAsArrival_NotDoubleCounted()
+    {
+        var producer = new LevelDataProducer(2);
+        Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500));
+        Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500));
 
-        [Test]
-        public void AuctionPrint_TradesThroughIcebergPeak_LevelShowsTheRefreshedPeak()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.PreOpen));
+        TimeProvider.SetCurrentTime(Now3);
+        Publish(producer, Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520));
 
-            // total 100, only 10 displayed - but an auction sizes its print off full remaining
-            // quantity, so this trades 45, far more than the order was ever showing
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
-                maxVisibleQuantity: 10));
-            TimeProvider.SetCurrentTime(Now2);
-            Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100));
+        // still-Hidden stop order: must not appear in the working-book levels yet
+        TimeProvider.SetCurrentTime(Now4);
+        var afterStopCreate = Publish(producer,
+            Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510));
+        Assert.IsFalse(afterStopCreate.Bids.Count > 0 && afterStopCreate.Bids[0].Price == 530);
 
-            var level = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
+        TimeProvider.SetCurrentTime(Now5);
+        Publish(producer, Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510));
 
-            Assert.IsEmpty(level.Offers);
-            Assert.AreEqual(1, level.Bids.Count);
-            Assert.AreEqual(100, level.Bids[0].Price);
-            Assert.AreEqual(10, level.Bids[0].Quantity,
-                "a fresh peak, not the traded quantity taken off the peak it was showing");
-            Assert.AreEqual(1, level.Bids[0].Count);
-        }
+        // act - trade at the trigger price, converting the stop into a working limit order
+        // that immediately matches the resting 520 offer
+        TimeProvider.SetCurrentTime(Now6);
+        var level = Publish(producer,
+            Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510));
 
-        [Test]
-        public void StopOrderActivation_ReportedAsArrival_NotDoubleCounted()
-        {
-            var producer = new LevelDataProducer(2);
-            Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
-            Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500));
-            Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500));
-
-            TimeProvider.SetCurrentTime(Now3);
-            Publish(producer, Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520));
-
-            // still-Hidden stop order: must not appear in the working-book levels yet
-            TimeProvider.SetCurrentTime(Now4);
-            var afterStopCreate = Publish(producer,
-                Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510));
-            Assert.IsFalse(afterStopCreate.Bids.Count > 0 && afterStopCreate.Bids[0].Price == 530);
-
-            TimeProvider.SetCurrentTime(Now5);
-            Publish(producer, Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510));
-
-            // act - trade at the trigger price, converting the stop into a working limit order
-            // that immediately matches the resting 520 offer
-            TimeProvider.SetCurrentTime(Now6);
-            var level = Publish(producer,
-                Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510));
-
-            // the triggered order (530, qty 5) fully fills against the 520 offer (qty 5) and
-            // leaves the book - it should never have appeared as a resting level at all
-            Assert.IsFalse(level.Bids.Count > 0 && level.Bids[0].Price == 530);
-            Assert.IsEmpty(level.Offers);
-        }
+        // the triggered order (530, qty 5) fully fills against the 520 offer (qty 5) and
+        // leaves the book - it should never have appeared as a resting level at all
+        Assert.IsFalse(level.Bids.Count > 0 && level.Bids[0].Price == 530);
+        Assert.IsEmpty(level.Offers);
     }
 }

--- a/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
@@ -1,197 +1,193 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers
+namespace Circus.Tests.DataProducers;
+
+public class SecurityStatusDataProducerTests
 {
-    public class SecurityStatusDataProducerTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+    private TestTimeProvider TimeProvider;
+    private SecurityStatusDataProducer Producer;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+        TimeProvider = new TestTimeProvider(Now1);
+        Producer = new SecurityStatusDataProducer();
+    }
 
-        private TestTimeProvider TimeProvider;
-        private SecurityStatusDataProducer Producer;
+    private IList<SecurityStatusDataEvent> Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> bookEvents) =>
+        Producer.Process(book, bookEvents);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Producer = new SecurityStatusDataProducer();
-        }
+    private IOrderBook PlainBook() =>
+        new InMemoryOrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), TimeProvider);
 
-        private IList<SecurityStatusDataEvent> Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> bookEvents) =>
-            Producer.Process(book, bookEvents);
+    // A 5-tick volatility range on a reference of 100, pausing for two minutes.
+    private IOrderBook PausingBook() =>
+        new InMemoryOrderBook(
+            new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)}),
+            TimeProvider);
 
-        private IOrderBook PlainBook() =>
-            new InMemoryOrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), TimeProvider);
+    [Test]
+    public void OrdinaryOpen_PublishesTheStatusAndNothingPending()
+    {
+        // arrange
+        var book = PlainBook();
 
-        // A 5-tick volatility range on a reference of 100, pausing for two minutes.
-        private IOrderBook PausingBook() =>
-            new InMemoryOrderBook(
-                new Security("GCZ6", SecurityType.Future, 10, 10,
-                    PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)}),
-                TimeProvider);
+        // act
+        var events = Publish(book, book.UpdateStatus(OrderBookStatus.Open));
 
-        [Test]
-        public void OrdinaryOpen_PublishesTheStatusAndNothingPending()
-        {
-            // arrange
-            var book = PlainBook();
+        // assert
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(Now1, events[0].Time);
+        Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
+        Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason);
+        Assert.IsNull(events[0].ResumesAt);
+        Assert.IsNull(events[0].LimitState);
+    }
 
-            // act
-            var events = Publish(book, book.UpdateStatus(OrderBookStatus.Open));
+    [Test]
+    public void OrderFlowChangingNeitherStatusNorLimit_PublishesNothing()
+    {
+        // arrange
+        var book = PlainBook();
+        Publish(book, book.UpdateStatus(OrderBookStatus.Open));
 
-            // assert
-            Assert.AreEqual(1, events.Count);
-            Assert.AreEqual(Now1, events[0].Time);
-            Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
-            Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason);
-            Assert.IsNull(events[0].ResumesAt);
-            Assert.IsNull(events[0].LimitState);
-        }
+        // act
+        var events = Publish(book,
+            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
 
-        [Test]
-        public void OrderFlowChangingNeitherStatusNorLimit_PublishesNothing()
-        {
-            // arrange
-            var book = PlainBook();
-            Publish(book, book.UpdateStatus(OrderBookStatus.Open));
+        // assert
+        Assert.AreEqual(0, events.Count);
+    }
 
-            // act
-            var events = Publish(book,
-                book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
+    [Test]
+    public void VolatilityPause_PublishesTheReasonAndWhenItIsDueBack()
+    {
+        // arrange - referenced at 100, so a trade at 200 breaches the range
+        var book = PausingBook();
+        Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+        Publish(book, book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200));
 
-            // assert
-            Assert.AreEqual(0, events.Count);
-        }
+        // act
+        var events = Publish(book,
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
 
-        [Test]
-        public void VolatilityPause_PublishesTheReasonAndWhenItIsDueBack()
-        {
-            // arrange - referenced at 100, so a trade at 200 breaches the range
-            var book = PausingBook();
-            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
-            Publish(book, book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200));
+        // assert - the moment it is due back is the thing a halt notification is for, and it
+        // could not be published at all before this producer existed
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(OrderBookStatus.Paused, events[0].Status);
+        Assert.AreEqual(StatusChangeReason.PriceRestriction, events[0].Reason);
+        Assert.AreEqual(Now1 + PauseFor, events[0].ResumesAt);
+    }
 
-            // act
-            var events = Publish(book,
-                book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
+    [Test]
+    public void PauseElapsing_PublishesTheResumptionWithNothingPending()
+    {
+        // arrange - paused, due back in two minutes
+        var book = PausingBook();
+        Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+        book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
+        Publish(book, book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
 
-            // assert - the moment it is due back is the thing a halt notification is for, and it
-            // could not be published at all before this producer existed
-            Assert.AreEqual(1, events.Count);
-            Assert.AreEqual(OrderBookStatus.Paused, events[0].Status);
-            Assert.AreEqual(StatusChangeReason.PriceRestriction, events[0].Reason);
-            Assert.AreEqual(Now1 + PauseFor, events[0].ResumesAt);
-        }
+        // act
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        var events = Publish(book, book.AdvanceTime());
 
-        [Test]
-        public void PauseElapsing_PublishesTheResumptionWithNothingPending()
-        {
-            // arrange - paused, due back in two minutes
-            var book = PausingBook();
-            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
-            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
-            Publish(book, book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
+        // assert
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
+        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, events[0].Reason);
+        Assert.IsNull(events[0].ResumesAt, "back to trading, so nothing is pending");
+    }
 
-            // act
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            var events = Publish(book, book.AdvanceTime());
+    [Test]
+    public void OpenEndedInterruption_PublishesNoResumeTime()
+    {
+        // arrange - a range with no duration configured stands until something ends it
+        var book = new InMemoryOrderBook(
+            new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)}),
+            TimeProvider);
+        Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+        book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
 
-            // assert
-            Assert.AreEqual(1, events.Count);
-            Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
-            Assert.AreEqual(StatusChangeReason.InterruptionElapsed, events[0].Reason);
-            Assert.IsNull(events[0].ResumesAt, "back to trading, so nothing is pending");
-        }
+        // act
+        var events = Publish(book,
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
 
-        [Test]
-        public void OpenEndedInterruption_PublishesNoResumeTime()
-        {
-            // arrange - a range with no duration configured stands until something ends it
-            var book = new InMemoryOrderBook(
-                new Security("GCZ6", SecurityType.Future, 10, 10,
-                    PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)}),
-                TimeProvider);
-            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
-            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
+        // assert
+        Assert.AreEqual(OrderBookStatus.Paused, events[0].Status);
+        Assert.IsNull(events[0].ResumesAt);
+    }
 
-            // act
-            var events = Publish(book,
-                book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
+    [Test]
+    public void LimitLock_PublishesTheSideWhileTheStatusStaysOpen()
+    {
+        // arrange - a book holding a buy above the ceiling, reached by resting it while the
+        // limit was wider and then moving the reference so the limit narrows under it. The
+        // clock moves on so that buy is genuinely the older order when the sell arrives.
+        var book = new InMemoryOrderBook(
+            new Security("GCZ6", SecurityType.Future, 10, 10,
+                PriceRestrictions: new PriceRestrictionConfig[]
+                {
+                    new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
+                }),
+            TimeProvider);
 
-            // assert
-            Assert.AreEqual(OrderBookStatus.Paused, events[0].Status);
-            Assert.IsNull(events[0].ResumesAt);
-        }
+        Publish(book, book.UpdateStatus(OrderBookStatus.Open, 200));
+        book.CreateLimitOrder("Company1", "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
+        book.CreateLimitOrder("Company2", "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
+        book.CreateLimitOrder("Company2", "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
 
-        [Test]
-        public void LimitLock_PublishesTheSideWhileTheStatusStaysOpen()
-        {
-            // arrange - a book holding a buy above the ceiling, reached by resting it while the
-            // limit was wider and then moving the reference so the limit narrows under it. The
-            // clock moves on so that buy is genuinely the older order when the sell arrives.
-            var book = new InMemoryOrderBook(
-                new Security("GCZ6", SecurityType.Future, 10, 10,
-                    PriceRestrictions: new PriceRestrictionConfig[]
-                    {
-                        new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
-                    }),
-                TimeProvider);
+        TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
+        Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
 
-            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 200));
-            book.CreateLimitOrder("Company1", "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
-            book.CreateLimitOrder("Company2", "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
-            book.CreateLimitOrder("Company2", "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
+        // act - a sell inside the limit, crossing into the buy that is not
+        var events = Publish(book,
+            book.CreateLimitOrder("Company1", "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150));
 
-            TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
-            Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
+        // assert - stuck, and still open. That a limit is not a status is the whole reason it
+        // needs assembling with one.
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(Side.Buy, events[0].LimitState);
+        Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
+        Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason,
+            "the last status change is still what put it here");
 
-            // act - a sell inside the limit, crossing into the buy that is not
-            var events = Publish(book,
-                book.CreateLimitOrder("Company1", "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150));
+        // act - the order out beyond the ceiling is pulled and the book trades inside the limit
+        book.CancelOrder("Company2", "Cancel1", "Buy2");
+        var released = Publish(book,
+            book.CreateLimitOrder("Company2", "Buy3", new OrderValidity.Day(), Side.Buy, 5, 150));
 
-            // assert - stuck, and still open. That a limit is not a status is the whole reason it
-            // needs assembling with one.
-            Assert.AreEqual(1, events.Count);
-            Assert.AreEqual(Side.Buy, events[0].LimitState);
-            Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
-            Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason,
-                "the last status change is still what put it here");
+        // assert
+        Assert.AreEqual(1, released.Count);
+        Assert.IsNull(released[0].LimitState);
+        Assert.AreEqual(OrderBookStatus.Open, released[0].Status);
+    }
 
-            // act - the order out beyond the ceiling is pulled and the book trades inside the limit
-            book.CancelOrder("Company2", "Cancel1", "Buy2");
-            var released = Publish(book,
-                book.CreateLimitOrder("Company2", "Buy3", new OrderValidity.Day(), Side.Buy, 5, 150));
+    [Test]
+    public void StatusCarriesForwardAcrossALimitChange()
+    {
+        // arrange - a status the limit event must not disturb
+        var book = PlainBook();
+        var opened = Publish(book, book.UpdateStatus(OrderBookStatus.Paused));
 
-            // assert
-            Assert.AreEqual(1, released.Count);
-            Assert.IsNull(released[0].LimitState);
-            Assert.AreEqual(OrderBookStatus.Open, released[0].Status);
-        }
+        // assert
+        Assert.AreEqual(OrderBookStatus.Paused, opened.Single().Status);
 
-        [Test]
-        public void StatusCarriesForwardAcrossALimitChange()
-        {
-            // arrange - a status the limit event must not disturb
-            var book = PlainBook();
-            var opened = Publish(book, book.UpdateStatus(OrderBookStatus.Paused));
+        // act - a limit event arriving on its own carries the remembered status with it, which
+        // is what holding state is for
+        var events = Producer.Process(book,
+            new OrderBookEvent[] {new LimitStateChanged(book.Security, Now1, Side.Sell, 90)});
 
-            // assert
-            Assert.AreEqual(OrderBookStatus.Paused, opened.Single().Status);
-
-            // act - a limit event arriving on its own carries the remembered status with it, which
-            // is what holding state is for
-            var events = Producer.Process(book,
-                new OrderBookEvent[] {new LimitStateChanged(book.Security, Now1, Side.Sell, 90)});
-
-            // assert
-            Assert.AreEqual(OrderBookStatus.Paused, events.Single().Status);
-            Assert.AreEqual(Side.Sell, events.Single().LimitState);
-        }
+        // assert
+        Assert.AreEqual(OrderBookStatus.Paused, events.Single().Status);
+        Assert.AreEqual(Side.Sell, events.Single().LimitState);
     }
 }

--- a/Circus.Tests/DataProducers/TradeDataProducerTests.cs
+++ b/Circus.Tests/DataProducers/TradeDataProducerTests.cs
@@ -1,37 +1,35 @@
-﻿using System;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers
+namespace Circus.Tests.DataProducers;
+
+public class TradeDataProducerTests
 {
-    public class TradeDataProducerTests
+    [Test]
+    public void TradeDataProducer_Traded_FiresEvent()
     {
-        [Test]
-        public void TradeDataProducer_Traded_FiresEvent()
-        {
-            // arrange
-            var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var now = new DateTime(2000, 1, 1, 12, 0, 0);
-            var timeProvider = new TestTimeProvider(now);
-            var producer = new TradeDataProducer();
+        // arrange
+        var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var now = new DateTime(2000, 1, 1, 12, 0, 0);
+        var timeProvider = new TestTimeProvider(now);
+        var producer = new TradeDataProducer();
 
-            var book = new InMemoryOrderBook(sec, timeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100);
-            var bookEvents =
-                book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100);
+        var book = new InMemoryOrderBook(sec, timeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100);
+        var bookEvents =
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100);
 
-            // act
-            var events = producer.Process(book, bookEvents);
+        // act
+        var events = producer.Process(book, bookEvents);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            Assert.AreEqual(now, events[0].Time);
-            Assert.AreEqual(100, events[0].Price);
-            Assert.AreEqual(3, events[0].Quantity);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(now, events[0].Time);
+        Assert.AreEqual(100, events[0].Price);
+        Assert.AreEqual(3, events[0].Quantity);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -1,455 +1,452 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookAuctionTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookAuctionTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+    private static readonly string CompanyId4 = "Company4";
+    private static readonly string CompanyId5 = "Company5";
+    private static readonly string CompanyId6 = "Company6";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+    private static readonly string OrderId6 = "Order6";
+    private static readonly string OrderId7 = "Order7";
+    private static readonly string OrderId8 = "Order8";
+    private static readonly string CancelId1 = "Cancel1";
+
+    private static TestTimeProvider TimeProvider;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+        TimeProvider = new TestTimeProvider(Now1);
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-        private static readonly string CompanyId4 = "Company4";
-        private static readonly string CompanyId5 = "Company5";
-        private static readonly string CompanyId6 = "Company6";
+    [Test]
+    public void Opening_PicksMaxVolumePrice_AcrossMultipleLevels_WithPriceImprovement()
+    {
+        // arrange - best bid 140 vs best offer 110 would only cross 5 at the touch, but the
+        // volume-maximizing single price is 120, clearing 11: the 140 and 130 buys fully fill
+        // (price improvement - they pay 120, not their own higher limit), the 110 and 120
+        // sells fully fill (also price improvement - they get 120, not their own lower limit),
+        // and the 120 buy (the marginal order) only partially fills for the 1 unit left over
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
-        private static readonly string OrderId6 = "Order6";
-        private static readonly string OrderId7 = "Order7";
-        private static readonly string OrderId8 = "Order8";
-        private static readonly string CancelId1 = "Cancel1";
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 7, 130);
+        book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 15, 120);
+        book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 110);
+        book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 6, 120);
+        book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 20, 130);
 
-        private static TestTimeProvider TimeProvider;
+        // act
+        var events = book.UpdateStatus(OrderBookStatus.Open);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-        }
-
-        [Test]
-        public void Opening_PicksMaxVolumePrice_AcrossMultipleLevels_WithPriceImprovement()
-        {
-            // arrange - best bid 140 vs best offer 110 would only cross 5 at the touch, but the
-            // volume-maximizing single price is 120, clearing 11: the 140 and 130 buys fully fill
-            // (price improvement - they pay 120, not their own higher limit), the 110 and 120
-            // sells fully fill (also price improvement - they get 120, not their own lower limit),
-            // and the 120 buy (the marginal order) only partially fills for the 1 unit left over
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
-
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 7, 130);
-            book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 15, 120);
-            book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 110);
-            book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 6, 120);
-            book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 20, 130);
-
-            // act
-            var events = book.UpdateStatus(OrderBookStatus.Open);
-
-            // assert - every fill in this batch prints at the single auction price of 120
-            Assert.IsInstanceOf<StatusChanged>(events[0]);
-            var matches = events.OfType<OrdersMatched>().ToList();
-            Assert.IsNotEmpty(matches);
-            foreach (var matched in matches)
-                Assert.AreEqual(120, matched.Price);
-
-            Assert.AreEqual(11, matches.Sum(m => m.Quantity));
-
-            // the auction it was quoting is over, so the quote is withdrawn
-            Assert.IsNull(events.OfType<IndicativePriceChanged>().Last().Price);
-
-            // the marginal buy order (120) is left resting, partially filled
-            var buyLevels = book.GetLevels(Side.Buy, 10);
-            Assert.AreEqual(1, buyLevels.Count);
-            Assert.AreEqual(120, buyLevels[0].Price);
-            Assert.AreEqual(14, buyLevels[0].Quantity);
-
-            // the 110 and 120 sells fully cleared (11 total); the 130 sell (outside the clearing
-            // price's crossing range) is untouched
-            var sellLevels = book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(130, sellLevels[0].Price);
-            Assert.AreEqual(20, sellLevels[0].Quantity);
-        }
-
-        [Test]
-        public void Opening_IcebergAheadOfLaterOrder_FillsInFullBeforeTheLaterOrderGetsAnything()
-        {
-            // arrange - an iceberg (qty 100, peak 10) rests first at the clearing price; a plain
-            // order (qty 60) arrives second at the same price. Only 100 total sell liquidity is
-            // available - exactly enough to satisfy the iceberg's full size and nothing else.
-            // Price-time priority means the iceberg, having arrived first, must be filled in full
-            // before the later order gets anything - it must not lose its place in the queue just
-            // because its displayed peak needs replenishing mid-print.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
-
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
-                maxVisibleQuantity: 10);
-            TimeProvider.SetCurrentTime(Now2);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 60, 100);
-            TimeProvider.SetCurrentTime(Now3);
-            book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 100, 100);
-
-            // act
-            var events = book.UpdateStatus(OrderBookStatus.Open);
-
-            // assert
-            var fills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills).ToList();
-            var icebergFilled = fills.Where(f => f.Order.ClientOrderId == OrderId1).Sum(f => f.Quantity);
-            var laterOrderFilled = fills.Where(f => f.Order.ClientOrderId == OrderId2).Sum(f => f.Quantity);
-
-            Assert.AreEqual(100, icebergFilled, "the earlier-arriving iceberg should be filled in full");
-            Assert.AreEqual(0, laterOrderFilled,
-                "the later order should receive nothing once the earlier iceberg exhausts all available liquidity");
-        }
-
-        [Test]
-        public void Opening_IcebergPartiallyFilled_DisplayedPeakCorrectAfterwardsNotNegative()
-        {
-            // arrange - an iceberg (qty 100, peak 10) is the only buy order at the clearing price;
-            // only 45 units of sell liquidity are available, so it fills for 45 in a single
-            // auction allocation (not five separate peak-sized touches) and is left resting with
-            // 55 remaining. Sizing that single fill against the full remaining quantity rather
-            // than the 10-unit peak must not leave DisplayedQuantity negative or stale - it should
-            // come out re-derived to a fresh full peak, the same as if it had just been entered.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
-
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
-                maxVisibleQuantity: 10);
-            TimeProvider.SetCurrentTime(Now2);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100);
-
-            // act
-            var events = book.UpdateStatus(OrderBookStatus.Open);
-
-            // assert - one clean allocation of 45, not several smaller touches
-            var icebergFills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills)
-                .Where(f => f.Order.ClientOrderId == OrderId1).ToList();
-            Assert.AreEqual(1, icebergFills.Count);
-            Assert.AreEqual(45, icebergFills[0].Quantity);
-
-            var buyLevels = book.GetLevels(Side.Buy, 10);
-            Assert.AreEqual(1, buyLevels.Count);
-            Assert.AreEqual(100, buyLevels[0].Price);
-            Assert.AreEqual(10, buyLevels[0].Quantity, "displayed peak should be a fresh full 10, not negative or stale");
-        }
-
-        [Test]
-        public void Opening_TiedCandidates_DefaultsToCmeDirectionRule()
-        {
-            // arrange - 120 and 130 tie for max executable volume (10 each), with the surplus on
-            // the sell side at both - CME's rule picks the lowest of the tied prices in that case
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
-
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 7, 130);
-            book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 15, 110);
-            book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
-            book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 6, 120);
-            book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 20, 140);
-
-            // act
-            var events = book.UpdateStatus(OrderBookStatus.Open);
-
-            // assert
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
+        // assert - every fill in this batch prints at the single auction price of 120
+        Assert.IsInstanceOf<StatusChanged>(events[0]);
+        var matches = events.OfType<OrdersMatched>().ToList();
+        Assert.IsNotEmpty(matches);
+        foreach (var matched in matches)
             Assert.AreEqual(120, matched.Price);
-        }
 
-        [Test]
-        public void Opening_TiedCandidates_ReferencePriceBreaksTieOverCmeDirectionRule()
-        {
-            // arrange - same tie as above (120 vs 130), but with a reference price seeded at 130
-            // (must be tick-aligned to TickSize 10) - that should win over the default rule
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen, 130);
+        Assert.AreEqual(11, matches.Sum(m => m.Quantity));
 
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 7, 130);
-            book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 15, 110);
-            book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
-            book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 6, 120);
-            book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 20, 140);
+        // the auction it was quoting is over, so the quote is withdrawn
+        Assert.IsNull(events.OfType<IndicativePriceChanged>().Last().Price);
 
-            // act
-            var events = book.UpdateStatus(OrderBookStatus.Open);
+        // the marginal buy order (120) is left resting, partially filled
+        var buyLevels = book.GetLevels(Side.Buy, 10);
+        Assert.AreEqual(1, buyLevels.Count);
+        Assert.AreEqual(120, buyLevels[0].Price);
+        Assert.AreEqual(14, buyLevels[0].Quantity);
 
-            // assert
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(130, matched.Price);
-        }
+        // the 110 and 120 sells fully cleared (11 total); the 130 sell (outside the clearing
+        // price's crossing range) is untouched
+        var sellLevels = book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(130, sellLevels[0].Price);
+        Assert.AreEqual(20, sellLevels[0].Quantity);
+    }
 
-        [Test]
-        public void Opening_NoCrossingBook_NoAuctionPrint()
-        {
-            // arrange
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+    [Test]
+    public void Opening_IcebergAheadOfLaterOrder_FillsInFullBeforeTheLaterOrderGetsAnything()
+    {
+        // arrange - an iceberg (qty 100, peak 10) rests first at the clearing price; a plain
+        // order (qty 60) arrives second at the same price. Only 100 total sell liquidity is
+        // available - exactly enough to satisfy the iceberg's full size and nothing else.
+        // Price-time priority means the iceberg, having arrived first, must be filled in full
+        // before the later order gets anything - it must not lose its place in the queue just
+        // because its displayed peak needs replenishing mid-print.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen);
 
-            // act
-            var events = book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
+            maxVisibleQuantity: 10);
+        TimeProvider.SetCurrentTime(Now2);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 60, 100);
+        TimeProvider.SetCurrentTime(Now3);
+        book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 100, 100);
 
-            // assert
-            Assert.AreEqual(1, events.Count);
-            Assert.IsInstanceOf<StatusChanged>(events[0]);
-            var buyLevels = book.GetLevels(Side.Buy, 10);
-            Assert.AreEqual(1, buyLevels.Count);
-            Assert.AreEqual(5, buyLevels[0].Quantity);
-        }
+        // act
+        var events = book.UpdateStatus(OrderBookStatus.Open);
 
-        [Test]
-        public void PreOpen_CrossedBook_QuotesButNeverTrades()
-        {
-            // arrange - pre-open is governed by an auction, so the one thing that must never
-            // happen is that governance turning into execution: a crossed book during pre-open is
-            // quoted, not printed. Orders sit untouched until the open.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
+        // assert
+        var fills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills).ToList();
+        var icebergFilled = fills.Where(f => f.Order.ClientOrderId == OrderId1).Sum(f => f.Quantity);
+        var laterOrderFilled = fills.Where(f => f.Order.ClientOrderId == OrderId2).Sum(f => f.Quantity);
 
-            // act - deeply crossed: the bid is well through the offer
-            var buy = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
-            var sell = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+        Assert.AreEqual(100, icebergFilled, "the earlier-arriving iceberg should be filled in full");
+        Assert.AreEqual(0, laterOrderFilled,
+            "the later order should receive nothing once the earlier iceberg exhausts all available liquidity");
+    }
 
-            // assert - a confirmation each, and no trade
-            Assert.AreEqual(1, buy.Count, "nothing crosses yet, so not even a quote");
-            Assert.IsInstanceOf<CreateOrderConfirmed>(buy[0]);
-            Assert.AreEqual(2, sell.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(sell[0]);
+    [Test]
+    public void Opening_IcebergPartiallyFilled_DisplayedPeakCorrectAfterwardsNotNegative()
+    {
+        // arrange - an iceberg (qty 100, peak 10) is the only buy order at the clearing price;
+        // only 45 units of sell liquidity are available, so it fills for 45 in a single
+        // auction allocation (not five separate peak-sized touches) and is left resting with
+        // 55 remaining. Sizing that single fill against the full remaining quantity rather
+        // than the 10-unit peak must not leave DisplayedQuantity negative or stale - it should
+        // come out re-derived to a fresh full peak, the same as if it had just been entered.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen);
 
-            // the auction is quoting the whole time, it just isn't acting on it
-            var quote = sell[1] as IndicativePriceChanged;
-            Assert.IsNotNull(quote);
-            Assert.AreEqual(100, quote.Price);
-            Assert.AreEqual(10, quote.Quantity);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
+            maxVisibleQuantity: 10);
+        TimeProvider.SetCurrentTime(Now2);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100);
 
-            // and both orders are still resting in full
-            Assert.AreEqual(10, book.GetLevels(Side.Buy, 10)[0].Quantity);
-            Assert.AreEqual(10, book.GetLevels(Side.Sell, 10)[0].Quantity);
-        }
+        // act
+        var events = book.UpdateStatus(OrderBookStatus.Open);
 
-        [Test]
-        public void ClosingFromPreOpen_AbandonsTheAuction_WithoutPrinting()
-        {
-            // arrange - a crossed book in pre-open, quoting a price it would clear at
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
-            var quoting = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
-            Assert.IsNotEmpty(quoting.OfType<IndicativePriceChanged>().ToList());
+        // assert - one clean allocation of 45, not several smaller touches
+        var icebergFills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills)
+            .Where(f => f.Order.ClientOrderId == OrderId1).ToList();
+        Assert.AreEqual(1, icebergFills.Count);
+        Assert.AreEqual(45, icebergFills[0].Quantity);
 
-            // act - closing rather than opening. Pre-open is a phase that prints on the way out,
-            // but the phase being entered doesn't trade, so the orders it accumulated are
-            // abandoned rather than crossed.
-            var events = book.UpdateStatus(OrderBookStatus.Closed);
+        var buyLevels = book.GetLevels(Side.Buy, 10);
+        Assert.AreEqual(1, buyLevels.Count);
+        Assert.AreEqual(100, buyLevels[0].Price);
+        Assert.AreEqual(10, buyLevels[0].Quantity, "displayed peak should be a fresh full 10, not negative or stale");
+    }
 
-            // assert
-            Assert.IsEmpty(events.OfType<OrdersMatched>().ToList(),
-                "the auction must not print into a phase that doesn't trade");
-            Assert.AreEqual(2, events.OfType<ExpireOrderConfirmed>().ToList().Count);
-            Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+    [Test]
+    public void Opening_TiedCandidates_DefaultsToCmeDirectionRule()
+    {
+        // arrange - 120 and 130 tie for max executable volume (10 each), with the surplus on
+        // the sell side at both - CME's rule picks the lowest of the tied prices in that case
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen);
 
-            // the quote goes with it - a closed book is not still quoting one
-            var quote = events.OfType<IndicativePriceChanged>().Last();
-            Assert.IsNull(quote.Price);
-            Assert.AreEqual(0, quote.Quantity);
-        }
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 7, 130);
+        book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 15, 110);
+        book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
+        book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 6, 120);
+        book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 20, 140);
 
-        [Test]
-        public void IndicativePrice_NotQuotedWhileOpen()
-        {
-            // arrange - continuous trading is governed by price-time, which has no single price it
-            // would print at, so there is no indicative auction price to publish while open
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
+        // act
+        var events = book.UpdateStatus(OrderBookStatus.Open);
 
-            // act + assert - a resting order, then one that crosses it and trades: neither quotes
-            var resting = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
-            var crossing = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
+        // assert
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(120, matched.Price);
+    }
 
-            Assert.IsEmpty(resting.OfType<IndicativePriceChanged>().ToList());
-            Assert.IsInstanceOf<OrdersMatched>(crossing[^1]);
-            Assert.IsEmpty(crossing.OfType<IndicativePriceChanged>().ToList());
+    [Test]
+    public void Opening_TiedCandidates_ReferencePriceBreaksTieOverCmeDirectionRule()
+    {
+        // arrange - same tie as above (120 vs 130), but with a reference price seeded at 130
+        // (must be tick-aligned to TickSize 10) - that should win over the default rule
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen, 130);
 
-            // ...and it comes back the moment a volatility pause interrupts trading
-            book.UpdateStatus(OrderBookStatus.Paused);
-            var paused = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 10, 100);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 7, 130);
+        book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 15, 110);
+        book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
+        book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 6, 120);
+        book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 20, 140);
 
-            var quote = paused.OfType<IndicativePriceChanged>().Last();
-            Assert.AreEqual(100, quote.Price);
-            Assert.AreEqual(6, quote.Quantity, "what is left of the buy after the trade above");
-        }
+        // act
+        var events = book.UpdateStatus(OrderBookStatus.Open);
 
-        [Test]
-        public void IndicativePrice_PublishedAsThePreOpenBookMoves()
-        {
-            // arrange
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            var preOpen = book.UpdateStatus(OrderBookStatus.PreOpen);
+        // assert
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(130, matched.Price);
+    }
 
-            // assert - nothing resting yet, so nothing to quote
-            Assert.IsEmpty(preOpen.OfType<IndicativePriceChanged>().ToList());
+    [Test]
+    public void Opening_NoCrossingBook_NoAuctionPrint()
+    {
+        // arrange
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
-            // act - one-sided book, still no cross
-            var oneSided = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
-            Assert.IsEmpty(oneSided.OfType<IndicativePriceChanged>().ToList());
+        // act
+        var events = book.UpdateStatus(OrderBookStatus.Open);
 
-            // act - a crossing sell arrives
-            var crossed = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
-            var quote = crossed.OfType<IndicativePriceChanged>().Last();
-            Assert.AreEqual(100, quote.Price);
-            Assert.AreEqual(10, quote.Quantity);
+        // assert
+        Assert.AreEqual(1, events.Count);
+        Assert.IsInstanceOf<StatusChanged>(events[0]);
+        var buyLevels = book.GetLevels(Side.Buy, 10);
+        Assert.AreEqual(1, buyLevels.Count);
+        Assert.AreEqual(5, buyLevels[0].Quantity);
+    }
 
-            // act - more sell liquidity at the same price. The buy side still caps what could
-            // clear, so the quote hasn't moved and nothing is published for it
-            var deeperSell = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 100);
-            Assert.IsEmpty(deeperSell.OfType<IndicativePriceChanged>().ToList());
+    [Test]
+    public void PreOpen_CrossedBook_QuotesButNeverTrades()
+    {
+        // arrange - pre-open is governed by an auction, so the one thing that must never
+        // happen is that governance turning into execution: a crossed book during pre-open is
+        // quoted, not printed. Orders sit untouched until the open.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen);
 
-            // act - the buy side catching up does move it
-            var deeperBuy = book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 100);
-            var requoted = deeperBuy.OfType<IndicativePriceChanged>().Last();
-            Assert.AreEqual(100, requoted.Price);
-            Assert.AreEqual(15, requoted.Quantity);
+        // act - deeply crossed: the bid is well through the offer
+        var buy = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
+        var sell = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
 
-            // act - cancelling every sell removes the cross again, withdrawing the quote
-            var thinner = book.CancelOrder(CompanyId3, CancelId1, OrderId3);
-            Assert.AreEqual(10, thinner.OfType<IndicativePriceChanged>().Last().Quantity);
+        // assert - a confirmation each, and no trade
+        Assert.AreEqual(1, buy.Count, "nothing crosses yet, so not even a quote");
+        Assert.IsInstanceOf<CreateOrderConfirmed>(buy[0]);
+        Assert.AreEqual(2, sell.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(sell[0]);
 
-            var uncrossed = book.CancelOrder(CompanyId2, CancelId1, OrderId2);
-            var withdrawn = uncrossed.OfType<IndicativePriceChanged>().Last();
-            Assert.IsNull(withdrawn.Price);
-            Assert.AreEqual(0, withdrawn.Quantity);
+        // the auction is quoting the whole time, it just isn't acting on it
+        var quote = sell[1] as IndicativePriceChanged;
+        Assert.IsNotNull(quote);
+        Assert.AreEqual(100, quote.Price);
+        Assert.AreEqual(10, quote.Quantity);
 
-            // and nothing more is published while there is still nothing to quote
-            var stillNothing = book.CancelOrder(CompanyId1, CancelId1, OrderId1);
-            Assert.IsEmpty(stillNothing.OfType<IndicativePriceChanged>().ToList());
-        }
+        // and both orders are still resting in full
+        Assert.AreEqual(10, book.GetLevels(Side.Buy, 10)[0].Quantity);
+        Assert.AreEqual(10, book.GetLevels(Side.Sell, 10)[0].Quantity);
+    }
 
-        [Test]
-        public void RestingOrderOutsideBand_WithoutCrossingAnything_DoesNotPause()
-        {
-            // arrange - a resting limit order sitting far from the market doesn't represent any
-            // actual price movement by itself; only an executed trade at an extreme price should
-            // pause the book. This order doesn't cross anything (isolated at 200, nothing on the
-            // opposing side), so it must not trigger a pause just for being entered.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
+    [Test]
+    public void ClosingFromPreOpen_AbandonsTheAuction_WithoutPrinting()
+    {
+        // arrange - a crossed book in pre-open, quoting a price it would clear at
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
+        var quoting = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+        Assert.IsNotEmpty(quoting.OfType<IndicativePriceChanged>().ToList());
 
-            // act
-            var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 10, 200);
+        // act - closing rather than opening. Pre-open is a phase that prints on the way out,
+        // but the phase being entered doesn't trade, so the orders it accumulated are
+        // abandoned rather than crossed.
+        var events = book.UpdateStatus(OrderBookStatus.Closed);
 
-            // assert - accepted normally, no pause
-            Assert.AreEqual(1, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        }
+        // assert
+        Assert.IsEmpty(events.OfType<OrdersMatched>().ToList(),
+            "the auction must not print into a phase that doesn't trade");
+        Assert.AreEqual(2, events.OfType<ExpireOrderConfirmed>().ToList().Count);
+        Assert.AreEqual(OrderBookStatus.Closed, book.Status);
 
-        [Test]
-        public void VolatilityBandBreach_OnActualTrade_PausesInsteadOfExecuting_StopElectsOnReopen()
-        {
-            // arrange - continuous trading establishes a reference price of 100, then a resting
-            // sell stop (trigger 90) is added, plus a resting sell at 200 that hasn't crossed
-            // anything yet (so hasn't paused anything, per the test above)
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
-            book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 80, 90);
-            book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 10, 200);
+        // the quote goes with it - a closed book is not still quoting one
+        var quote = events.OfType<IndicativePriceChanged>().Last();
+        Assert.IsNull(quote.Price);
+        Assert.AreEqual(0, quote.Quantity);
+    }
 
-            // act - a buy at 200 would actually cross and trade against the resting 200 sell, at a
-            // price 100 away from the 100 reference - breaching the 50-wide volatility band. The
-            // trade is prevented (not executed) and the book pauses instead; neither order fills
-            TimeProvider.SetCurrentTime(Now3);
-            var events = book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 10, 200);
+    [Test]
+    public void IndicativePrice_NotQuotedWhileOpen()
+    {
+        // arrange - continuous trading is governed by price-time, which has no single price it
+        // would print at, so there is no indicative auction price to publish while open
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
 
-            // assert
-            Assert.AreEqual(3, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.AreEqual(OrderBookStatus.Paused, ((StatusChanged) events[1]).Status);
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        // act + assert - a resting order, then one that crosses it and trades: neither quotes
+        var resting = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+        var crossing = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
 
-            // the pause is an auction, and it quotes the crossed book it inherited rather than
-            // printing it
-            var paused = events[2] as IndicativePriceChanged;
-            Assert.IsNotNull(paused);
-            Assert.AreEqual(200, paused.Price);
-            Assert.AreEqual(10, paused.Quantity);
+        Assert.IsEmpty(resting.OfType<IndicativePriceChanged>().ToList());
+        Assert.IsInstanceOf<OrdersMatched>(crossing[^1]);
+        Assert.IsEmpty(crossing.OfType<IndicativePriceChanged>().ToList());
 
-            var sellLevels = book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(200, sellLevels[0].Price);
-            Assert.AreEqual(10, sellLevels[0].Quantity); // untouched - the trade was prevented
+        // ...and it comes back the moment a volatility pause interrupts trading
+        book.UpdateStatus(OrderBookStatus.Paused);
+        var paused = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 10, 100);
 
-            // orders can still be entered/cancelled while paused
-            TimeProvider.SetCurrentTime(Now4);
-            book.CreateLimitOrder(CompanyId1, OrderId7, new OrderValidity.Day(), Side.Buy, 10, 90);
-            book.CreateLimitOrder(CompanyId2, OrderId8, new OrderValidity.Day(), Side.Sell, 10, 90);
+        var quote = paused.OfType<IndicativePriceChanged>().Last();
+        Assert.AreEqual(100, quote.Price);
+        Assert.AreEqual(6, quote.Quantity, "what is left of the buy after the trade above");
+    }
 
-            // act - ending the pause (seeding a fresh reference of 90) runs the same uncrossing
-            // pass, clearing at 90 and moving the last traded price there, which elects the
-            // resting stop (trigger 90, satisfied by <= 90)
-            var reopenEvents = book.UpdateStatus(OrderBookStatus.Open, 90);
+    [Test]
+    public void IndicativePrice_PublishedAsThePreOpenBookMoves()
+    {
+        // arrange
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var preOpen = book.UpdateStatus(OrderBookStatus.PreOpen);
 
-            // assert
-            Assert.IsTrue(reopenEvents.OfType<OrdersMatched>().Any(m => m.Price == 90));
-            var stopElected = reopenEvents.Any(e => e is UpdateOrderConfirmed u && u.Order.ClientOrderId == OrderId3) ||
-                reopenEvents.OfType<OrdersMatched>().Any(m => m.Fills.Any(f => f.ClientOrderId == OrderId3));
-            Assert.IsTrue(stopElected);
-        }
+        // assert - nothing resting yet, so nothing to quote
+        Assert.IsEmpty(preOpen.OfType<IndicativePriceChanged>().ToList());
 
-        [Test]
-        public void EntryBandOnly_NoVolatilityBandConfigured_Unaffected()
-        {
-            // arrange - #23's hard-reject band still works exactly as before with no volatility
-            // band alongside it
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
+        // act - one-sided book, still no cross
+        var oneSided = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+        Assert.IsEmpty(oneSided.OfType<IndicativePriceChanged>().ToList());
 
-            // act
-            var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 200);
+        // act - a crossing sell arrives
+        var crossed = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+        var quote = crossed.OfType<IndicativePriceChanged>().Last();
+        Assert.AreEqual(100, quote.Price);
+        Assert.AreEqual(10, quote.Quantity);
 
-            // assert - rejected outright, no pause
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        }
+        // act - more sell liquidity at the same price. The buy side still caps what could
+        // clear, so the quote hasn't moved and nothing is published for it
+        var deeperSell = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 100);
+        Assert.IsEmpty(deeperSell.OfType<IndicativePriceChanged>().ToList());
+
+        // act - the buy side catching up does move it
+        var deeperBuy = book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 100);
+        var requoted = deeperBuy.OfType<IndicativePriceChanged>().Last();
+        Assert.AreEqual(100, requoted.Price);
+        Assert.AreEqual(15, requoted.Quantity);
+
+        // act - cancelling every sell removes the cross again, withdrawing the quote
+        var thinner = book.CancelOrder(CompanyId3, CancelId1, OrderId3);
+        Assert.AreEqual(10, thinner.OfType<IndicativePriceChanged>().Last().Quantity);
+
+        var uncrossed = book.CancelOrder(CompanyId2, CancelId1, OrderId2);
+        var withdrawn = uncrossed.OfType<IndicativePriceChanged>().Last();
+        Assert.IsNull(withdrawn.Price);
+        Assert.AreEqual(0, withdrawn.Quantity);
+
+        // and nothing more is published while there is still nothing to quote
+        var stillNothing = book.CancelOrder(CompanyId1, CancelId1, OrderId1);
+        Assert.IsEmpty(stillNothing.OfType<IndicativePriceChanged>().ToList());
+    }
+
+    [Test]
+    public void RestingOrderOutsideBand_WithoutCrossingAnything_DoesNotPause()
+    {
+        // arrange - a resting limit order sitting far from the market doesn't represent any
+        // actual price movement by itself; only an executed trade at an extreme price should
+        // pause the book. This order doesn't cross anything (isolated at 200, nothing on the
+        // opposing side), so it must not trigger a pause just for being entered.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+
+        // act
+        var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 10, 200);
+
+        // assert - accepted normally, no pause
+        Assert.AreEqual(1, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void VolatilityBandBreach_OnActualTrade_PausesInsteadOfExecuting_StopElectsOnReopen()
+    {
+        // arrange - continuous trading establishes a reference price of 100, then a resting
+        // sell stop (trigger 90) is added, plus a resting sell at 200 that hasn't crossed
+        // anything yet (so hasn't paused anything, per the test above)
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
+        book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 80, 90);
+        book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 10, 200);
+
+        // act - a buy at 200 would actually cross and trade against the resting 200 sell, at a
+        // price 100 away from the 100 reference - breaching the 50-wide volatility band. The
+        // trade is prevented (not executed) and the book pauses instead; neither order fills
+        TimeProvider.SetCurrentTime(Now3);
+        var events = book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 10, 200);
+
+        // assert
+        Assert.AreEqual(3, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.AreEqual(OrderBookStatus.Paused, ((StatusChanged) events[1]).Status);
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+
+        // the pause is an auction, and it quotes the crossed book it inherited rather than
+        // printing it
+        var paused = events[2] as IndicativePriceChanged;
+        Assert.IsNotNull(paused);
+        Assert.AreEqual(200, paused.Price);
+        Assert.AreEqual(10, paused.Quantity);
+
+        var sellLevels = book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(200, sellLevels[0].Price);
+        Assert.AreEqual(10, sellLevels[0].Quantity); // untouched - the trade was prevented
+
+        // orders can still be entered/cancelled while paused
+        TimeProvider.SetCurrentTime(Now4);
+        book.CreateLimitOrder(CompanyId1, OrderId7, new OrderValidity.Day(), Side.Buy, 10, 90);
+        book.CreateLimitOrder(CompanyId2, OrderId8, new OrderValidity.Day(), Side.Sell, 10, 90);
+
+        // act - ending the pause (seeding a fresh reference of 90) runs the same uncrossing
+        // pass, clearing at 90 and moving the last traded price there, which elects the
+        // resting stop (trigger 90, satisfied by <= 90)
+        var reopenEvents = book.UpdateStatus(OrderBookStatus.Open, 90);
+
+        // assert
+        Assert.IsTrue(reopenEvents.OfType<OrdersMatched>().Any(m => m.Price == 90));
+        var stopElected = reopenEvents.Any(e => e is UpdateOrderConfirmed u && u.Order.ClientOrderId == OrderId3) ||
+            reopenEvents.OfType<OrdersMatched>().Any(m => m.Fills.Any(f => f.ClientOrderId == OrderId3));
+        Assert.IsTrue(stopElected);
+    }
+
+    [Test]
+    public void EntryBandOnly_NoVolatilityBandConfigured_Unaffected()
+    {
+        // arrange - #23's hard-reject band still works exactly as before with no volatility
+        // band alongside it
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+
+        // act
+        var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 200);
+
+        // assert - rejected outright, no pause
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
@@ -1,217 +1,214 @@
-﻿using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookCancelOrderTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookCancelOrderTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    [Test]
+    public void LimitOrder_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
+        // act
+        var events = Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var cancelled = events[0] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(Sec, cancelled.Security);
+        Assert.AreEqual(Now2, cancelled.Time);
+        Assert.AreEqual(CompanyId1, cancelled.CompanyId);
+        Assert.AreEqual(OrderId1, cancelled.PreviousClientOrderId);
+        Assert.AreEqual(OrderCancelledReason.Cancelled, cancelled.Reason);
+        Assert.AreEqual(100, cancelled.PreviousPrice, "the working-book price it's being removed from");
+        Assert.AreEqual(3, cancelled.PreviousQuantity, "the working-book displayed quantity being removed");
+        Assert.AreEqual(CompanyId1, cancelled.Order.CompanyId);
+        Assert.AreEqual(OrderId4, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(Sec, cancelled.Order.Security);
+        Assert.AreEqual(Now1, cancelled.Order.CreatedTime);
+        Assert.AreEqual(Now1, cancelled.Order.ModifiedTime);
+        Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, cancelled.Order.Side);
+        Assert.AreEqual(100, cancelled.Order.Price);
+        Assert.IsNull(cancelled.Order.TriggerPrice);
+        Assert.AreEqual(3, cancelled.Order.Quantity);
+        Assert.AreEqual(0, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+    }
 
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+    [Test]
+    public void StopOrder_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
+        TimeProvider.SetCurrentTime(Now2);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+        // act
+        var events = Book.CancelOrder(CompanyId3, OrderId4, OrderId3);
 
-        [Test]
-        public void LimitOrder_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var cancelled = events[0] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(Sec, cancelled.Security);
+        Assert.AreEqual(Now2, cancelled.Time);
+        Assert.AreEqual(CompanyId3, cancelled.CompanyId);
+        Assert.AreEqual(OrderId3, cancelled.PreviousClientOrderId);
+        Assert.AreEqual(OrderCancelledReason.Cancelled, cancelled.Reason);
+        Assert.IsNull(cancelled.PreviousPrice, "still Hidden - never resting in the working book");
+        Assert.AreEqual(3, cancelled.PreviousQuantity, "the working-book displayed quantity being removed");
+        Assert.AreEqual(CompanyId3, cancelled.Order.CompanyId);
+        Assert.AreEqual(OrderId4, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(Sec, cancelled.Order.Security);
+        Assert.AreEqual(Now1, cancelled.Order.CreatedTime);
+        Assert.AreEqual(Now1, cancelled.Order.ModifiedTime);
+        Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(OrderType.StopMarket, cancelled.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, cancelled.Order.Side);
+        Assert.IsNull(cancelled.Order.Price);
+        Assert.AreEqual(110, cancelled.Order.TriggerPrice);
+        Assert.AreEqual(3, cancelled.Order.Quantity);
+        Assert.AreEqual(0, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+    }
 
-            // act
-            var events = Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
+    [Test]
+    public void MarketClosed_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.UpdateStatus(OrderBookStatus.Closed);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var cancelled = events[0] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(Sec, cancelled.Security);
-            Assert.AreEqual(Now2, cancelled.Time);
-            Assert.AreEqual(CompanyId1, cancelled.CompanyId);
-            Assert.AreEqual(OrderId1, cancelled.PreviousClientOrderId);
-            Assert.AreEqual(OrderCancelledReason.Cancelled, cancelled.Reason);
-            Assert.AreEqual(100, cancelled.PreviousPrice, "the working-book price it's being removed from");
-            Assert.AreEqual(3, cancelled.PreviousQuantity, "the working-book displayed quantity being removed");
-            Assert.AreEqual(CompanyId1, cancelled.Order.CompanyId);
-            Assert.AreEqual(OrderId4, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(Sec, cancelled.Order.Security);
-            Assert.AreEqual(Now1, cancelled.Order.CreatedTime);
-            Assert.AreEqual(Now1, cancelled.Order.ModifiedTime);
-            Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, cancelled.Order.Side);
-            Assert.AreEqual(100, cancelled.Order.Price);
-            Assert.IsNull(cancelled.Order.TriggerPrice);
-            Assert.AreEqual(3, cancelled.Order.Quantity);
-            Assert.AreEqual(0, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-        }
+        // act
+        var events = Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
 
-        [Test]
-        public void StopOrder_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
-            TimeProvider.SetCurrentTime(Now2);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CancelOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.MarketClosed, rejected.Reason);
+        Assert.IsNull(rejected.ExchangeOrderId, "rejected before the order was ever looked up");
+    }
 
-            // act
-            var events = Book.CancelOrder(CompanyId3, OrderId4, OrderId3);
+    [Test]
+    public void Completed_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
+            .OfType<CreateOrderConfirmed>().Single();
+        Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var cancelled = events[0] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(Sec, cancelled.Security);
-            Assert.AreEqual(Now2, cancelled.Time);
-            Assert.AreEqual(CompanyId3, cancelled.CompanyId);
-            Assert.AreEqual(OrderId3, cancelled.PreviousClientOrderId);
-            Assert.AreEqual(OrderCancelledReason.Cancelled, cancelled.Reason);
-            Assert.IsNull(cancelled.PreviousPrice, "still Hidden - never resting in the working book");
-            Assert.AreEqual(3, cancelled.PreviousQuantity, "the working-book displayed quantity being removed");
-            Assert.AreEqual(CompanyId3, cancelled.Order.CompanyId);
-            Assert.AreEqual(OrderId4, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(Sec, cancelled.Order.Security);
-            Assert.AreEqual(Now1, cancelled.Order.CreatedTime);
-            Assert.AreEqual(Now1, cancelled.Order.ModifiedTime);
-            Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(OrderType.StopMarket, cancelled.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, cancelled.Order.Side);
-            Assert.IsNull(cancelled.Order.Price);
-            Assert.AreEqual(110, cancelled.Order.TriggerPrice);
-            Assert.AreEqual(3, cancelled.Order.Quantity);
-            Assert.AreEqual(0, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-        }
+        // act
+        var events = Book.CancelOrder(CompanyId1, OrderId5, OrderId4);
 
-        [Test]
-        public void MarketClosed_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.UpdateStatus(OrderBookStatus.Closed);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CancelOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId4, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
+        Assert.AreEqual(created.Order.ExchangeOrderId, rejected.ExchangeOrderId,
+            "the order was found (and is now cancelled), so its ExchangeOrderId is known");
+    }
 
-            // act
-            var events = Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
+    [Test]
+    public void NotFound_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CancelOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.MarketClosed, rejected.Reason);
-            Assert.IsNull(rejected.ExchangeOrderId, "rejected before the order was ever looked up");
-        }
+        // act
+        var events = Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
 
-        [Test]
-        public void Completed_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
-                .OfType<CreateOrderConfirmed>().Single();
-            Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CancelOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.OrderNotInBook, rejected.Reason);
+    }
 
-            // act
-            var events = Book.CancelOrder(CompanyId1, OrderId5, OrderId4);
+    [Test]
+    public void ForeignClientOrderId_Rejected()
+    {
+        // arrange - client 2 cannot cancel client 1's order by quoting client 1's clientOrderId,
+        // since the (companyId, clientOrderId) lookup is scoped per client
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CancelOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId4, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
-            Assert.AreEqual(created.Order.ExchangeOrderId, rejected.ExchangeOrderId,
-                "the order was found (and is now cancelled), so its ExchangeOrderId is known");
-        }
+        // act
+        var events = Book.CancelOrder(CompanyId2, OrderId4, OrderId1);
 
-        [Test]
-        public void NotFound_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CancelOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(CompanyId2, rejected.CompanyId);
+        Assert.AreEqual(OrderRejectedReason.OrderNotInBook, rejected.Reason);
 
-            // act
-            var events = Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CancelOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.OrderNotInBook, rejected.Reason);
-        }
-
-        [Test]
-        public void ForeignClientOrderId_Rejected()
-        {
-            // arrange - client 2 cannot cancel client 1's order by quoting client 1's clientOrderId,
-            // since the (companyId, clientOrderId) lookup is scoped per client
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // act
-            var events = Book.CancelOrder(CompanyId2, OrderId4, OrderId1);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CancelOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(CompanyId2, rejected.CompanyId);
-            Assert.AreEqual(OrderRejectedReason.OrderNotInBook, rejected.Reason);
-
-            // the order itself is untouched and still cancellable by its actual owner
-            var ownerEvents = Book.CancelOrder(CompanyId1, OrderId5, OrderId1);
-            Assert.IsInstanceOf<CancelOrderConfirmed>(ownerEvents[0]);
-        }
+        // the order itself is untouched and still cancellable by its actual owner
+        var ownerEvents = Book.CancelOrder(CompanyId1, OrderId5, OrderId1);
+        Assert.IsInstanceOf<CancelOrderConfirmed>(ownerEvents[0]);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
@@ -1,131 +1,128 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// Circuit breakers stop trading rather than capping it, and are configured in levels. What
+// matters beyond the halt itself is that a price through several levels is served by the one it
+// actually reached rather than by whichever it passed first.
+[TestFixture]
+public class InMemoryOrderBookCircuitBreakerTests
 {
-    // Circuit breakers stop trading rather than capping it, and are configured in levels. What
-    // matters beyond the halt itself is that a price through several levels is served by the one it
-    // actually reached rather than by whichever it passed first.
-    [TestFixture]
-    public class InMemoryOrderBookCircuitBreakerTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly TimeSpan HaltFor = TimeSpan.FromMinutes(15);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+
+    private TestTimeProvider TimeProvider;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly TimeSpan HaltFor = TimeSpan.FromMinutes(15);
+        TimeProvider = new TestTimeProvider(Now1);
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
+    // CME's equity index levels: halt at 7 and 13 percent, end the trading day at 20. On a
+    // reference of 1000 with a tick size of 10 that is 7, 13 and 20 ticks either side.
+    private IOrderBook LeveledBook()
+    {
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor),
+                new CircuitBreaker(new PriceLimitWidth.Percent(13), HaltFor),
+                new CircuitBreaker(new PriceLimitWidth.Percent(20))
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 1000);
+        return book;
+    }
 
-        private TestTimeProvider TimeProvider;
+    private static void Trade(IOrderBook book, string n, decimal price)
+    {
+        book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
+        book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-        }
+    [Test]
+    public void FirstLevelBreached_HaltsForItsDuration()
+    {
+        // arrange
+        var book = LeveledBook();
 
-        // CME's equity index levels: halt at 7 and 13 percent, end the trading day at 20. On a
-        // reference of 1000 with a tick size of 10 that is 7, 13 and 20 ticks either side.
-        private IOrderBook LeveledBook()
-        {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor),
-                    new CircuitBreaker(new PriceLimitWidth.Percent(13), HaltFor),
-                    new CircuitBreaker(new PriceLimitWidth.Percent(20))
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 1000);
-            return book;
-        }
+        // act - 1080 is 8 percent away, through the first level and no further
+        Trade(book, "1", 1080);
 
-        private static void Trade(IOrderBook book, string n, decimal price)
-        {
-            book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
-            book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
-        }
+        // assert
+        Assert.AreEqual(OrderBookStatus.Halted, book.Status);
 
-        [Test]
-        public void FirstLevelBreached_HaltsForItsDuration()
-        {
-            // arrange
-            var book = LeveledBook();
+        // the orders that tripped it are pulled, so resuming has nothing left to re-trip on
+        book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
+        book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
 
-            // act - 1080 is 8 percent away, through the first level and no further
-            Trade(book, "1", 1080);
+        TimeProvider.SetCurrentTime(Now1 + HaltFor);
+        var events = book.AdvanceTime();
 
-            // assert
-            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
+            events.OfType<StatusChanged>().Single().Reason);
+    }
 
-            // the orders that tripped it are pulled, so resuming has nothing left to re-trip on
-            book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
-            book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
+    [Test]
+    public void PriceThroughEveryLevel_ServedByTheWidestOneItReached()
+    {
+        // arrange
+        var book = LeveledBook();
 
-            TimeProvider.SetCurrentTime(Now1 + HaltFor);
-            var events = book.AdvanceTime();
+        // act - 1250 is 25 percent away, through all three levels
+        Trade(book, "1", 1250);
+        Assert.AreEqual(OrderBookStatus.Halted, book.Status);
 
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-            Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
-                events.OfType<StatusChanged>().Single().Reason);
-        }
+        // act - the two narrower levels would each have ended by now
+        book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
+        book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
+        TimeProvider.SetCurrentTime(Now1 + HaltFor + HaltFor);
+        var events = book.AdvanceTime();
 
-        [Test]
-        public void PriceThroughEveryLevel_ServedByTheWidestOneItReached()
-        {
-            // arrange
-            var book = LeveledBook();
+        // assert - still halted, because the level it actually reached never resumes on its own
+        Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+        Assert.AreEqual(0, events.Count);
+    }
 
-            // act - 1250 is 25 percent away, through all three levels
-            Trade(book, "1", 1250);
-            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+    [Test]
+    public void HaltOutranksAPauseBreachedAtTheSamePrice()
+    {
+        // arrange - a volatility band far narrower than the breaker, so any price tripping the
+        // breaker trips the band too. The severer consequence has to win.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new VolatilityBand(2, PauseFor: TimeSpan.FromMinutes(2)),
+                new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor)
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 1000);
 
-            // act - the two narrower levels would each have ended by now
-            book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
-            book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
-            TimeProvider.SetCurrentTime(Now1 + HaltFor + HaltFor);
-            var events = book.AdvanceTime();
+        // act
+        Trade(book, "1", 1080);
 
-            // assert - still halted, because the level it actually reached never resumes on its own
-            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
-            Assert.AreEqual(0, events.Count);
-        }
+        // assert
+        Assert.AreEqual(OrderBookStatus.Halted, book.Status, "halting outranks pausing");
+    }
 
-        [Test]
-        public void HaltOutranksAPauseBreachedAtTheSamePrice()
-        {
-            // arrange - a volatility band far narrower than the breaker, so any price tripping the
-            // breaker trips the band too. The severer consequence has to win.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new VolatilityBand(2, PauseFor: TimeSpan.FromMinutes(2)),
-                    new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor)
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 1000);
+    [Test]
+    public void OrderEntryIsUnaffected_ABreakerGovernsTradesOnly()
+    {
+        // arrange
+        var book = LeveledBook();
 
-            // act
-            Trade(book, "1", 1080);
+        // act - far beyond every level, but resting an order there is not trading there
+        var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 5000);
 
-            // assert
-            Assert.AreEqual(OrderBookStatus.Halted, book.Status, "halting outranks pausing");
-        }
-
-        [Test]
-        public void OrderEntryIsUnaffected_ABreakerGovernsTradesOnly()
-        {
-            // arrange
-            var book = LeveledBook();
-
-            // act - far beyond every level, but resting an order there is not trading there
-            var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 5000);
-
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        }
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
@@ -1,2304 +1,2302 @@
-﻿using System;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookCreateOrderTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookCreateOrderTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
-
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
-
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
-
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
-
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
-
-        [TestCase(Side.Buy)]
-        [TestCase(Side.Sell)]
-        public void LimitOrder_Success(Side side)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(Sec, created.Security);
-            Assert.AreEqual(Now1, created.Time);
-            Assert.AreEqual(CompanyId1, created.CompanyId);
-            Assert.AreEqual(created.Order.ExchangeOrderId, created.ExchangeOrderId);
-            Assert.AreEqual(CompanyId1, created.Order.CompanyId);
-            Assert.AreEqual(OrderId1, created.Order.ClientOrderId);
-            Assert.AreEqual(Sec, created.Order.Security);
-            Assert.AreEqual(Now1, created.Order.CreatedTime);
-            Assert.AreEqual(Now1, created.Order.ModifiedTime);
-            Assert.IsNull(created.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, created.Order.Status);
-            Assert.AreEqual(OrderType.Limit, created.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
-            Assert.AreEqual(side, created.Order.Side);
-            Assert.AreEqual(100, created.Order.Price);
-            Assert.IsNull(created.Order.TriggerPrice);
-            Assert.AreEqual(3, created.Order.Quantity);
-            Assert.AreEqual(0, created.Order.FilledQuantity);
-            Assert.AreEqual(3, created.Order.RemainingQuantity);
-        }
-
-        [TestCase(Side.Buy, 700)]
-        [TestCase(Side.Sell, 300)]
-        public void MarketOrder_Success(Side side, decimal limitPrice)
-        {
-            // arrange
-            var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
-            var book = new InMemoryOrderBook(sec, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side == Side.Buy ? Side.Sell : Side.Buy, 3, 500);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.Day(), side, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(sec, created.Security);
-            Assert.AreEqual(Now2, created.Time);
-            Assert.AreEqual(CompanyId2, created.CompanyId);
-            Assert.AreEqual(CompanyId2, created.Order.CompanyId);
-            Assert.AreEqual(OrderId2, created.Order.ClientOrderId);
-            Assert.AreEqual(sec, created.Order.Security);
-            Assert.AreEqual(Now2, created.Order.CreatedTime);
-            Assert.AreEqual(Now2, created.Order.ModifiedTime);
-            Assert.IsNull(created.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, created.Order.Status);
-            Assert.AreEqual(OrderType.Market, created.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
-            Assert.AreEqual(side, created.Order.Side);
-            Assert.AreEqual(limitPrice, created.Order.Price);
-            Assert.IsNull(created.Order.TriggerPrice);
-            Assert.AreEqual(5, created.Order.Quantity);
-            Assert.AreEqual(0, created.Order.FilledQuantity);
-            Assert.AreEqual(5, created.Order.RemainingQuantity);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(sec, matched.Security);
-            Assert.AreEqual(Now2, matched.Time);
-            Assert.AreEqual(500, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(500, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(side == Side.Buy ? Side.Sell : Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(500, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(500, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Market, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(side, matched.Fills[1].Order.Side);
-            Assert.AreEqual(limitPrice, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [TestCase(Side.Buy, 520, 510)]
-        [TestCase(Side.Sell, 490, 490)]
-        public void StopLimitOrder_Success(Side side, decimal price, decimal triggerPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, price, triggerPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(Sec, created.Security);
-            Assert.AreEqual(Now2, created.Time);
-            Assert.AreEqual(CompanyId3, created.CompanyId);
-            Assert.AreEqual(CompanyId3, created.Order.CompanyId);
-            Assert.AreEqual(OrderId3, created.Order.ClientOrderId);
-            Assert.AreEqual(Sec, created.Order.Security);
-            Assert.AreEqual(Now2, created.Order.CreatedTime);
-            Assert.AreEqual(Now2, created.Order.ModifiedTime);
-            Assert.IsNull(created.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Hidden, created.Order.Status);
-            Assert.AreEqual(OrderType.StopLimit, created.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
-            Assert.AreEqual(side, created.Order.Side);
-            Assert.AreEqual(price, created.Order.Price);
-            Assert.AreEqual(triggerPrice, created.Order.TriggerPrice);
-            Assert.AreEqual(5, created.Order.Quantity);
-            Assert.AreEqual(0, created.Order.FilledQuantity);
-            Assert.AreEqual(5, created.Order.RemainingQuantity);
-        }
-        
-        [TestCase(Side.Buy, 510)]
-        [TestCase(Side.Sell, 490)]
-        public void StopMarketOrder_Success(Side side, decimal triggerPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, triggerPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(Sec, created.Security);
-            Assert.AreEqual(Now2, created.Time);
-            Assert.AreEqual(CompanyId3, created.CompanyId);
-            Assert.AreEqual(CompanyId3, created.Order.CompanyId);
-            Assert.AreEqual(OrderId3, created.Order.ClientOrderId);
-            Assert.AreEqual(Sec, created.Order.Security);
-            Assert.AreEqual(Now2, created.Order.CreatedTime);
-            Assert.AreEqual(Now2, created.Order.ModifiedTime);
-            Assert.IsNull(created.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Hidden, created.Order.Status);
-            Assert.AreEqual(OrderType.StopMarket, created.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
-            Assert.AreEqual(side, created.Order.Side);
-            Assert.IsNull(created.Order.Price);
-            Assert.AreEqual(triggerPrice, created.Order.TriggerPrice);
-            Assert.AreEqual(5, created.Order.Quantity);
-            Assert.AreEqual(0, created.Order.FilledQuantity);
-            Assert.AreEqual(5, created.Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchAtSamePriceWithAggressorRemaining_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now2, matched.Time);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(100, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(100, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(100, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchAtDifferentPriceWithAggressorRemaining_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now2, matched.Time);
-            Assert.AreEqual(110, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchAtDifferentPriceWithRestingRemaining_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now2, matched.Time);
-            Assert.AreEqual(110, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchSellAgainstOrderByTime()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now3, matched.Time);
-            Assert.AreEqual(120, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(120, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(120, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(120, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchSellAgainstOrdersByPrice()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched1 = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched1);
-            Assert.AreEqual(Sec, matched1.Security);
-            Assert.AreEqual(Now3, matched1.Time);
-            Assert.AreEqual(120, matched1.Price);
-            Assert.AreEqual(5, matched1.Quantity);
-            Assert.IsNotNull(matched1.Fills);
-            Assert.AreEqual(2, matched1.Fills.Count);
-
-            Assert.AreEqual(Sec, matched1.Fills[0].Security);
-            Assert.AreEqual(Now3, matched1.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched1.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched1.Fills[0].ClientOrderId);
-            Assert.AreEqual(120, matched1.Fills[0].Price);
-            Assert.AreEqual(5, matched1.Fills[0].Quantity);
-            Assert.AreEqual(true, matched1.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched1.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched1.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched1.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched1.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
-            Assert.AreEqual(120, matched1.Fills[0].Order.Price);
-            Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched1.Fills[1].Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
-            Assert.AreEqual(120, matched1.Fills[1].Price);
-            Assert.AreEqual(5, matched1.Fills[1].Quantity);
-            Assert.AreEqual(false, matched1.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched1.Fills[1].Order.Price);
-            Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
-
-            var matched2 = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched2);
-            Assert.AreEqual(Sec, matched2.Security);
-            Assert.AreEqual(Now3, matched2.Time);
-            Assert.AreEqual(110, matched2.Price);
-            Assert.AreEqual(3, matched2.Quantity);
-            Assert.IsNotNull(matched2.Fills);
-            Assert.AreEqual(2, matched2.Fills.Count);
-
-            Assert.AreEqual(Sec, matched2.Fills[0].Security);
-            Assert.AreEqual(Now3, matched2.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched2.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched2.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[0].Price);
-            Assert.AreEqual(3, matched2.Fills[0].Quantity);
-            Assert.AreEqual(true, matched2.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched2.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched2.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched2.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched2.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched2.Fills[0].Order.Price);
-            Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched2.Fills[1].Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[1].Price);
-            Assert.AreEqual(3, matched2.Fills[1].Quantity);
-            Assert.AreEqual(false, matched2.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched2.Fills[1].Order.Price);
-            Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
-            Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchSellAgainstOrderAtSamePriceByTime()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now3, matched.Time);
-            Assert.AreEqual(110, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchSellAgainstOrdersAtSamePriceByTime()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched1 = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched1);
-            Assert.AreEqual(Sec, matched1.Security);
-            Assert.AreEqual(Now3, matched1.Time);
-            Assert.AreEqual(110, matched1.Price);
-            Assert.AreEqual(5, matched1.Quantity);
-            Assert.IsNotNull(matched1.Fills);
-            Assert.AreEqual(2, matched1.Fills.Count);
-
-            Assert.AreEqual(Sec, matched1.Fills[0].Security);
-            Assert.AreEqual(Now3, matched1.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched1.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched1.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched1.Fills[0].Price);
-            Assert.AreEqual(5, matched1.Fills[0].Quantity);
-            Assert.AreEqual(true, matched1.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched1.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched1.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched1.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched1.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched1.Fills[0].Order.Price);
-            Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched1.Fills[1].Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched1.Fills[1].Price);
-            Assert.AreEqual(5, matched1.Fills[1].Quantity);
-            Assert.AreEqual(false, matched1.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched1.Fills[1].Order.Price);
-            Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
-
-            var matched2 = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched2);
-            Assert.AreEqual(Sec, matched2.Security);
-            Assert.AreEqual(Now3, matched2.Time);
-            Assert.AreEqual(110, matched2.Price);
-            Assert.AreEqual(3, matched2.Quantity);
-            Assert.IsNotNull(matched2.Fills);
-            Assert.AreEqual(2, matched2.Fills.Count);
-
-            Assert.AreEqual(Sec, matched2.Fills[0].Security);
-            Assert.AreEqual(Now3, matched2.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched2.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched2.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[0].Price);
-            Assert.AreEqual(3, matched2.Fills[0].Quantity);
-            Assert.AreEqual(true, matched2.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched2.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched2.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched2.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched2.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched2.Fills[0].Order.Price);
-            Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched2.Fills[1].Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[1].Price);
-            Assert.AreEqual(3, matched2.Fills[1].Quantity);
-            Assert.AreEqual(false, matched2.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched2.Fills[1].Order.Price);
-            Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
-            Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchBuyAgainstOrderByTime()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now3, matched.Time);
-            Assert.AreEqual(80, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(80, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[0].Order.Side);
-            Assert.AreEqual(80, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(80, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchBuyAgainstOrdersByPrice()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched1 = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched1);
-            Assert.AreEqual(Sec, matched1.Security);
-            Assert.AreEqual(Now3, matched1.Time);
-            Assert.AreEqual(80, matched1.Price);
-            Assert.AreEqual(5, matched1.Quantity);
-            Assert.IsNotNull(matched1.Fills);
-            Assert.AreEqual(2, matched1.Fills.Count);
-
-            Assert.AreEqual(Sec, matched1.Fills[0].Security);
-            Assert.AreEqual(Now3, matched1.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched1.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched1.Fills[0].ClientOrderId);
-            Assert.AreEqual(80, matched1.Fills[0].Price);
-            Assert.AreEqual(5, matched1.Fills[0].Quantity);
-            Assert.AreEqual(true, matched1.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched1.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched1.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched1.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched1.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched1.Fills[0].Order.Side);
-            Assert.AreEqual(80, matched1.Fills[0].Order.Price);
-            Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched1.Fills[1].Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
-            Assert.AreEqual(80, matched1.Fills[1].Price);
-            Assert.AreEqual(5, matched1.Fills[1].Quantity);
-            Assert.AreEqual(false, matched1.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched1.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched1.Fills[1].Order.Price);
-            Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
-
-            var matched2 = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched2);
-            Assert.AreEqual(Sec, matched2.Security);
-            Assert.AreEqual(Now3, matched2.Time);
-            Assert.AreEqual(90, matched2.Price);
-            Assert.AreEqual(3, matched2.Quantity);
-            Assert.IsNotNull(matched2.Fills);
-            Assert.AreEqual(2, matched2.Fills.Count);
-
-            Assert.AreEqual(Sec, matched2.Fills[0].Security);
-            Assert.AreEqual(Now3, matched2.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched2.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched2.Fills[0].ClientOrderId);
-            Assert.AreEqual(90, matched2.Fills[0].Price);
-            Assert.AreEqual(3, matched2.Fills[0].Quantity);
-            Assert.AreEqual(true, matched2.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched2.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched2.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched2.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched2.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched2.Fills[0].Order.Side);
-            Assert.AreEqual(90, matched2.Fills[0].Order.Price);
-            Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched2.Fills[1].Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
-            Assert.AreEqual(90, matched2.Fills[1].Price);
-            Assert.AreEqual(3, matched2.Fills[1].Quantity);
-            Assert.AreEqual(false, matched2.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched2.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched2.Fills[1].Order.Price);
-            Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
-            Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchBuyAgainstOrderAtSamePriceByTime()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now3, matched.Time);
-            Assert.AreEqual(90, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(90, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[0].Order.Side);
-            Assert.AreEqual(90, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(90, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchBuyAgainstOrdersAtSamePriceByTime()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched1 = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched1);
-            Assert.AreEqual(Sec, matched1.Security);
-            Assert.AreEqual(Now3, matched1.Time);
-            Assert.AreEqual(90, matched1.Price);
-            Assert.AreEqual(5, matched1.Quantity);
-            Assert.IsNotNull(matched1.Fills);
-            Assert.AreEqual(2, matched1.Fills.Count);
-
-            Assert.AreEqual(Sec, matched1.Fills[0].Security);
-            Assert.AreEqual(Now3, matched1.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched1.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched1.Fills[0].ClientOrderId);
-            Assert.AreEqual(90, matched1.Fills[0].Price);
-            Assert.AreEqual(5, matched1.Fills[0].Quantity);
-            Assert.AreEqual(true, matched1.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched1.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched1.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched1.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched1.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched1.Fills[0].Order.Side);
-            Assert.AreEqual(90, matched1.Fills[0].Order.Price);
-            Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched1.Fills[1].Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
-            Assert.AreEqual(90, matched1.Fills[1].Price);
-            Assert.AreEqual(5, matched1.Fills[1].Quantity);
-            Assert.AreEqual(false, matched1.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched1.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched1.Fills[1].Order.Price);
-            Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
-
-            var matched2 = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched2);
-            Assert.AreEqual(Sec, matched2.Security);
-            Assert.AreEqual(Now3, matched2.Time);
-            Assert.AreEqual(90, matched2.Price);
-            Assert.AreEqual(3, matched2.Quantity);
-            Assert.IsNotNull(matched2.Fills);
-            Assert.AreEqual(2, matched2.Fills.Count);
-
-            Assert.AreEqual(Sec, matched2.Fills[0].Security);
-            Assert.AreEqual(Now3, matched2.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched2.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched2.Fills[0].ClientOrderId);
-            Assert.AreEqual(90, matched2.Fills[0].Price);
-            Assert.AreEqual(3, matched2.Fills[0].Quantity);
-            Assert.AreEqual(true, matched2.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched2.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched2.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched2.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched2.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched2.Fills[0].Order.Side);
-            Assert.AreEqual(90, matched2.Fills[0].Order.Price);
-            Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched2.Fills[1].Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
-            Assert.AreEqual(90, matched2.Fills[1].Price);
-            Assert.AreEqual(3, matched2.Fills[1].Quantity);
-            Assert.AreEqual(false, matched2.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched2.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched2.Fills[1].Order.Price);
-            Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
-            Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchAgainstOrderAtSamePriceByTimeAfterIncreaseQuantity()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now3);
-            Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 7);
-            TimeProvider.SetCurrentTime(Now4);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now4, matched.Time);
-            Assert.AreEqual(110, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now4, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now4, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchAgainstOrdersAtSamePriceByTimeAfterIncreaseQuantity()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now3);
-            Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6);
-            TimeProvider.SetCurrentTime(Now4);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched1 = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched1);
-            Assert.AreEqual(Sec, matched1.Security);
-            Assert.AreEqual(Now4, matched1.Time);
-            Assert.AreEqual(110, matched1.Price);
-            Assert.AreEqual(5, matched1.Quantity);
-            Assert.IsNotNull(matched1.Fills);
-            Assert.AreEqual(2, matched1.Fills.Count);
-
-            Assert.AreEqual(Sec, matched1.Fills[0].Security);
-            Assert.AreEqual(Now4, matched1.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched1.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched1.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched1.Fills[0].Price);
-            Assert.AreEqual(5, matched1.Fills[0].Quantity);
-            Assert.AreEqual(true, matched1.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched1.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched1.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched1.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched1.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now4, matched1.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched1.Fills[0].Order.Price);
-            Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched1.Fills[1].Security);
-            Assert.AreEqual(Now4, matched1.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched1.Fills[1].Price);
-            Assert.AreEqual(5, matched1.Fills[1].Quantity);
-            Assert.AreEqual(false, matched1.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
-            Assert.AreEqual(Now4, matched1.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now4, matched1.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched1.Fills[1].Order.Price);
-            Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
-            Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
-
-            var matched2 = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched2);
-            Assert.AreEqual(Sec, matched2.Security);
-            Assert.AreEqual(Now4, matched2.Time);
-            Assert.AreEqual(110, matched2.Price);
-            Assert.AreEqual(3, matched2.Quantity);
-            Assert.IsNotNull(matched2.Fills);
-            Assert.AreEqual(2, matched2.Fills.Count);
-
-            Assert.AreEqual(Sec, matched2.Fills[0].Security);
-            Assert.AreEqual(Now4, matched2.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched2.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId4, matched2.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[0].Price);
-            Assert.AreEqual(3, matched2.Fills[0].Quantity);
-            Assert.AreEqual(true, matched2.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched2.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId4, matched2.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched2.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched2.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched2.Fills[0].Order.Price);
-            Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(6, matched2.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(3, matched2.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched2.Fills[1].Security);
-            Assert.AreEqual(Now4, matched2.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[1].Price);
-            Assert.AreEqual(3, matched2.Fills[1].Quantity);
-            Assert.AreEqual(false, matched2.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
-            Assert.AreEqual(Now4, matched2.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now4, matched2.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now4, matched2.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched2.Fills[1].Order.Price);
-            Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
-            Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchAgainstOrderAtSamePriceByTimeAfterDecreaseQuantity()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now3);
-            Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
-            TimeProvider.SetCurrentTime(Now4);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now4, matched.Time);
-            Assert.AreEqual(110, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now4, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId4, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now4, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId4, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId4, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(4, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(1, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now4, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchAgainstOrdersAtSamePriceByTimeAfterDecreaseQuantity()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-            TimeProvider.SetCurrentTime(Now3);
-            Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
-            TimeProvider.SetCurrentTime(Now4);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched1 = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched1);
-            Assert.AreEqual(Sec, matched1.Security);
-            Assert.AreEqual(Now4, matched1.Time);
-            Assert.AreEqual(110, matched1.Price);
-            Assert.AreEqual(4, matched1.Quantity);
-            Assert.IsNotNull(matched1.Fills);
-            Assert.AreEqual(2, matched1.Fills.Count);
-
-            Assert.AreEqual(Sec, matched1.Fills[0].Security);
-            Assert.AreEqual(Now4, matched1.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched1.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId4, matched1.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched1.Fills[0].Price);
-            Assert.AreEqual(4, matched1.Fills[0].Quantity);
-            Assert.AreEqual(true, matched1.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched1.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId4, matched1.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched1.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched1.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now4, matched1.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched1.Fills[0].Order.Price);
-            Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(4, matched1.Fills[0].Order.Quantity);
-            Assert.AreEqual(4, matched1.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched1.Fills[1].Security);
-            Assert.AreEqual(Now4, matched1.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched1.Fills[1].Price);
-            Assert.AreEqual(4, matched1.Fills[1].Quantity);
-            Assert.AreEqual(false, matched1.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
-            Assert.AreEqual(Now4, matched1.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now4, matched1.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched1.Fills[1].Order.Price);
-            Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
-            Assert.AreEqual(4, matched1.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(4, matched1.Fills[1].Order.RemainingQuantity);
-
-            var matched2 = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched2);
-            Assert.AreEqual(Sec, matched2.Security);
-            Assert.AreEqual(Now4, matched2.Time);
-            Assert.AreEqual(110, matched2.Price);
-            Assert.AreEqual(4, matched2.Quantity);
-            Assert.IsNotNull(matched2.Fills);
-            Assert.AreEqual(2, matched2.Fills.Count);
-
-            Assert.AreEqual(Sec, matched2.Fills[0].Security);
-            Assert.AreEqual(Now4, matched2.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched2.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched2.Fills[0].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[0].Price);
-            Assert.AreEqual(4, matched2.Fills[0].Quantity);
-            Assert.AreEqual(true, matched2.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched2.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched2.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched2.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched2.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
-            Assert.AreEqual(110, matched2.Fills[0].Order.Price);
-            Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
-            Assert.AreEqual(4, matched2.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(1, matched2.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched2.Fills[1].Security);
-            Assert.AreEqual(Now4, matched2.Fills[1].Time);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
-            Assert.AreEqual(110, matched2.Fills[1].Price);
-            Assert.AreEqual(4, matched2.Fills[1].Quantity);
-            Assert.AreEqual(false, matched2.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
-            Assert.AreEqual(Now4, matched2.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now4, matched2.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now4, matched2.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched2.Fills[1].Order.Price);
-            Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
-            Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_MatchGoodTilCanceledAfterReopen()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.UpdateStatus(OrderBookStatus.Closed);
-            TimeProvider.SetCurrentTime(Now3);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            TimeProvider.SetCurrentTime(Now4);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 8, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now4, matched.Time);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now4, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(100, matched.Fills[0].Price);
-            Assert.AreEqual(5, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now4, matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.GoodTilCanceled(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(100, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(5, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now4, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(100, matched.Fills[1].Price);
-            Assert.AreEqual(5, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now4, matched.Fills[1].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(8, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(5, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void MarketClosed_Rejected()
-        {
-            // arrange
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(OrderRejectedReason.MarketClosed, rejected.Reason);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.IsNull(rejected.ExchangeOrderId, "no order was ever created, so there's no ExchangeOrderId to report");
-        }
-
-        [Test]
-        public void MarketOrder_MarketOrdersNotAccepted_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-
-            // act
-            var events = Book.CreateMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.MarketOrdersNotAccepted, rejected.Reason);
-        }
-
-        [TestCase(0)]
-        [TestCase(-1)]
-        public void InvalidQuantity_Rejected(int quantity)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, quantity, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(OrderRejectedReason.InvalidQuantity, rejected.Reason);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-        }
-
-        [TestCase(8)]
-        [TestCase(-8)]
-        [TestCase(-108)]
-        [TestCase(10.01)]
-        public void InvalidPriceIncrement_Rejected(decimal price)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, price);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-        }
-
-        [TestCase(-10)]
-        [TestCase(-100)]
-        public void NegativePriceOnTick_Success(decimal price)
-        {
-            // arrange - negative prices are legitimate (e.g. calendar spreads, or the 2020 WTI
-            // crude event) and must still be accepted as long as they're on a valid tick
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, price);
-
-            // assert
-            Assert.IsNotNull(events);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(price, created.Order.Price);
-        }
-
-        [TestCase(8)]
-        [TestCase(-8)]
-        [TestCase(-108)]
-        [TestCase(10.01)]
-        public void InvalidTriggerPriceIncrement_Rejected(decimal triggerPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, triggerPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-        }
-        
-        [Test]
-        public void StopOrder_TriggerPriceMustBeLessThanPrice_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 90, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId3, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanPrice, rejected.Reason);
-        }
-
-        [Test]
-        public void StopOrder_TriggerPriceMustBeGreaterThanPrice_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 110, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId3, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, rejected.Reason);
-        }
-        
-        [Test]
-        public void StopOrder_NoLastTradedPrice_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.NoLastTradedPrice, rejected.Reason);
-        }
-
-        [TestCase(90)]
-        [TestCase(100)]
-        public void StopOrder_TriggerPriceMustBeGreaterThanLastTraded_Rejected(int price)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-
-            // act
-            var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, price);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId3, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, rejected.Reason);
-        }
-
-        [TestCase(110)]
-        [TestCase(100)]
-        public void StopOrder_TriggerPriceMustBeLessThanLastTraded_Rejected(int price)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-
-            // act
-            var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, price);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId3, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, rejected.Reason);
-        }
-        
-        [Test]
-        public void MarketOrder_EmptyBook_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.NoOrdersToMatchMarketOrder, rejected.Reason);
-        }
-        
-        [Test]
-        public void DuplicateOrderId_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.OrderInBook, rejected.Reason);
-        }
-
-        [Test]
-        public void OrderIdReusedAfterCancel_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CancelOrder(CompanyId1, OrderId5, OrderId1);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.OrderIdAlreadyUsed, rejected.Reason);
-        }
-
-        [Test]
-        public void OrderIdReusedAfterFullFill_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3, 100); // fully fills OrderId1
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.OrderIdAlreadyUsed, rejected.Reason);
-        }
-
-        [Test]
-        public void ClientOrderId_ReusedBySameClient_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.OrderInBook, rejected.Reason);
-        }
-
-        [Test]
-        public void ClientOrderId_SameValueDifferentClient_Success()
-        {
-            // arrange - the same client-supplied id is only required to be unique per client,
-            // not book-wide, since uniqueness is scoped by the (CompanyId, ClientOrderId) pair
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // act - same side/price as CompanyId1's order, so it rests instead of matching
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(CompanyId2, created.Order.CompanyId);
-            Assert.AreEqual(OrderId1, created.Order.ClientOrderId);
-        }
-
-        [Test]
-        public void GoodTilDateOrder_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(7);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, created.Order.OrderValidity);
-        }
-
-        [Test]
-        public void GoodTilDateOrder_SameDayAsToday_Success()
-        {
-            // arrange - a good-til-date order dated today is valid and behaves like a Day order for this session
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var goodTilDate = DateOnly.FromDateTime(Now1);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, created.Order.OrderValidity);
-        }
-
-        [Test]
-        public void GoodTilDateOrder_DateInPast_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(-1);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.InvalidExpireDate, rejected.Reason);
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        public void ClientOrderId_Missing_Rejected(string clientOrderId)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderRejectedReason.ClientOrderIdRequired, rejected.Reason);
-        }
-
-        [TestCase(20)]
-        public void ClientOrderId_AtMaxLength_Success(int length)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var clientOrderId = new string('a', length);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(clientOrderId, created.Order.ClientOrderId);
-        }
-
-        [TestCase(21)]
-        [TestCase(36)]
-        public void ClientOrderId_TooLong_Rejected(int length)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var clientOrderId = new string('a', length);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderRejectedReason.ClientOrderIdTooLong, rejected.Reason);
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        public void CompanyId_Missing_Rejected(string companyId)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.CompanyIdRequired, rejected.Reason);
-        }
-
-        [TestCase(20)]
-        public void CompanyId_AtMaxLength_Success(int length)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var companyId = new string('a', length);
-
-            // act
-            var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(companyId, created.Order.CompanyId);
-        }
-
-        [TestCase(21)]
-        [TestCase(36)]
-        public void CompanyId_TooLong_Rejected(int length)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var companyId = new string('a', length);
-
-            // act
-            var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderId1, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.CompanyIdTooLong, rejected.Reason);
-        }
-
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
     }
+
+    [TestCase(Side.Buy)]
+    [TestCase(Side.Sell)]
+    public void LimitOrder_Success(Side side)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(Sec, created.Security);
+        Assert.AreEqual(Now1, created.Time);
+        Assert.AreEqual(CompanyId1, created.CompanyId);
+        Assert.AreEqual(created.Order.ExchangeOrderId, created.ExchangeOrderId);
+        Assert.AreEqual(CompanyId1, created.Order.CompanyId);
+        Assert.AreEqual(OrderId1, created.Order.ClientOrderId);
+        Assert.AreEqual(Sec, created.Order.Security);
+        Assert.AreEqual(Now1, created.Order.CreatedTime);
+        Assert.AreEqual(Now1, created.Order.ModifiedTime);
+        Assert.IsNull(created.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, created.Order.Status);
+        Assert.AreEqual(OrderType.Limit, created.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
+        Assert.AreEqual(side, created.Order.Side);
+        Assert.AreEqual(100, created.Order.Price);
+        Assert.IsNull(created.Order.TriggerPrice);
+        Assert.AreEqual(3, created.Order.Quantity);
+        Assert.AreEqual(0, created.Order.FilledQuantity);
+        Assert.AreEqual(3, created.Order.RemainingQuantity);
+    }
+
+    [TestCase(Side.Buy, 700)]
+    [TestCase(Side.Sell, 300)]
+    public void MarketOrder_Success(Side side, decimal limitPrice)
+    {
+        // arrange
+        var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
+        var book = new InMemoryOrderBook(sec, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side == Side.Buy ? Side.Sell : Side.Buy, 3, 500);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.Day(), side, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(sec, created.Security);
+        Assert.AreEqual(Now2, created.Time);
+        Assert.AreEqual(CompanyId2, created.CompanyId);
+        Assert.AreEqual(CompanyId2, created.Order.CompanyId);
+        Assert.AreEqual(OrderId2, created.Order.ClientOrderId);
+        Assert.AreEqual(sec, created.Order.Security);
+        Assert.AreEqual(Now2, created.Order.CreatedTime);
+        Assert.AreEqual(Now2, created.Order.ModifiedTime);
+        Assert.IsNull(created.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, created.Order.Status);
+        Assert.AreEqual(OrderType.Market, created.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
+        Assert.AreEqual(side, created.Order.Side);
+        Assert.AreEqual(limitPrice, created.Order.Price);
+        Assert.IsNull(created.Order.TriggerPrice);
+        Assert.AreEqual(5, created.Order.Quantity);
+        Assert.AreEqual(0, created.Order.FilledQuantity);
+        Assert.AreEqual(5, created.Order.RemainingQuantity);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(sec, matched.Security);
+        Assert.AreEqual(Now2, matched.Time);
+        Assert.AreEqual(500, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(500, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(side == Side.Buy ? Side.Sell : Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(500, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(500, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Market, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(side, matched.Fills[1].Order.Side);
+        Assert.AreEqual(limitPrice, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [TestCase(Side.Buy, 520, 510)]
+    [TestCase(Side.Sell, 490, 490)]
+    public void StopLimitOrder_Success(Side side, decimal price, decimal triggerPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, price, triggerPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(Sec, created.Security);
+        Assert.AreEqual(Now2, created.Time);
+        Assert.AreEqual(CompanyId3, created.CompanyId);
+        Assert.AreEqual(CompanyId3, created.Order.CompanyId);
+        Assert.AreEqual(OrderId3, created.Order.ClientOrderId);
+        Assert.AreEqual(Sec, created.Order.Security);
+        Assert.AreEqual(Now2, created.Order.CreatedTime);
+        Assert.AreEqual(Now2, created.Order.ModifiedTime);
+        Assert.IsNull(created.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Hidden, created.Order.Status);
+        Assert.AreEqual(OrderType.StopLimit, created.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
+        Assert.AreEqual(side, created.Order.Side);
+        Assert.AreEqual(price, created.Order.Price);
+        Assert.AreEqual(triggerPrice, created.Order.TriggerPrice);
+        Assert.AreEqual(5, created.Order.Quantity);
+        Assert.AreEqual(0, created.Order.FilledQuantity);
+        Assert.AreEqual(5, created.Order.RemainingQuantity);
+    }
+
+    [TestCase(Side.Buy, 510)]
+    [TestCase(Side.Sell, 490)]
+    public void StopMarketOrder_Success(Side side, decimal triggerPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, triggerPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(Sec, created.Security);
+        Assert.AreEqual(Now2, created.Time);
+        Assert.AreEqual(CompanyId3, created.CompanyId);
+        Assert.AreEqual(CompanyId3, created.Order.CompanyId);
+        Assert.AreEqual(OrderId3, created.Order.ClientOrderId);
+        Assert.AreEqual(Sec, created.Order.Security);
+        Assert.AreEqual(Now2, created.Order.CreatedTime);
+        Assert.AreEqual(Now2, created.Order.ModifiedTime);
+        Assert.IsNull(created.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Hidden, created.Order.Status);
+        Assert.AreEqual(OrderType.StopMarket, created.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), created.Order.OrderValidity);
+        Assert.AreEqual(side, created.Order.Side);
+        Assert.IsNull(created.Order.Price);
+        Assert.AreEqual(triggerPrice, created.Order.TriggerPrice);
+        Assert.AreEqual(5, created.Order.Quantity);
+        Assert.AreEqual(0, created.Order.FilledQuantity);
+        Assert.AreEqual(5, created.Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchAtSamePriceWithAggressorRemaining_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now2, matched.Time);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(100, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(100, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(100, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchAtDifferentPriceWithAggressorRemaining_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now2, matched.Time);
+        Assert.AreEqual(110, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchAtDifferentPriceWithRestingRemaining_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now2, matched.Time);
+        Assert.AreEqual(110, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchSellAgainstOrderByTime()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now3, matched.Time);
+        Assert.AreEqual(120, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(120, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(120, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(120, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchSellAgainstOrdersByPrice()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched1 = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched1);
+        Assert.AreEqual(Sec, matched1.Security);
+        Assert.AreEqual(Now3, matched1.Time);
+        Assert.AreEqual(120, matched1.Price);
+        Assert.AreEqual(5, matched1.Quantity);
+        Assert.IsNotNull(matched1.Fills);
+        Assert.AreEqual(2, matched1.Fills.Count);
+
+        Assert.AreEqual(Sec, matched1.Fills[0].Security);
+        Assert.AreEqual(Now3, matched1.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched1.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched1.Fills[0].ClientOrderId);
+        Assert.AreEqual(120, matched1.Fills[0].Price);
+        Assert.AreEqual(5, matched1.Fills[0].Quantity);
+        Assert.AreEqual(true, matched1.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched1.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched1.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched1.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched1.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
+        Assert.AreEqual(120, matched1.Fills[0].Order.Price);
+        Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched1.Fills[1].Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
+        Assert.AreEqual(120, matched1.Fills[1].Price);
+        Assert.AreEqual(5, matched1.Fills[1].Quantity);
+        Assert.AreEqual(false, matched1.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched1.Fills[1].Order.Price);
+        Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
+
+        var matched2 = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched2);
+        Assert.AreEqual(Sec, matched2.Security);
+        Assert.AreEqual(Now3, matched2.Time);
+        Assert.AreEqual(110, matched2.Price);
+        Assert.AreEqual(3, matched2.Quantity);
+        Assert.IsNotNull(matched2.Fills);
+        Assert.AreEqual(2, matched2.Fills.Count);
+
+        Assert.AreEqual(Sec, matched2.Fills[0].Security);
+        Assert.AreEqual(Now3, matched2.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched2.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched2.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[0].Price);
+        Assert.AreEqual(3, matched2.Fills[0].Quantity);
+        Assert.AreEqual(true, matched2.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched2.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched2.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched2.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched2.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched2.Fills[0].Order.Price);
+        Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched2.Fills[1].Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[1].Price);
+        Assert.AreEqual(3, matched2.Fills[1].Quantity);
+        Assert.AreEqual(false, matched2.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched2.Fills[1].Order.Price);
+        Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
+        Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchSellAgainstOrderAtSamePriceByTime()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now3, matched.Time);
+        Assert.AreEqual(110, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchSellAgainstOrdersAtSamePriceByTime()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched1 = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched1);
+        Assert.AreEqual(Sec, matched1.Security);
+        Assert.AreEqual(Now3, matched1.Time);
+        Assert.AreEqual(110, matched1.Price);
+        Assert.AreEqual(5, matched1.Quantity);
+        Assert.IsNotNull(matched1.Fills);
+        Assert.AreEqual(2, matched1.Fills.Count);
+
+        Assert.AreEqual(Sec, matched1.Fills[0].Security);
+        Assert.AreEqual(Now3, matched1.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched1.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched1.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched1.Fills[0].Price);
+        Assert.AreEqual(5, matched1.Fills[0].Quantity);
+        Assert.AreEqual(true, matched1.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched1.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched1.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched1.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched1.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched1.Fills[0].Order.Price);
+        Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched1.Fills[1].Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched1.Fills[1].Price);
+        Assert.AreEqual(5, matched1.Fills[1].Quantity);
+        Assert.AreEqual(false, matched1.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched1.Fills[1].Order.Price);
+        Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
+
+        var matched2 = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched2);
+        Assert.AreEqual(Sec, matched2.Security);
+        Assert.AreEqual(Now3, matched2.Time);
+        Assert.AreEqual(110, matched2.Price);
+        Assert.AreEqual(3, matched2.Quantity);
+        Assert.IsNotNull(matched2.Fills);
+        Assert.AreEqual(2, matched2.Fills.Count);
+
+        Assert.AreEqual(Sec, matched2.Fills[0].Security);
+        Assert.AreEqual(Now3, matched2.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched2.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched2.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[0].Price);
+        Assert.AreEqual(3, matched2.Fills[0].Quantity);
+        Assert.AreEqual(true, matched2.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched2.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched2.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched2.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched2.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched2.Fills[0].Order.Price);
+        Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched2.Fills[1].Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[1].Price);
+        Assert.AreEqual(3, matched2.Fills[1].Quantity);
+        Assert.AreEqual(false, matched2.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched2.Fills[1].Order.Price);
+        Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
+        Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchBuyAgainstOrderByTime()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now3, matched.Time);
+        Assert.AreEqual(80, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(80, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[0].Order.Side);
+        Assert.AreEqual(80, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(80, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchBuyAgainstOrdersByPrice()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched1 = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched1);
+        Assert.AreEqual(Sec, matched1.Security);
+        Assert.AreEqual(Now3, matched1.Time);
+        Assert.AreEqual(80, matched1.Price);
+        Assert.AreEqual(5, matched1.Quantity);
+        Assert.IsNotNull(matched1.Fills);
+        Assert.AreEqual(2, matched1.Fills.Count);
+
+        Assert.AreEqual(Sec, matched1.Fills[0].Security);
+        Assert.AreEqual(Now3, matched1.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched1.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched1.Fills[0].ClientOrderId);
+        Assert.AreEqual(80, matched1.Fills[0].Price);
+        Assert.AreEqual(5, matched1.Fills[0].Quantity);
+        Assert.AreEqual(true, matched1.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched1.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched1.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched1.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched1.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched1.Fills[0].Order.Side);
+        Assert.AreEqual(80, matched1.Fills[0].Order.Price);
+        Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched1.Fills[1].Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
+        Assert.AreEqual(80, matched1.Fills[1].Price);
+        Assert.AreEqual(5, matched1.Fills[1].Quantity);
+        Assert.AreEqual(false, matched1.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched1.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched1.Fills[1].Order.Price);
+        Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
+
+        var matched2 = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched2);
+        Assert.AreEqual(Sec, matched2.Security);
+        Assert.AreEqual(Now3, matched2.Time);
+        Assert.AreEqual(90, matched2.Price);
+        Assert.AreEqual(3, matched2.Quantity);
+        Assert.IsNotNull(matched2.Fills);
+        Assert.AreEqual(2, matched2.Fills.Count);
+
+        Assert.AreEqual(Sec, matched2.Fills[0].Security);
+        Assert.AreEqual(Now3, matched2.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched2.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched2.Fills[0].ClientOrderId);
+        Assert.AreEqual(90, matched2.Fills[0].Price);
+        Assert.AreEqual(3, matched2.Fills[0].Quantity);
+        Assert.AreEqual(true, matched2.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched2.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched2.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched2.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched2.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched2.Fills[0].Order.Side);
+        Assert.AreEqual(90, matched2.Fills[0].Order.Price);
+        Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched2.Fills[1].Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
+        Assert.AreEqual(90, matched2.Fills[1].Price);
+        Assert.AreEqual(3, matched2.Fills[1].Quantity);
+        Assert.AreEqual(false, matched2.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched2.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched2.Fills[1].Order.Price);
+        Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
+        Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchBuyAgainstOrderAtSamePriceByTime()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now3, matched.Time);
+        Assert.AreEqual(90, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(90, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[0].Order.Side);
+        Assert.AreEqual(90, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(90, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchBuyAgainstOrdersAtSamePriceByTime()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched1 = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched1);
+        Assert.AreEqual(Sec, matched1.Security);
+        Assert.AreEqual(Now3, matched1.Time);
+        Assert.AreEqual(90, matched1.Price);
+        Assert.AreEqual(5, matched1.Quantity);
+        Assert.IsNotNull(matched1.Fills);
+        Assert.AreEqual(2, matched1.Fills.Count);
+
+        Assert.AreEqual(Sec, matched1.Fills[0].Security);
+        Assert.AreEqual(Now3, matched1.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched1.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched1.Fills[0].ClientOrderId);
+        Assert.AreEqual(90, matched1.Fills[0].Price);
+        Assert.AreEqual(5, matched1.Fills[0].Quantity);
+        Assert.AreEqual(true, matched1.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched1.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched1.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched1.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched1.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched1.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched1.Fills[0].Order.Side);
+        Assert.AreEqual(90, matched1.Fills[0].Order.Price);
+        Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched1.Fills[1].Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
+        Assert.AreEqual(90, matched1.Fills[1].Price);
+        Assert.AreEqual(5, matched1.Fills[1].Quantity);
+        Assert.AreEqual(false, matched1.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched1.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched1.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched1.Fills[1].Order.Price);
+        Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
+
+        var matched2 = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched2);
+        Assert.AreEqual(Sec, matched2.Security);
+        Assert.AreEqual(Now3, matched2.Time);
+        Assert.AreEqual(90, matched2.Price);
+        Assert.AreEqual(3, matched2.Quantity);
+        Assert.IsNotNull(matched2.Fills);
+        Assert.AreEqual(2, matched2.Fills.Count);
+
+        Assert.AreEqual(Sec, matched2.Fills[0].Security);
+        Assert.AreEqual(Now3, matched2.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched2.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched2.Fills[0].ClientOrderId);
+        Assert.AreEqual(90, matched2.Fills[0].Price);
+        Assert.AreEqual(3, matched2.Fills[0].Quantity);
+        Assert.AreEqual(true, matched2.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched2.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched2.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched2.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched2.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched2.Fills[0].Order.Side);
+        Assert.AreEqual(90, matched2.Fills[0].Order.Price);
+        Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched2.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched2.Fills[1].Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
+        Assert.AreEqual(90, matched2.Fills[1].Price);
+        Assert.AreEqual(3, matched2.Fills[1].Quantity);
+        Assert.AreEqual(false, matched2.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched2.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched2.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched2.Fills[1].Order.Price);
+        Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
+        Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchAgainstOrderAtSamePriceByTimeAfterIncreaseQuantity()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now3);
+        Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 7);
+        TimeProvider.SetCurrentTime(Now4);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now4, matched.Time);
+        Assert.AreEqual(110, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now4, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now4, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchAgainstOrdersAtSamePriceByTimeAfterIncreaseQuantity()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now3);
+        Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6);
+        TimeProvider.SetCurrentTime(Now4);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched1 = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched1);
+        Assert.AreEqual(Sec, matched1.Security);
+        Assert.AreEqual(Now4, matched1.Time);
+        Assert.AreEqual(110, matched1.Price);
+        Assert.AreEqual(5, matched1.Quantity);
+        Assert.IsNotNull(matched1.Fills);
+        Assert.AreEqual(2, matched1.Fills.Count);
+
+        Assert.AreEqual(Sec, matched1.Fills[0].Security);
+        Assert.AreEqual(Now4, matched1.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched1.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched1.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched1.Fills[0].Price);
+        Assert.AreEqual(5, matched1.Fills[0].Quantity);
+        Assert.AreEqual(true, matched1.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched1.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched1.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched1.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched1.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now4, matched1.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched1.Fills[0].Order.Price);
+        Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched1.Fills[0].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched1.Fills[1].Security);
+        Assert.AreEqual(Now4, matched1.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched1.Fills[1].Price);
+        Assert.AreEqual(5, matched1.Fills[1].Quantity);
+        Assert.AreEqual(false, matched1.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
+        Assert.AreEqual(Now4, matched1.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now4, matched1.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched1.Fills[1].Order.Price);
+        Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
+        Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
+
+        var matched2 = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched2);
+        Assert.AreEqual(Sec, matched2.Security);
+        Assert.AreEqual(Now4, matched2.Time);
+        Assert.AreEqual(110, matched2.Price);
+        Assert.AreEqual(3, matched2.Quantity);
+        Assert.IsNotNull(matched2.Fills);
+        Assert.AreEqual(2, matched2.Fills.Count);
+
+        Assert.AreEqual(Sec, matched2.Fills[0].Security);
+        Assert.AreEqual(Now4, matched2.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched2.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId4, matched2.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[0].Price);
+        Assert.AreEqual(3, matched2.Fills[0].Quantity);
+        Assert.AreEqual(true, matched2.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched2.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId4, matched2.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched2.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched2.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched2.Fills[0].Order.Price);
+        Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(6, matched2.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched2.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(3, matched2.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched2.Fills[1].Security);
+        Assert.AreEqual(Now4, matched2.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[1].Price);
+        Assert.AreEqual(3, matched2.Fills[1].Quantity);
+        Assert.AreEqual(false, matched2.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
+        Assert.AreEqual(Now4, matched2.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now4, matched2.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now4, matched2.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched2.Fills[1].Order.Price);
+        Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
+        Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchAgainstOrderAtSamePriceByTimeAfterDecreaseQuantity()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now3);
+        Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
+        TimeProvider.SetCurrentTime(Now4);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now4, matched.Time);
+        Assert.AreEqual(110, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now4, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId4, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now4, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId4, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId4, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(4, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(1, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now4, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchAgainstOrdersAtSamePriceByTimeAfterDecreaseQuantity()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
+        TimeProvider.SetCurrentTime(Now3);
+        Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
+        TimeProvider.SetCurrentTime(Now4);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched1 = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched1);
+        Assert.AreEqual(Sec, matched1.Security);
+        Assert.AreEqual(Now4, matched1.Time);
+        Assert.AreEqual(110, matched1.Price);
+        Assert.AreEqual(4, matched1.Quantity);
+        Assert.IsNotNull(matched1.Fills);
+        Assert.AreEqual(2, matched1.Fills.Count);
+
+        Assert.AreEqual(Sec, matched1.Fills[0].Security);
+        Assert.AreEqual(Now4, matched1.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched1.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId4, matched1.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched1.Fills[0].Price);
+        Assert.AreEqual(4, matched1.Fills[0].Quantity);
+        Assert.AreEqual(true, matched1.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched1.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId4, matched1.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched1.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched1.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now4, matched1.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched1.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched1.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched1.Fills[0].Order.Price);
+        Assert.IsNull(matched1.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(4, matched1.Fills[0].Order.Quantity);
+        Assert.AreEqual(4, matched1.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched1.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched1.Fills[1].Security);
+        Assert.AreEqual(Now4, matched1.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched1.Fills[1].Price);
+        Assert.AreEqual(4, matched1.Fills[1].Quantity);
+        Assert.AreEqual(false, matched1.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched1.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched1.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched1.Fills[1].Order.Security);
+        Assert.AreEqual(Now4, matched1.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now4, matched1.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched1.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched1.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched1.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched1.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched1.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched1.Fills[1].Order.Price);
+        Assert.IsNull(matched1.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched1.Fills[1].Order.Quantity);
+        Assert.AreEqual(4, matched1.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(4, matched1.Fills[1].Order.RemainingQuantity);
+
+        var matched2 = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched2);
+        Assert.AreEqual(Sec, matched2.Security);
+        Assert.AreEqual(Now4, matched2.Time);
+        Assert.AreEqual(110, matched2.Price);
+        Assert.AreEqual(4, matched2.Quantity);
+        Assert.IsNotNull(matched2.Fills);
+        Assert.AreEqual(2, matched2.Fills.Count);
+
+        Assert.AreEqual(Sec, matched2.Fills[0].Security);
+        Assert.AreEqual(Now4, matched2.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched2.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched2.Fills[0].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[0].Price);
+        Assert.AreEqual(4, matched2.Fills[0].Quantity);
+        Assert.AreEqual(true, matched2.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched2.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched2.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched2.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched2.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched2.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched2.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched2.Fills[0].Order.Side);
+        Assert.AreEqual(110, matched2.Fills[0].Order.Price);
+        Assert.IsNull(matched2.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched2.Fills[0].Order.Quantity);
+        Assert.AreEqual(4, matched2.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(1, matched2.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched2.Fills[1].Security);
+        Assert.AreEqual(Now4, matched2.Fills[1].Time);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
+        Assert.AreEqual(110, matched2.Fills[1].Price);
+        Assert.AreEqual(4, matched2.Fills[1].Quantity);
+        Assert.AreEqual(false, matched2.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId3, matched2.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched2.Fills[1].Order.Security);
+        Assert.AreEqual(Now4, matched2.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now4, matched2.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now4, matched2.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched2.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched2.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched2.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched2.Fills[1].Order.Price);
+        Assert.IsNull(matched2.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched2.Fills[1].Order.Quantity);
+        Assert.AreEqual(8, matched2.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_MatchGoodTilCanceledAfterReopen()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.UpdateStatus(OrderBookStatus.Closed);
+        TimeProvider.SetCurrentTime(Now3);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        TimeProvider.SetCurrentTime(Now4);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 8, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now4, matched.Time);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now4, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(100, matched.Fills[0].Price);
+        Assert.AreEqual(5, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now4, matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.GoodTilCanceled(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(100, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(5, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now4, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(100, matched.Fills[1].Price);
+        Assert.AreEqual(5, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now4, matched.Fills[1].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(8, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(5, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void MarketClosed_Rejected()
+    {
+        // arrange
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(OrderRejectedReason.MarketClosed, rejected.Reason);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.IsNull(rejected.ExchangeOrderId, "no order was ever created, so there's no ExchangeOrderId to report");
+    }
+
+    [Test]
+    public void MarketOrder_MarketOrdersNotAccepted_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+
+        // act
+        var events = Book.CreateMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.MarketOrdersNotAccepted, rejected.Reason);
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void InvalidQuantity_Rejected(int quantity)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, quantity, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(OrderRejectedReason.InvalidQuantity, rejected.Reason);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+    }
+
+    [TestCase(8)]
+    [TestCase(-8)]
+    [TestCase(-108)]
+    [TestCase(10.01)]
+    public void InvalidPriceIncrement_Rejected(decimal price)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, price);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+    }
+
+    [TestCase(-10)]
+    [TestCase(-100)]
+    public void NegativePriceOnTick_Success(decimal price)
+    {
+        // arrange - negative prices are legitimate (e.g. calendar spreads, or the 2020 WTI
+        // crude event) and must still be accepted as long as they're on a valid tick
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, price);
+
+        // assert
+        Assert.IsNotNull(events);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(price, created.Order.Price);
+    }
+
+    [TestCase(8)]
+    [TestCase(-8)]
+    [TestCase(-108)]
+    [TestCase(10.01)]
+    public void InvalidTriggerPriceIncrement_Rejected(decimal triggerPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, triggerPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+    }
+
+    [Test]
+    public void StopOrder_TriggerPriceMustBeLessThanPrice_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 90, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId3, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanPrice, rejected.Reason);
+    }
+
+    [Test]
+    public void StopOrder_TriggerPriceMustBeGreaterThanPrice_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 110, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId3, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, rejected.Reason);
+    }
+
+    [Test]
+    public void StopOrder_NoLastTradedPrice_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.NoLastTradedPrice, rejected.Reason);
+    }
+
+    [TestCase(90)]
+    [TestCase(100)]
+    public void StopOrder_TriggerPriceMustBeGreaterThanLastTraded_Rejected(int price)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        // act
+        var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, price);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId3, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, rejected.Reason);
+    }
+
+    [TestCase(110)]
+    [TestCase(100)]
+    public void StopOrder_TriggerPriceMustBeLessThanLastTraded_Rejected(int price)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        // act
+        var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, price);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId3, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, rejected.Reason);
+    }
+
+    [Test]
+    public void MarketOrder_EmptyBook_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.NoOrdersToMatchMarketOrder, rejected.Reason);
+    }
+
+    [Test]
+    public void DuplicateOrderId_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.OrderInBook, rejected.Reason);
+    }
+
+    [Test]
+    public void OrderIdReusedAfterCancel_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CancelOrder(CompanyId1, OrderId5, OrderId1);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.OrderIdAlreadyUsed, rejected.Reason);
+    }
+
+    [Test]
+    public void OrderIdReusedAfterFullFill_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3, 100); // fully fills OrderId1
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.OrderIdAlreadyUsed, rejected.Reason);
+    }
+
+    [Test]
+    public void ClientOrderId_ReusedBySameClient_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.OrderInBook, rejected.Reason);
+    }
+
+    [Test]
+    public void ClientOrderId_SameValueDifferentClient_Success()
+    {
+        // arrange - the same client-supplied id is only required to be unique per client,
+        // not book-wide, since uniqueness is scoped by the (CompanyId, ClientOrderId) pair
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // act - same side/price as CompanyId1's order, so it rests instead of matching
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(CompanyId2, created.Order.CompanyId);
+        Assert.AreEqual(OrderId1, created.Order.ClientOrderId);
+    }
+
+    [Test]
+    public void GoodTilDateOrder_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(7);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, created.Order.OrderValidity);
+    }
+
+    [Test]
+    public void GoodTilDateOrder_SameDayAsToday_Success()
+    {
+        // arrange - a good-til-date order dated today is valid and behaves like a Day order for this session
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var goodTilDate = DateOnly.FromDateTime(Now1);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, created.Order.OrderValidity);
+    }
+
+    [Test]
+    public void GoodTilDateOrder_DateInPast_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(-1);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.InvalidExpireDate, rejected.Reason);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void ClientOrderId_Missing_Rejected(string clientOrderId)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderRejectedReason.ClientOrderIdRequired, rejected.Reason);
+    }
+
+    [TestCase(20)]
+    public void ClientOrderId_AtMaxLength_Success(int length)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var clientOrderId = new string('a', length);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(clientOrderId, created.Order.ClientOrderId);
+    }
+
+    [TestCase(21)]
+    [TestCase(36)]
+    public void ClientOrderId_TooLong_Rejected(int length)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var clientOrderId = new string('a', length);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, clientOrderId, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderRejectedReason.ClientOrderIdTooLong, rejected.Reason);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void CompanyId_Missing_Rejected(string companyId)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.CompanyIdRequired, rejected.Reason);
+    }
+
+    [TestCase(20)]
+    public void CompanyId_AtMaxLength_Success(int length)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var companyId = new string('a', length);
+
+        // act
+        var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(companyId, created.Order.CompanyId);
+    }
+
+    [TestCase(21)]
+    [TestCase(36)]
+    public void CompanyId_TooLong_Rejected(int length)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var companyId = new string('a', length);
+
+        // act
+        var events = Book.CreateLimitOrder(companyId, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderId1, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.CompanyIdTooLong, rejected.Reason);
+    }
+
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
@@ -1,186 +1,183 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// A daily limit is the one restriction that neither rejects nor interrupts. The market stays
+// open, keeps quoting, trades at the limit and can trade back inside - so almost every
+// assertion here is that the book is still Open while refusing to go further.
+[TestFixture]
+public class InMemoryOrderBookDailyLimitTests
 {
-    // A daily limit is the one restriction that neither rejects nor interrupts. The market stays
-    // open, keeps quoting, trades at the limit and can trade back inside - so almost every
-    // assertion here is that the book is still Open while refusing to go further.
-    [TestFixture]
-    public class InMemoryOrderBookDailyLimitTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+
+    private TestTimeProvider TimeProvider;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        TimeProvider = new TestTimeProvider(Now1);
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
+    // 5 ticks on a tick size of 10, referenced at 100, so the limits are 50 and 150.
+    private IOrderBook LimitedBook()
+    {
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        return book;
+    }
 
-        private TestTimeProvider TimeProvider;
+    [Test]
+    public void OrderBeyondTheLimit_RejectedOnEntry()
+    {
+        // arrange
+        var book = LimitedBook();
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-        }
+        // act
+        var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 160);
 
-        // 5 ticks on a tick size of 10, referenced at 100, so the limits are 50 and 150.
-        private IOrderBook LimitedBook()
-        {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            return book;
-        }
+        // assert - its own reason, not the band's: a band moves with the market and would very
+        // likely take this price shortly, a daily limit stands for the session
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.BeyondDailyPriceLimit, rejected.Reason);
+    }
 
-        [Test]
-        public void OrderBeyondTheLimit_RejectedOnEntry()
-        {
-            // arrange
-            var book = LimitedBook();
+    [Test]
+    public void TradingAtTheLimitIsAllowed()
+    {
+        // arrange
+        var book = LimitedBook();
 
-            // act
-            var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 160);
+        // act - exactly on the limit
+        book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Sell, 5, 150);
+        var events = book.CreateLimitOrder(CompanyId2, "Order2", new OrderValidity.Day(), Side.Buy, 5, 150);
 
-            // assert - its own reason, not the band's: a band moves with the market and would very
-            // likely take this price shortly, a daily limit stands for the session
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.BeyondDailyPriceLimit, rejected.Reason);
-        }
+        // assert
+        var matched = events.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(150, matched.Price);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        Assert.AreEqual(0, events.OfType<LimitStateChanged>().Count(), "trading at the limit is not being stuck");
+    }
 
-        [Test]
-        public void TradingAtTheLimitIsAllowed()
-        {
-            // arrange
-            var book = LimitedBook();
+    // Because entry and trades face the same limit, an order beyond it cannot simply be sent -
+    // which is the point. Getting one to rest out there means resting it while the limit was
+    // wider and then moving the reference so the limit narrows under it. That leaves a book
+    // whose own resting order is beyond the ceiling, which is exactly the state a sweep has to
+    // refuse: it traded at 200, holds a buy at 240, and is now referenced at 100.
+    private IOrderBook BookWithRestingOrderAboveTheLimit()
+    {
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
 
-            // act - exactly on the limit
-            book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Sell, 5, 150);
-            var events = book.CreateLimitOrder(CompanyId2, "Order2", new OrderValidity.Day(), Side.Buy, 5, 150);
+        book.UpdateStatus(OrderBookStatus.Open, 200);
+        book.CreateLimitOrder(CompanyId1, "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
+        book.CreateLimitOrder(CompanyId2, "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
+        book.CreateLimitOrder(CompanyId2, "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
 
-            // assert
-            var matched = events.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(150, matched.Price);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-            Assert.AreEqual(0, events.OfType<LimitStateChanged>().Count(), "trading at the limit is not being stuck");
-        }
+        // The clock has to move on before whatever the test does next. Matcher.Run picks the
+        // resting side with a strict ModifiedTime comparison, so orders sharing a timestamp
+        // hand it to the sell - and price-time prints at the resting order's price. Left at one
+        // instant, an incoming sell would price the trade at its own limit rather than at the
+        // buy resting above the ceiling, and there would be nothing out of range to refuse.
+        TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        return book;
+    }
 
-        // Because entry and trades face the same limit, an order beyond it cannot simply be sent -
-        // which is the point. Getting one to rest out there means resting it while the limit was
-        // wider and then moving the reference so the limit narrows under it. That leaves a book
-        // whose own resting order is beyond the ceiling, which is exactly the state a sweep has to
-        // refuse: it traded at 200, holds a buy at 240, and is now referenced at 100.
-        private IOrderBook BookWithRestingOrderAboveTheLimit()
-        {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
+    [Test]
+    public void TradeThroughTheLimit_BlockedWithoutHaltingOrPausing()
+    {
+        // arrange
+        var book = BookWithRestingOrderAboveTheLimit();
 
-            book.UpdateStatus(OrderBookStatus.Open, 200);
-            book.CreateLimitOrder(CompanyId1, "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
-            book.CreateLimitOrder(CompanyId2, "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
-            book.CreateLimitOrder(CompanyId2, "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
+        // act - a sell at 150 is inside the limit and perfectly enterable, but it crosses the
+        // resting buy at 240, and that is where the trade would print
+        var events = book.CreateLimitOrder(CompanyId1, "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150);
 
-            // The clock has to move on before whatever the test does next. Matcher.Run picks the
-            // resting side with a strict ModifiedTime comparison, so orders sharing a timestamp
-            // hand it to the sell - and price-time prints at the resting order's price. Left at one
-            // instant, an incoming sell would price the trade at its own limit rather than at the
-            // buy resting above the ceiling, and there would be nothing out of range to refuse.
-            TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            return book;
-        }
+        // assert - nothing printed, and the market is neither paused nor halted
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.AreEqual(0, events.OfType<OrdersMatched>().Count());
+        Assert.AreEqual(OrderBookStatus.Open, book.Status, "a limit is not a halt");
 
-        [Test]
-        public void TradeThroughTheLimit_BlockedWithoutHaltingOrPausing()
-        {
-            // arrange
-            var book = BookWithRestingOrderAboveTheLimit();
+        // ...and it says which way it is stuck: the blocked price is above the last trade, so
+        // buyers are the ones who cannot get through
+        var limited = events.OfType<LimitStateChanged>().Single();
+        Assert.AreEqual(Side.Buy, limited.Side);
+        Assert.AreEqual(240, limited.Price);
+    }
 
-            // act - a sell at 150 is inside the limit and perfectly enterable, but it crosses the
-            // resting buy at 240, and that is where the trade would print
-            var events = book.CreateLimitOrder(CompanyId1, "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150);
+    [Test]
+    public void LimitState_PublishedOnceAndReleasedByATrade()
+    {
+        // arrange - already limit locked
+        var book = BookWithRestingOrderAboveTheLimit();
+        book.CreateLimitOrder(CompanyId1, "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150);
 
-            // assert - nothing printed, and the market is neither paused nor halted
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.AreEqual(0, events.OfType<OrdersMatched>().Count());
-            Assert.AreEqual(OrderBookStatus.Open, book.Status, "a limit is not a halt");
+        // act - another sweep against the same wall says nothing new
+        var again = book.CreateLimitOrder(CompanyId1, "Sell3", new OrderValidity.Day(), Side.Sell, 5, 140);
+        Assert.AreEqual(0, again.OfType<LimitStateChanged>().Count(), "already said, and still true");
 
-            // ...and it says which way it is stuck: the blocked price is above the last trade, so
-            // buyers are the ones who cannot get through
-            var limited = events.OfType<LimitStateChanged>().Single();
-            Assert.AreEqual(Side.Buy, limited.Side);
-            Assert.AreEqual(240, limited.Price);
-        }
+        // act - the order out beyond the ceiling is pulled, and the book trades inside the limit
+        book.CancelOrder(CompanyId2, "Cancel1", "Buy2");
+        var traded = book.CreateLimitOrder(CompanyId2, "Buy3", new OrderValidity.Day(), Side.Buy, 5, 140);
 
-        [Test]
-        public void LimitState_PublishedOnceAndReleasedByATrade()
-        {
-            // arrange - already limit locked
-            var book = BookWithRestingOrderAboveTheLimit();
-            book.CreateLimitOrder(CompanyId1, "Sell2", new OrderValidity.Day(), Side.Sell, 5, 150);
+        // assert - trading again, and said so
+        Assert.AreEqual(1, traded.OfType<OrdersMatched>().Count());
+        var released = traded.OfType<LimitStateChanged>().Single();
+        Assert.IsNull(released.Side);
+        Assert.IsNull(released.Price);
+    }
 
-            // act - another sweep against the same wall says nothing new
-            var again = book.CreateLimitOrder(CompanyId1, "Sell3", new OrderValidity.Day(), Side.Sell, 5, 140);
-            Assert.AreEqual(0, again.OfType<LimitStateChanged>().Count(), "already said, and still true");
+    [Test]
+    public void PercentageWidth_ResolvesAgainstTheReference()
+    {
+        // arrange - 7 percent of a reference of 1000, so 70 either side
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new DailyPriceLimit(new PriceLimitWidth.Percent(7))
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 1000);
 
-            // act - the order out beyond the ceiling is pulled, and the book trades inside the limit
-            book.CancelOrder(CompanyId2, "Cancel1", "Buy2");
-            var traded = book.CreateLimitOrder(CompanyId2, "Buy3", new OrderValidity.Day(), Side.Buy, 5, 140);
+        // act + assert - 1070 is exactly on the ceiling
+        var atEdge = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 1070);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(atEdge[0]);
 
-            // assert - trading again, and said so
-            Assert.AreEqual(1, traded.OfType<OrdersMatched>().Count());
-            var released = traded.OfType<LimitStateChanged>().Single();
-            Assert.IsNull(released.Side);
-            Assert.IsNull(released.Price);
-        }
+        var beyond = book.CreateLimitOrder(CompanyId1, "Order2", new OrderValidity.Day(), Side.Buy, 5, 1080);
+        Assert.AreEqual(OrderRejectedReason.BeyondDailyPriceLimit, (beyond[0] as CreateOrderRejected)?.Reason);
+    }
 
-        [Test]
-        public void PercentageWidth_ResolvesAgainstTheReference()
-        {
-            // arrange - 7 percent of a reference of 1000, so 70 either side
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new DailyPriceLimit(new PriceLimitWidth.Percent(7))
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 1000);
+    [Test]
+    public void NoReferenceYet_LimitInactive()
+    {
+        // arrange - a percentage of nothing is not a width
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new DailyPriceLimit(new PriceLimitWidth.Percent(7))
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
 
-            // act + assert - 1070 is exactly on the ceiling
-            var atEdge = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 1070);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(atEdge[0]);
+        // act
+        var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 1_000_000);
 
-            var beyond = book.CreateLimitOrder(CompanyId1, "Order2", new OrderValidity.Day(), Side.Buy, 5, 1080);
-            Assert.AreEqual(OrderRejectedReason.BeyondDailyPriceLimit, (beyond[0] as CreateOrderRejected)?.Reason);
-        }
-
-        [Test]
-        public void NoReferenceYet_LimitInactive()
-        {
-            // arrange - a percentage of nothing is not a width
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new DailyPriceLimit(new PriceLimitWidth.Percent(7))
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = book.CreateLimitOrder(CompanyId1, "Order1", new OrderValidity.Day(), Side.Buy, 5, 1_000_000);
-
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        }
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
@@ -1,271 +1,268 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookIcebergTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookIcebergTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId1B = "Order1b";
+
+    private static TestTimeProvider TimeProvider;
+    private static LevelTrackingOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(6)]
+    public void MaxVisibleQuantity_OutsideValidRange_Rejected(int maxVisibleQuantity)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100,
+            maxVisibleQuantity: maxVisibleQuantity);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId1B = "Order1b";
+        // assert
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.MaxVisibleQuantityOutOfRange, rejected.Reason);
+    }
 
-        private static TestTimeProvider TimeProvider;
-        private static LevelTrackingOrderBook Book;
+    [Test]
+    public void Levels_ReportDisplayedPeak_NotTrueRemainingSize()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
-        }
+        // act - total 20, only 5 displayed at a time
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
+            maxVisibleQuantity: 5);
 
-        [TestCase(0)]
-        [TestCase(-1)]
-        [TestCase(6)]
-        public void MaxVisibleQuantity_OutsideValidRange_Rejected(int maxVisibleQuantity)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
+        // assert
+        var levels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, levels.Count);
+        Assert.AreEqual(5, levels[0].Quantity);
+        Assert.AreEqual(1, levels[0].Count);
+    }
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100,
-                maxVisibleQuantity: maxVisibleQuantity);
+    [Test]
+    public void Replenishment_LosesPriority_BystanderMatchedBeforeReplenishedPeak()
+    {
+        // arrange - iceberg (peak 5, total 12) rests first, a plain order arrives right
+        // behind it at the same price
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
+            maxVisibleQuantity: 5);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-            // assert
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.MaxVisibleQuantityOutOfRange, rejected.Reason);
-        }
+        // act - an aggressor larger than the peak
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
 
-        [Test]
-        public void Levels_ReportDisplayedPeak_NotTrueRemainingSize()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
+        // assert - first fill consumes the iceberg's full peak (5); it still has 7 left, so it
+        // replenishes (to a full peak of 5 again) and is requeued behind Company2 - visible in
+        // the feed as its own UpdateOrderConfirmed, with a fresh ExchangeOrderId marking the
+        // lost priority
+        Assert.AreEqual(4, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-            // act - total 20, only 5 displayed at a time
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
-                maxVisibleQuantity: 5);
+        var firstMatch = events[1] as OrdersMatched;
+        Assert.IsNotNull(firstMatch);
+        Assert.AreEqual(5, firstMatch.Quantity);
+        Assert.AreEqual(OrderId1, firstMatch.Fills[0].ClientOrderId);
+        Assert.AreEqual(OrderStatus.Working, firstMatch.Fills[0].Order.Status);
+        Assert.AreEqual(7, firstMatch.Fills[0].Order.RemainingQuantity);
+        Assert.AreEqual(0, firstMatch.Fills[0].Order.DisplayedQuantity); // not yet replenished
 
-            // assert
-            var levels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, levels.Count);
-            Assert.AreEqual(5, levels[0].Quantity);
-            Assert.AreEqual(1, levels[0].Count);
-        }
+        var replenish = events[2] as UpdateOrderConfirmed;
+        Assert.IsNotNull(replenish);
+        Assert.AreEqual(OrderId1, replenish.Order.ClientOrderId);
+        Assert.AreEqual(5, replenish.Order.DisplayedQuantity); // replenished back to full peak
+        Assert.AreNotEqual(replenish.PreviousExchangeOrderId, replenish.Order.ExchangeOrderId);
 
-        [Test]
-        public void Replenishment_LosesPriority_BystanderMatchedBeforeReplenishedPeak()
-        {
-            // arrange - iceberg (peak 5, total 12) rests first, a plain order arrives right
-            // behind it at the same price
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
-                maxVisibleQuantity: 5);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            TimeProvider.SetCurrentTime(Now3);
+        // third event: the aggressor's remaining 3 units match Company2 - not the iceberg's
+        // freshly-replenished peak - proving the iceberg lost its queue position
+        var secondMatch = events[3] as OrdersMatched;
+        Assert.IsNotNull(secondMatch);
+        Assert.AreEqual(3, secondMatch.Quantity);
+        Assert.AreEqual(OrderId2, secondMatch.Fills[0].ClientOrderId);
+        Assert.AreEqual(OrderStatus.Filled, secondMatch.Fills[1].Order.Status); // aggressor done
 
-            // act - an aggressor larger than the peak
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
+        // book afterward: iceberg untouched-since (7 remaining, 5 displayed), Company2 down to 2
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(2, sellLevels[0].Count);
+        Assert.AreEqual(7, sellLevels[0].Quantity); // 5 (iceberg's displayed) + 2 (Company2 left)
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
 
-            // assert - first fill consumes the iceberg's full peak (5); it still has 7 left, so it
-            // replenishes (to a full peak of 5 again) and is requeued behind Company2 - visible in
-            // the feed as its own UpdateOrderConfirmed, with a fresh ExchangeOrderId marking the
-            // lost priority
-            Assert.AreEqual(4, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+    [Test]
+    public void FinalReplenishment_NotMultipleOfPeak_ShowsOnlyWhatsLeft()
+    {
+        // arrange - total 12, peak 5: replenishment cycle is 5, 5, then a final 2
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
+            maxVisibleQuantity: 5);
+        TimeProvider.SetCurrentTime(Now2);
 
-            var firstMatch = events[1] as OrdersMatched;
-            Assert.IsNotNull(firstMatch);
-            Assert.AreEqual(5, firstMatch.Quantity);
-            Assert.AreEqual(OrderId1, firstMatch.Fills[0].ClientOrderId);
-            Assert.AreEqual(OrderStatus.Working, firstMatch.Fills[0].Order.Status);
-            Assert.AreEqual(7, firstMatch.Fills[0].Order.RemainingQuantity);
-            Assert.AreEqual(0, firstMatch.Fills[0].Order.DisplayedQuantity); // not yet replenished
+        // act - a single aggressor large enough to consume the whole iceberg
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 12, 100);
 
-            var replenish = events[2] as UpdateOrderConfirmed;
-            Assert.IsNotNull(replenish);
-            Assert.AreEqual(OrderId1, replenish.Order.ClientOrderId);
-            Assert.AreEqual(5, replenish.Order.DisplayedQuantity); // replenished back to full peak
-            Assert.AreNotEqual(replenish.PreviousExchangeOrderId, replenish.Order.ExchangeOrderId);
+        // assert - three separate prints as the peak replenishes: 5, 5, then the 2 left over,
+        // with a replenish event after each of the first two (not after the last - the
+        // iceberg is fully filled at that point, nothing left to replenish)
+        Assert.AreEqual(6, events.Count);
+        var matches = events.OfType<OrdersMatched>().ToList();
+        Assert.AreEqual(3, matches.Count);
+        Assert.AreEqual(5, matches[0].Quantity);
+        Assert.AreEqual(5, matches[1].Quantity);
+        Assert.AreEqual(2, matches[2].Quantity);
+        Assert.AreEqual(2, events.OfType<UpdateOrderConfirmed>().Count());
 
-            // third event: the aggressor's remaining 3 units match Company2 - not the iceberg's
-            // freshly-replenished peak - proving the iceberg lost its queue position
-            var secondMatch = events[3] as OrdersMatched;
-            Assert.IsNotNull(secondMatch);
-            Assert.AreEqual(3, secondMatch.Quantity);
-            Assert.AreEqual(OrderId2, secondMatch.Fills[0].ClientOrderId);
-            Assert.AreEqual(OrderStatus.Filled, secondMatch.Fills[1].Order.Status); // aggressor done
+        var lastFill = matches[2].Fills[0];
+        Assert.AreEqual(OrderId1, lastFill.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Filled, lastFill.Order.Status);
+        Assert.AreEqual(12, lastFill.Order.FilledQuantity);
 
-            // book afterward: iceberg untouched-since (7 remaining, 5 displayed), Company2 down to 2
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(2, sellLevels[0].Count);
-            Assert.AreEqual(7, sellLevels[0].Quantity); // 5 (iceberg's displayed) + 2 (Company2 left)
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
+        Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
 
-        [Test]
-        public void FinalReplenishment_NotMultipleOfPeak_ShowsOnlyWhatsLeft()
-        {
-            // arrange - total 12, peak 5: replenishment cycle is 5, 5, then a final 2
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
-                maxVisibleQuantity: 5);
-            TimeProvider.SetCurrentTime(Now2);
+    [Test]
+    public void HiddenReserve_CountsInFullForMinQuantity_EvenThoughNotDisplayed()
+    {
+        // arrange - only 3 displayed at a time out of a true total of 20
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
+            maxVisibleQuantity: 3);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // act - a single aggressor large enough to consume the whole iceberg
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 12, 100);
+        // act - requires the full 15 to fill immediately or nothing does; the published level
+        // only shows 3, but the true available liquidity (20) is what the gate actually checks
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = 15 }, Side.Buy, 15, 100);
 
-            // assert - three separate prints as the peak replenishes: 5, 5, then the 2 left over,
-            // with a replenish event after each of the first two (not after the last - the
-            // iceberg is fully filled at that point, nothing left to replenish)
-            Assert.AreEqual(6, events.Count);
-            var matches = events.OfType<OrdersMatched>().ToList();
-            Assert.AreEqual(3, matches.Count);
-            Assert.AreEqual(5, matches[0].Quantity);
-            Assert.AreEqual(5, matches[1].Quantity);
-            Assert.AreEqual(2, matches[2].Quantity);
-            Assert.AreEqual(2, events.OfType<UpdateOrderConfirmed>().Count());
+        // assert - accepted and fully filled, replenishing across several peaks (3 each) to do
+        // it - the resting iceberg still has 5 of its own true size left even after the
+        // aggressor's 15 is satisfied, so it replenishes one last time trailing the final
+        // match too; events[^1] can't be assumed to be the match itself here.
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        var lastMatch = events.OfType<OrdersMatched>().Last();
+        Assert.AreEqual(OrderStatus.Filled, lastMatch.Fills[1].Order.Status);
+        Assert.AreEqual(15, lastMatch.Fills[1].Order.FilledQuantity);
 
-            var lastFill = matches[2].Fills[0];
-            Assert.AreEqual(OrderId1, lastFill.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Filled, lastFill.Order.Status);
-            Assert.AreEqual(12, lastFill.Order.FilledQuantity);
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(3, sellLevels[0].Quantity); // 20 - 15 = 5 true remaining, displayed capped to peak 3
+    }
 
-            Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
+    [Test]
+    public void UpdateOrder_IcebergQuantityIncrease_DoesNotLosePriority()
+    {
+        // arrange - iceberg rests first, a plain order arrives behind it
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100,
+            maxVisibleQuantity: 3);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-        [Test]
-        public void HiddenReserve_CountsInFullForMinQuantity_EvenThoughNotDisplayed()
-        {
-            // arrange - only 3 displayed at a time out of a true total of 20
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
-                maxVisibleQuantity: 3);
-            TimeProvider.SetCurrentTime(Now2);
+        // act - grow the iceberg's total size (hidden reserve only, peak is immutable)
+        Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
+        TimeProvider.SetCurrentTime(Now4);
 
-            // act - requires the full 15 to fill immediately or nothing does; the published level
-            // only shows 3, but the true available liquidity (20) is what the gate actually checks
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = 15 }, Side.Buy, 15, 100);
+        // a sell should still match the iceberg first - no priority lost
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
-            // assert - accepted and fully filled, replenishing across several peaks (3 each) to do
-            // it - the resting iceberg still has 5 of its own true size left even after the
-            // aggressor's 15 is satisfied, so it replenishes one last time trailing the final
-            // match too; events[^1] can't be assumed to be the match itself here.
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            var lastMatch = events.OfType<OrdersMatched>().Last();
-            Assert.AreEqual(OrderStatus.Filled, lastMatch.Fills[1].Order.Status);
-            Assert.AreEqual(15, lastMatch.Fills[1].Order.FilledQuantity);
+        // assert
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(OrderId1B, matched.Fills[0].ClientOrderId);
+    }
 
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(3, sellLevels[0].Quantity); // 20 - 15 = 5 true remaining, displayed capped to peak 3
-        }
+    [Test]
+    public void UpdateOrder_PlainOrderQuantityIncrease_StillLosesPriority()
+    {
+        // regression - confirms the exception added for icebergs doesn't affect plain orders
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-        [Test]
-        public void UpdateOrder_IcebergQuantityIncrease_DoesNotLosePriority()
-        {
-            // arrange - iceberg rests first, a plain order arrives behind it
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100,
-                maxVisibleQuantity: 3);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now3);
+        // act
+        Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
+        TimeProvider.SetCurrentTime(Now4);
 
-            // act - grow the iceberg's total size (hidden reserve only, peak is immutable)
-            Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
-            TimeProvider.SetCurrentTime(Now4);
+        // a sell should now match Company2 first - Company1 lost priority by growing
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
-            // a sell should still match the iceberg first - no priority lost
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+        // assert
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+    }
 
-            // assert
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(OrderId1B, matched.Fills[0].ClientOrderId);
-        }
+    [Test]
+    public void AggressorIsIceberg_OwnDisplayedPortionCapsEachFill()
+    {
+        // arrange - a small resting sell that fully consumes the aggressor's first peak, and
+        // a larger one behind it for the aggressor to keep working through
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-        [Test]
-        public void UpdateOrder_PlainOrderQuantityIncrease_StillLosesPriority()
-        {
-            // regression - confirms the exception added for icebergs doesn't affect plain orders
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now3);
+        // act - the aggressor itself is an iceberg: total 10, peak 3
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 10, 100,
+            maxVisibleQuantity: 3);
 
-            // act
-            Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
-            TimeProvider.SetCurrentTime(Now4);
+        // assert - each fill is capped at the aggressor's own displayed peak (3), not its full
+        // remaining size, down to whatever's left at the end (3, 3, 3, then 1). The aggressor
+        // itself replenishes (and loses priority) after each of the first three fills, but not
+        // the last, since it's fully filled at that point.
+        Assert.AreEqual(8, events.Count);
+        var matches = events.OfType<OrdersMatched>().ToList();
+        Assert.AreEqual(4, matches.Count);
+        Assert.AreEqual(3, matches[0].Quantity);
+        Assert.AreEqual(3, matches[1].Quantity);
+        Assert.AreEqual(3, matches[2].Quantity);
+        Assert.AreEqual(1, matches[3].Quantity);
+        Assert.AreEqual(3, events.OfType<UpdateOrderConfirmed>().Count());
 
-            // a sell should now match Company2 first - Company1 lost priority by growing
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
+        var lastFill = matches[3].Fills[1];
+        Assert.AreEqual(OrderId3, lastFill.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Filled, lastFill.Order.Status);
+        Assert.AreEqual(10, lastFill.Order.FilledQuantity);
 
-            // assert
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
-        }
-
-        [Test]
-        public void AggressorIsIceberg_OwnDisplayedPortionCapsEachFill()
-        {
-            // arrange - a small resting sell that fully consumes the aggressor's first peak, and
-            // a larger one behind it for the aggressor to keep working through
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 100);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act - the aggressor itself is an iceberg: total 10, peak 3
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 10, 100,
-                maxVisibleQuantity: 3);
-
-            // assert - each fill is capped at the aggressor's own displayed peak (3), not its full
-            // remaining size, down to whatever's left at the end (3, 3, 3, then 1). The aggressor
-            // itself replenishes (and loses priority) after each of the first three fills, but not
-            // the last, since it's fully filled at that point.
-            Assert.AreEqual(8, events.Count);
-            var matches = events.OfType<OrdersMatched>().ToList();
-            Assert.AreEqual(4, matches.Count);
-            Assert.AreEqual(3, matches[0].Quantity);
-            Assert.AreEqual(3, matches[1].Quantity);
-            Assert.AreEqual(3, matches[2].Quantity);
-            Assert.AreEqual(1, matches[3].Quantity);
-            Assert.AreEqual(3, events.OfType<UpdateOrderConfirmed>().Count());
-
-            var lastFill = matches[3].Fills[1];
-            Assert.AreEqual(OrderId3, lastFill.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Filled, lastFill.Order.Status);
-            Assert.AreEqual(10, lastFill.Order.FilledQuantity);
-
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(13, sellLevels[0].Quantity); // Company2's 20 - 7 consumed
-        }
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(13, sellLevels[0].Quantity); // Company2's 20 - 7 consumed
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
@@ -1,490 +1,488 @@
-using System;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// ImmediateOrCancel unifies what were previously two separate validities: MinQuantity unset
+// behaves like classic IOC/FillAndKill (fills what's available, cancels the rest, no minimum
+// required); MinQuantity set to the order's own Quantity reproduces FillOrKill exactly (the
+// whole order fills or nothing does); MinQuantity anywhere in between requires at least that
+// much to fill immediately or nothing fills at all.
+[TestFixture]
+public class InMemoryOrderBookImmediateOrCancelTests
 {
-    // ImmediateOrCancel unifies what were previously two separate validities: MinQuantity unset
-    // behaves like classic IOC/FillAndKill (fills what's available, cancels the rest, no minimum
-    // required); MinQuantity set to the order's own Quantity reproduces FillOrKill exactly (the
-    // whole order fills or nothing does); MinQuantity anywhere in between requires at least that
-    // much to fill immediately or nothing fills at all.
-    [TestFixture]
-    public class InMemoryOrderBookImmediateOrCancelTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+    private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+    private static readonly string CompanyId4 = "Company4";
+    private static readonly string CompanyId5 = "Company5";
+    private static readonly string CompanyId6 = "Company6";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+    private static readonly string OrderId6 = "Order6";
+
+    private static TestTimeProvider TimeProvider;
+    private static LevelTrackingOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
-
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
-        private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
-
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-        private static readonly string CompanyId4 = "Company4";
-        private static readonly string CompanyId5 = "Company5";
-        private static readonly string CompanyId6 = "Company6";
-
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
-        private static readonly string OrderId6 = "Order6";
-
-        private static TestTimeProvider TimeProvider;
-        private static LevelTrackingOrderBook Book;
-
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
-        }
-
-        // ----- no MinQuantity (classic IOC/FillAndKill behavior) -----
-
-        [Test]
-        public void LimitOrder_FullFill_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 3, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-
-            Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.ImmediateOrCancel(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_PartialFill_RemainderCancelled()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(2, matched.Quantity);
-
-            var cancelled = events[2] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(Sec, cancelled.Security);
-            Assert.AreEqual(Now2, cancelled.Time);
-            Assert.AreEqual(CompanyId2, cancelled.CompanyId);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(new OrderValidity.ImmediateOrCancel(), cancelled.Order.OrderValidity);
-            Assert.AreEqual(5, cancelled.Order.Quantity);
-            Assert.AreEqual(2, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-
-            // book has nothing resting from either order
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-            Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
-        }
-
-        [Test]
-        public void LimitOrder_EmptyBook_ImmediatelyCancelled()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-
-            var cancelled = events[1] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(0, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
-
-        [Test]
-        public void MarketOrder_PartialFillWithinProtection_RemainderCancelled()
-        {
-            // arrange
-            var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
-            var book = new LevelTrackingOrderBook(sec, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            // NB: a Market + GTC/Day order in the same situation would instead rest the
-            // remainder as a limit order at the protected price (see MarketOrder_Success).
-            var events = book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(500, matched.Price);
-            Assert.AreEqual(2, matched.Quantity);
-
-            var cancelled = events[2] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(OrderType.Market, cancelled.Order.Type);
-            Assert.AreEqual(700, cancelled.Order.Price);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(2, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-
-            Assert.AreEqual(0, book.GetLevels(Side.Buy, 10).Count);
-        }
-
-        [Test]
-        public void StopLimitOrder_TriggersAndPartiallyFills_RemainderCancelled()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
-            TimeProvider.SetCurrentTime(Now2);
-
-            // IOC stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 530, 520);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // only 2 available to fill the stop once triggered
-            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
-            TimeProvider.SetCurrentTime(Now5);
-
-            // act - trade at 520 triggers the stop
-            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(5, events.Count);
-
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.IsInstanceOf<OrdersMatched>(events[1]);
-
-            var triggered = events[2] as UpdateOrderConfirmed;
-            Assert.IsNotNull(triggered);
-            Assert.AreEqual(OrderId3, triggered.Order.ClientOrderId);
-            Assert.AreEqual(OrderType.Limit, triggered.Order.Type);
-            Assert.AreEqual(530, triggered.Order.Price);
-
-            var stopMatch = events[3] as OrdersMatched;
-            Assert.IsNotNull(stopMatch);
-            Assert.AreEqual(530, stopMatch.Price);
-            Assert.AreEqual(2, stopMatch.Quantity);
-
-            var cancelled = events[4] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(new OrderValidity.ImmediateOrCancel(), cancelled.Order.OrderValidity);
-            Assert.AreEqual(2, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-            Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
-        }
-
-        // ----- MinQuantity == full order quantity (FillOrKill-equivalent behavior) -----
-
-        [Test]
-        public void MinQuantity_EqualsFullQuantity_SufficientLiquidityAtSingleLevel_FullyFilled()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(5, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void MinQuantity_EqualsFullQuantity_SufficientLiquidityAcrossMultipleLevels_FullyFilled()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 110);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act - only fills if the 3@100 and 2@110 levels are summed together
-            var events = Book.CreateLimitOrder(CompanyId3, OrderId3,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched1 = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched1);
-            Assert.AreEqual(100, matched1.Price);
-            Assert.AreEqual(3, matched1.Quantity);
-
-            var matched2 = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched2);
-            Assert.AreEqual(110, matched2.Price);
-            Assert.AreEqual(2, matched2.Quantity);
-            Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
-            Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
-            Assert.AreEqual(5, matched2.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void MinQuantity_EqualsFullQuantity_InsufficientLiquidity_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now2, rejected.Time);
-            Assert.AreEqual(CompanyId2, rejected.CompanyId);
-            Assert.AreEqual(OrderId2, rejected.ClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
-
-            // book is completely untouched - no partial fill leaked through
-            var levels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, levels.Count);
-            Assert.AreEqual(100, levels[0].Price);
-            Assert.AreEqual(2, levels[0].Quantity);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
-
-        [Test]
-        public void MinQuantity_EqualsFullQuantity_StopLimitOrder_TriggersWithInsufficientLiquidity_Cancelled()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
-            TimeProvider.SetCurrentTime(Now2);
-
-            // FOK-equivalent stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 },
-                Side.Buy, 5, 530, 520);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // only 2 available - not enough to fill the stop's 5 in full
-            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
-            TimeProvider.SetCurrentTime(Now5);
-
-            // act - trade at 520 triggers the stop
-            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.IsInstanceOf<OrdersMatched>(events[1]);
-
-            var cancelled = events[2] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(OrderType.StopLimit, cancelled.Order.Type);
-            Assert.AreEqual(new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, cancelled.Order.OrderValidity);
-            Assert.AreEqual(0, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-
-            // the 2@530 resting sell was never touched
-            var levels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, levels.Count);
-            Assert.AreEqual(530, levels[0].Price);
-            Assert.AreEqual(2, levels[0].Quantity);
-        }
-
-        // ----- MinQuantity between 1 and the full order quantity -----
-
-        [TestCase(0)]
-        [TestCase(-1)]
-        [TestCase(6)]
-        public void MinQuantity_OutsideValidRange_Rejected(int minQuantity)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId1,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = minQuantity }, Side.Buy, 5, 100);
-
-            // assert
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.MinQuantityOutOfRange, rejected.Reason);
-        }
-
-        [Test]
-        public void MinQuantity_SufficientButNotFullSize_FillsAvailable_CancelsRemainder()
-        {
-            // arrange - only 3 available, less than the order's full size of 5, but enough to
-            // satisfy a MinQuantity of 3
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = 3 }, Side.Buy, 5, 100);
-
-            // assert - proceeds like classic IOC once the gate is satisfied: fills what's
-            // available, cancels the rest
-            Assert.AreEqual(3, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(3, matched.Quantity);
-
-            var cancelled = events[2] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(3, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void MinQuantity_Insufficient_RejectedOutright_NothingFills()
-        {
-            // arrange - only 2 available, below the MinQuantity of 3
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = 3 }, Side.Buy, 5, 100);
-
-            // assert - rejected outright, not even a partial fill below the minimum
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
-
-            // the resting sell is completely untouched
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(2, sellLevels[0].Quantity);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
-
-        [Test]
-        public void MinQuantity_TriggeredStop_GoesThroughSameGate()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
-            TimeProvider.SetCurrentTime(Now2);
-
-            // IOC stop-limit buy: triggers at/above 520, willing to pay up to 530, needs at least 2
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 2 },
-                Side.Buy, 5, 530, 520);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // only 1 available once the stop triggers - below its MinQuantity of 2
-            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 1, 530);
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
-            TimeProvider.SetCurrentTime(Now5);
-
-            // act - a sell crossing the just-rested 520 buy prints a trade at 520, triggering the stop
-            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
-
-            // assert - stop triggers, but the available 1 unit doesn't meet its MinQuantity of 2,
-            // so it's cancelled directly rather than being converted to a working limit order
-            Assert.AreEqual(3, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-            Assert.IsInstanceOf<OrdersMatched>(events[1]);
-
-            var cancelled = events[2] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(0, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-
-            // the 1 unit at 530 is untouched
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(530, sellLevels[0].Price);
-            Assert.AreEqual(1, sellLevels[0].Quantity);
-        }
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+    }
+
+    // ----- no MinQuantity (classic IOC/FillAndKill behavior) -----
+
+    [Test]
+    public void LimitOrder_FullFill_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 3, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+
+        Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.ImmediateOrCancel(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_PartialFill_RemainderCancelled()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(2, matched.Quantity);
+
+        var cancelled = events[2] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(Sec, cancelled.Security);
+        Assert.AreEqual(Now2, cancelled.Time);
+        Assert.AreEqual(CompanyId2, cancelled.CompanyId);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
+        Assert.AreEqual(new OrderValidity.ImmediateOrCancel(), cancelled.Order.OrderValidity);
+        Assert.AreEqual(5, cancelled.Order.Quantity);
+        Assert.AreEqual(2, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+
+        // book has nothing resting from either order
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+        Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
+    }
+
+    [Test]
+    public void LimitOrder_EmptyBook_ImmediatelyCancelled()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+
+        var cancelled = events[1] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(0, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
+
+    [Test]
+    public void MarketOrder_PartialFillWithinProtection_RemainderCancelled()
+    {
+        // arrange
+        var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
+        var book = new LevelTrackingOrderBook(sec, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        // NB: a Market + GTC/Day order in the same situation would instead rest the
+        // remainder as a limit order at the protected price (see MarketOrder_Success).
+        var events = book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(500, matched.Price);
+        Assert.AreEqual(2, matched.Quantity);
+
+        var cancelled = events[2] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(OrderType.Market, cancelled.Order.Type);
+        Assert.AreEqual(700, cancelled.Order.Price);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(2, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+
+        Assert.AreEqual(0, book.GetLevels(Side.Buy, 10).Count);
+    }
+
+    [Test]
+    public void StopLimitOrder_TriggersAndPartiallyFills_RemainderCancelled()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
+        TimeProvider.SetCurrentTime(Now2);
+
+        // IOC stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 530, 520);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // only 2 available to fill the stop once triggered
+        Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
+        TimeProvider.SetCurrentTime(Now5);
+
+        // act - trade at 520 triggers the stop
+        var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(5, events.Count);
+
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.IsInstanceOf<OrdersMatched>(events[1]);
+
+        var triggered = events[2] as UpdateOrderConfirmed;
+        Assert.IsNotNull(triggered);
+        Assert.AreEqual(OrderId3, triggered.Order.ClientOrderId);
+        Assert.AreEqual(OrderType.Limit, triggered.Order.Type);
+        Assert.AreEqual(530, triggered.Order.Price);
+
+        var stopMatch = events[3] as OrdersMatched;
+        Assert.IsNotNull(stopMatch);
+        Assert.AreEqual(530, stopMatch.Price);
+        Assert.AreEqual(2, stopMatch.Quantity);
+
+        var cancelled = events[4] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
+        Assert.AreEqual(new OrderValidity.ImmediateOrCancel(), cancelled.Order.OrderValidity);
+        Assert.AreEqual(2, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+        Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
+    }
+
+    // ----- MinQuantity == full order quantity (FillOrKill-equivalent behavior) -----
+
+    [Test]
+    public void MinQuantity_EqualsFullQuantity_SufficientLiquidityAtSingleLevel_FullyFilled()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(5, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void MinQuantity_EqualsFullQuantity_SufficientLiquidityAcrossMultipleLevels_FullyFilled()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 110);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act - only fills if the 3@100 and 2@110 levels are summed together
+        var events = Book.CreateLimitOrder(CompanyId3, OrderId3,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched1 = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched1);
+        Assert.AreEqual(100, matched1.Price);
+        Assert.AreEqual(3, matched1.Quantity);
+
+        var matched2 = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched2);
+        Assert.AreEqual(110, matched2.Price);
+        Assert.AreEqual(2, matched2.Quantity);
+        Assert.AreEqual(OrderStatus.Filled, matched2.Fills[1].Order.Status);
+        Assert.AreEqual(OrderId3, matched2.Fills[1].ClientOrderId);
+        Assert.AreEqual(5, matched2.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched2.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void MinQuantity_EqualsFullQuantity_InsufficientLiquidity_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now2, rejected.Time);
+        Assert.AreEqual(CompanyId2, rejected.CompanyId);
+        Assert.AreEqual(OrderId2, rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
+
+        // book is completely untouched - no partial fill leaked through
+        var levels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, levels.Count);
+        Assert.AreEqual(100, levels[0].Price);
+        Assert.AreEqual(2, levels[0].Quantity);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
+
+    [Test]
+    public void MinQuantity_EqualsFullQuantity_StopLimitOrder_TriggersWithInsufficientLiquidity_Cancelled()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
+        TimeProvider.SetCurrentTime(Now2);
+
+        // FOK-equivalent stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 },
+            Side.Buy, 5, 530, 520);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // only 2 available - not enough to fill the stop's 5 in full
+        Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
+        TimeProvider.SetCurrentTime(Now5);
+
+        // act - trade at 520 triggers the stop
+        var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.IsInstanceOf<OrdersMatched>(events[1]);
+
+        var cancelled = events[2] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(OrderType.StopLimit, cancelled.Order.Type);
+        Assert.AreEqual(new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, cancelled.Order.OrderValidity);
+        Assert.AreEqual(0, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+
+        // the 2@530 resting sell was never touched
+        var levels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, levels.Count);
+        Assert.AreEqual(530, levels[0].Price);
+        Assert.AreEqual(2, levels[0].Quantity);
+    }
+
+    // ----- MinQuantity between 1 and the full order quantity -----
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(6)]
+    public void MinQuantity_OutsideValidRange_Rejected(int minQuantity)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId1,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = minQuantity }, Side.Buy, 5, 100);
+
+        // assert
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.MinQuantityOutOfRange, rejected.Reason);
+    }
+
+    [Test]
+    public void MinQuantity_SufficientButNotFullSize_FillsAvailable_CancelsRemainder()
+    {
+        // arrange - only 3 available, less than the order's full size of 5, but enough to
+        // satisfy a MinQuantity of 3
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = 3 }, Side.Buy, 5, 100);
+
+        // assert - proceeds like classic IOC once the gate is satisfied: fills what's
+        // available, cancels the rest
+        Assert.AreEqual(3, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(3, matched.Quantity);
+
+        var cancelled = events[2] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(3, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void MinQuantity_Insufficient_RejectedOutright_NothingFills()
+    {
+        // arrange - only 2 available, below the MinQuantity of 3
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = 3 }, Side.Buy, 5, 100);
+
+        // assert - rejected outright, not even a partial fill below the minimum
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
+
+        // the resting sell is completely untouched
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(2, sellLevels[0].Quantity);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
+
+    [Test]
+    public void MinQuantity_TriggeredStop_GoesThroughSameGate()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
+        TimeProvider.SetCurrentTime(Now2);
+
+        // IOC stop-limit buy: triggers at/above 520, willing to pay up to 530, needs at least 2
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 2 },
+            Side.Buy, 5, 530, 520);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // only 1 available once the stop triggers - below its MinQuantity of 2
+        Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 1, 530);
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
+        TimeProvider.SetCurrentTime(Now5);
+
+        // act - a sell crossing the just-rested 520 buy prints a trade at 520, triggering the stop
+        var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
+
+        // assert - stop triggers, but the available 1 unit doesn't meet its MinQuantity of 2,
+        // so it's cancelled directly rather than being converted to a working limit order
+        Assert.AreEqual(3, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.IsInstanceOf<OrdersMatched>(events[1]);
+
+        var cancelled = events[2] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(0, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+
+        // the 1 unit at 530 is untouched
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(530, sellLevels[0].Price);
+        Assert.AreEqual(1, sellLevels[0].Quantity);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
@@ -1,245 +1,243 @@
-using System;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookMarketLimitOrderTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookMarketLimitOrderTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+
+    private static TestTimeProvider TimeProvider;
+    private static LevelTrackingOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    [Test]
+    public void FullFillAtBestLevel_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
+        // act
+        var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
 
-        private static TestTimeProvider TimeProvider;
-        private static LevelTrackingOrderBook Book;
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(OrderType.MarketLimit, created.Order.Type);
+        Assert.AreEqual(100, created.Order.Price);
 
-        [SetUp]
-        public void SetUp()
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.AreEqual(OrderType.MarketLimit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void PartialFillAtBestLevel_RestsAtBestPrice_TypeStaysMarketLimit()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(2, matched.Quantity);
+
+        var restingOrder = matched.Fills[1].Order;
+        Assert.AreEqual(OrderType.MarketLimit, restingOrder.Type);
+        Assert.AreEqual(OrderStatus.Working, restingOrder.Status);
+        Assert.AreEqual(100, restingOrder.Price);
+        Assert.AreEqual(2, restingOrder.FilledQuantity);
+        Assert.AreEqual(3, restingOrder.RemainingQuantity);
+
+        var levels = Book.GetLevels(Side.Buy, 10);
+        Assert.AreEqual(1, levels.Count);
+        Assert.AreEqual(100, levels[0].Price);
+        Assert.AreEqual(3, levels[0].Quantity);
+    }
+
+    [Test]
+    public void DoesNotSweepSecondLevel_UnlikePlainMarketOrder()
+    {
+        // arrange - a wide protection-tick band so a plain Market order provably reaches
+        // the second level, contrasted against a MarketLimit order in the identical setup
+        var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
+
+        var marketBook = new LevelTrackingOrderBook(sec, TimeProvider);
+        marketBook.UpdateStatus(OrderBookStatus.Open);
+        marketBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
+        marketBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
+
+        var marketLimitBook = new LevelTrackingOrderBook(sec, TimeProvider);
+        marketLimitBook.UpdateStatus(OrderBookStatus.Open);
+        marketLimitBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
+        marketLimitBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
+
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var marketEvents = marketBook.CreateMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
+        var marketLimitEvents = marketLimitBook.CreateMarketLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
+
+        // assert - the plain Market order sweeps both levels and fully fills
+        Assert.AreEqual(3, marketEvents.Count);
+        var finalAggressor = ((OrdersMatched) marketEvents[2]).Fills[1].Order;
+        Assert.AreEqual(OrderStatus.Filled, finalAggressor.Status);
+        Assert.AreEqual(5, finalAggressor.FilledQuantity);
+        Assert.AreEqual(0, finalAggressor.RemainingQuantity);
+
+        // the market-limit order only touches the 500 level and rests the remainder there
+        Assert.AreEqual(2, marketLimitEvents.Count);
+        var matched = marketLimitEvents[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(500, matched.Price);
+        Assert.AreEqual(2, matched.Quantity);
+        var restingOrder = matched.Fills[1].Order;
+        Assert.AreEqual(OrderType.MarketLimit, restingOrder.Type);
+        Assert.AreEqual(500, restingOrder.Price);
+        Assert.AreEqual(2, restingOrder.FilledQuantity);
+        Assert.AreEqual(3, restingOrder.RemainingQuantity);
+
+        // the 600 level is completely untouched
+        var remainingSellLevels = marketLimitBook.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, remainingSellLevels.Count);
+        Assert.AreEqual(600, remainingSellLevels[0].Price);
+        Assert.AreEqual(10, remainingSellLevels[0].Quantity);
+    }
+
+    [Test]
+    public void EmptyBook_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.CreateMarketLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.NoOrdersToMatchMarketOrder, rejected.Reason);
+    }
+
+    [Test]
+    public void ImmediateOrCancel_RemainderCancelledInsteadOfResting()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(2, matched.Quantity);
+
+        var cancelled = events[2] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
+        Assert.AreEqual(OrderType.MarketLimit, cancelled.Order.Type);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(2, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
+
+    [Test]
+    public void ImmediateOrCancel_MinQuantity_InsufficientLiquidityAtBestLevelAlone_Rejected()
+    {
+        // arrange - 2 available at the best level, 10 more one level back; FOK must only
+        // count the best level for a market-limit order, so this must be rejected even
+        // though 12 combined would be enough for an order that could sweep
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 110);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.CreateMarketLimitOrder(CompanyId3, OrderId3,
+            new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
+
+        // book is completely untouched
+        var levels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(2, levels.Count);
+        Assert.AreEqual(100, levels[0].Price);
+        Assert.AreEqual(2, levels[0].Quantity);
+    }
+
+    [Test]
+    public void Process_CreateOrder_MarketLimitFlagRoutesThrough()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.Process(new CreateMarketLimitOrder
         {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
-        }
+            Security = Sec, CompanyId = CompanyId2, ClientOrderId = OrderId2, OrderValidity = new OrderValidity.Day(),
+            Side = Side.Buy, Quantity = 3
+        });
 
-        [Test]
-        public void FullFillAtBestLevel_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(OrderType.MarketLimit, created.Order.Type);
-            Assert.AreEqual(100, created.Order.Price);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.AreEqual(OrderType.MarketLimit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void PartialFillAtBestLevel_RestsAtBestPrice_TypeStaysMarketLimit()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(2, matched.Quantity);
-
-            var restingOrder = matched.Fills[1].Order;
-            Assert.AreEqual(OrderType.MarketLimit, restingOrder.Type);
-            Assert.AreEqual(OrderStatus.Working, restingOrder.Status);
-            Assert.AreEqual(100, restingOrder.Price);
-            Assert.AreEqual(2, restingOrder.FilledQuantity);
-            Assert.AreEqual(3, restingOrder.RemainingQuantity);
-
-            var levels = Book.GetLevels(Side.Buy, 10);
-            Assert.AreEqual(1, levels.Count);
-            Assert.AreEqual(100, levels[0].Price);
-            Assert.AreEqual(3, levels[0].Quantity);
-        }
-
-        [Test]
-        public void DoesNotSweepSecondLevel_UnlikePlainMarketOrder()
-        {
-            // arrange - a wide protection-tick band so a plain Market order provably reaches
-            // the second level, contrasted against a MarketLimit order in the identical setup
-            var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
-
-            var marketBook = new LevelTrackingOrderBook(sec, TimeProvider);
-            marketBook.UpdateStatus(OrderBookStatus.Open);
-            marketBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
-            marketBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
-
-            var marketLimitBook = new LevelTrackingOrderBook(sec, TimeProvider);
-            marketLimitBook.UpdateStatus(OrderBookStatus.Open);
-            marketLimitBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
-            marketLimitBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
-
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var marketEvents = marketBook.CreateMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
-            var marketLimitEvents = marketLimitBook.CreateMarketLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
-
-            // assert - the plain Market order sweeps both levels and fully fills
-            Assert.AreEqual(3, marketEvents.Count);
-            var finalAggressor = ((OrdersMatched) marketEvents[2]).Fills[1].Order;
-            Assert.AreEqual(OrderStatus.Filled, finalAggressor.Status);
-            Assert.AreEqual(5, finalAggressor.FilledQuantity);
-            Assert.AreEqual(0, finalAggressor.RemainingQuantity);
-
-            // the market-limit order only touches the 500 level and rests the remainder there
-            Assert.AreEqual(2, marketLimitEvents.Count);
-            var matched = marketLimitEvents[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(500, matched.Price);
-            Assert.AreEqual(2, matched.Quantity);
-            var restingOrder = matched.Fills[1].Order;
-            Assert.AreEqual(OrderType.MarketLimit, restingOrder.Type);
-            Assert.AreEqual(500, restingOrder.Price);
-            Assert.AreEqual(2, restingOrder.FilledQuantity);
-            Assert.AreEqual(3, restingOrder.RemainingQuantity);
-
-            // the 600 level is completely untouched
-            var remainingSellLevels = marketLimitBook.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, remainingSellLevels.Count);
-            Assert.AreEqual(600, remainingSellLevels[0].Price);
-            Assert.AreEqual(10, remainingSellLevels[0].Quantity);
-        }
-
-        [Test]
-        public void EmptyBook_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.CreateMarketLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.NoOrdersToMatchMarketOrder, rejected.Reason);
-        }
-
-        [Test]
-        public void ImmediateOrCancel_RemainderCancelledInsteadOfResting()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(2, matched.Quantity);
-
-            var cancelled = events[2] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
-            Assert.AreEqual(OrderType.MarketLimit, cancelled.Order.Type);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(2, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
-
-        [Test]
-        public void ImmediateOrCancel_MinQuantity_InsufficientLiquidityAtBestLevelAlone_Rejected()
-        {
-            // arrange - 2 available at the best level, 10 more one level back; FOK must only
-            // count the best level for a market-limit order, so this must be rejected even
-            // though 12 combined would be enough for an order that could sweep
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 110);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.CreateMarketLimitOrder(CompanyId3, OrderId3,
-                new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
-
-            // book is completely untouched
-            var levels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(2, levels.Count);
-            Assert.AreEqual(100, levels[0].Price);
-            Assert.AreEqual(2, levels[0].Quantity);
-        }
-
-        [Test]
-        public void Process_CreateOrder_MarketLimitFlagRoutesThrough()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.Process(new CreateMarketLimitOrder
-            {
-                Security = Sec, CompanyId = CompanyId2, ClientOrderId = OrderId2, OrderValidity = new OrderValidity.Day(),
-                Side = Side.Buy, Quantity = 3
-            });
-
-            // assert
-            Assert.IsNotNull(events);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(OrderType.MarketLimit, created.Order.Type);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(OrderType.MarketLimit, created.Order.Type);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
@@ -1,242 +1,239 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// A trading day can hold more than one session. Sequence numbers are seeded from the date, so
+// the thing to prove is that a second session on the same date carries on issuing ids rather
+// than restarting - orders surviving the break still hold the ids a restart would hand out
+// again, and both _orders and _completedOrders are keyed on exactly those.
+[TestFixture]
+public class InMemoryOrderBookMultipleSessionsTests
 {
-    // A trading day can hold more than one session. Sequence numbers are seeded from the date, so
-    // the thing to prove is that a second session on the same date carries on issuing ids rather
-    // than restarting - orders surviving the break still hold the ids a restart would hand out
-    // again, and both _orders and _completedOrders are keyed on exactly those.
-    [TestFixture]
-    public class InMemoryOrderBookMultipleSessionsTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime MorningSession = new(2000, 1, 1, 9, 0, 0);
+    private static readonly DateTime AfternoonSession = new(2000, 1, 1, 14, 0, 0);
+    private static readonly DateTime NextDay = new(2000, 1, 2, 9, 0, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+
+    private TestTimeProvider TimeProvider;
+    private IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(MorningSession);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime MorningSession = new(2000, 1, 1, 9, 0, 0);
-        private static readonly DateTime AfternoonSession = new(2000, 1, 1, 14, 0, 0);
-        private static readonly DateTime NextDay = new(2000, 1, 2, 9, 0, 0);
+    // The seed InMemoryOrderBook derives from a date, so a test can say which run of ids it
+    // expects without hard-coding an 18-digit literal.
+    private static long SeedFor(DateTime date) =>
+        ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
+    private static long ExchangeOrderIdOf(IOrderBook book, string companyId, string clientOrderId,
+        OrderValidity validity, Side side, int quantity, decimal price)
+    {
+        var events = book.CreateLimitOrder(companyId, clientOrderId, validity, side, quantity, price);
+        var created = events.OfType<CreateOrderConfirmed>().Single();
+        return long.Parse(created.Order.ExchangeOrderId);
+    }
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
+    [Test]
+    public void TwoSessionsSameDay_SurvivingGoodTilCanceledOrder_NoIdCollision()
+    {
+        // arrange - a GTC order rests through the morning session and survives the break, so it
+        // still holds its id when the afternoon session starts
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var morningId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
+            Side.Buy, 5, 100);
+        Book.CloseTrading(endsTradingDay: false);
 
-        private TestTimeProvider TimeProvider;
-        private IOrderBook Book;
+        // act - the same date, so the seed is one the counter has already passed
+        TimeProvider.SetCurrentTime(AfternoonSession);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var afternoonId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
+            Side.Buy, 5, 90);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(MorningSession);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+        // assert
+        Assert.IsTrue(afternoonId > morningId, "the afternoon session continues the morning's run of ids");
+        Assert.AreEqual(SeedFor(MorningSession) + 1, morningId);
+        Assert.AreEqual(SeedFor(MorningSession) + 2, afternoonId);
+    }
 
-        // The seed InMemoryOrderBook derives from a date, so a test can say which run of ids it
-        // expects without hard-coding an 18-digit literal.
-        private static long SeedFor(DateTime date) =>
-            ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
+    [Test]
+    public void TwoSessionsSameDay_CompletedOrderIdsNotReissued()
+    {
+        // arrange - both morning orders fill completely, so they leave the working book and are
+        // held as completed under their ids
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        Book.CloseTrading(endsTradingDay: false);
 
-        private static long ExchangeOrderIdOf(IOrderBook book, string companyId, string clientOrderId,
-            OrderValidity validity, Side side, int quantity, decimal price)
-        {
-            var events = book.CreateLimitOrder(companyId, clientOrderId, validity, side, quantity, price);
-            var created = events.OfType<CreateOrderConfirmed>().Single();
-            return long.Parse(created.Order.ExchangeOrderId);
-        }
+        // act
+        TimeProvider.SetCurrentTime(AfternoonSession);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 100);
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
 
-        [Test]
-        public void TwoSessionsSameDay_SurvivingGoodTilCanceledOrder_NoIdCollision()
-        {
-            // arrange - a GTC order rests through the morning session and survives the break, so it
-            // still holds its id when the afternoon session starts
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var morningId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
-                Side.Buy, 5, 100);
-            Book.CloseTrading(endsTradingDay: false);
+        // assert - the afternoon pair traded rather than colliding with the morning pair's ids
+        var matched = events.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+    }
 
-            // act - the same date, so the seed is one the counter has already passed
-            TimeProvider.SetCurrentTime(AfternoonSession);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var afternoonId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
-                Side.Buy, 5, 90);
+    [Test]
+    public void PreOpenTwice_SameDay_DoesNotRestartSequenceNumbers()
+    {
+        // arrange - re-entering pre-open without an intervening close (as reopening a volatility
+        // pause does) must not look like the start of a fresh run of ids either
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        var first = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
+            Side.Buy, 5, 100);
 
-            // assert
-            Assert.IsTrue(afternoonId > morningId, "the afternoon session continues the morning's run of ids");
-            Assert.AreEqual(SeedFor(MorningSession) + 1, morningId);
-            Assert.AreEqual(SeedFor(MorningSession) + 2, afternoonId);
-        }
+        // act
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        var second = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
+            Side.Buy, 5, 90);
 
-        [Test]
-        public void TwoSessionsSameDay_CompletedOrderIdsNotReissued()
-        {
-            // arrange - both morning orders fill completely, so they leave the working book and are
-            // held as completed under their ids
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            Book.CloseTrading(endsTradingDay: false);
+        // assert
+        Assert.IsTrue(second > first);
+    }
 
-            // act
-            TimeProvider.SetCurrentTime(AfternoonSession);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 100);
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
+    [Test]
+    public void NewDay_SeedsFromDate()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var day1Id = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
+            Side.Buy, 5, 100);
+        Book.CloseTrading();
 
-            // assert - the afternoon pair traded rather than colliding with the morning pair's ids
-            var matched = events.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-        }
+        // act
+        TimeProvider.SetCurrentTime(NextDay);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var day2Id = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
+            Side.Buy, 5, 90);
 
-        [Test]
-        public void PreOpenTwice_SameDay_DoesNotRestartSequenceNumbers()
-        {
-            // arrange - re-entering pre-open without an intervening close (as reopening a volatility
-            // pause does) must not look like the start of a fresh run of ids either
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            var first = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
-                Side.Buy, 5, 100);
+        // assert - a new date still re-anchors, so an id carries the day it was issued
+        Assert.AreEqual(SeedFor(MorningSession) + 1, day1Id);
+        Assert.AreEqual(SeedFor(NextDay) + 1, day2Id);
+    }
 
-            // act
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            var second = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
-                Side.Buy, 5, 90);
+    [Test]
+    public void IntradayClose_DayOrderSurvives()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
-            // assert
-            Assert.IsTrue(second > first);
-        }
+        // act - closing for a break, with a session still to come today
+        var events = Book.CloseTrading(endsTradingDay: false);
 
-        [Test]
-        public void NewDay_SeedsFromDate()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var day1Id = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(),
-                Side.Buy, 5, 100);
-            Book.CloseTrading();
+        // assert
+        Assert.AreEqual(1, events.Count);
+        Assert.IsInstanceOf<StatusChanged>(events[0]);
+        Assert.AreEqual(0, events.OfType<ExpireOrderConfirmed>().Count(), "a break does not retire day orders");
+    }
 
-            // act
-            TimeProvider.SetCurrentTime(NextDay);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var day2Id = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
-                Side.Buy, 5, 90);
+    [Test]
+    public void IntradayClose_DayOrderStillTradesInTheNextSession()
+    {
+        // arrange - the surviving order has to be genuinely resting, not merely unexpired
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.CloseTrading(endsTradingDay: false);
 
-            // assert - a new date still re-anchors, so an id carries the day it was issued
-            Assert.AreEqual(SeedFor(MorningSession) + 1, day1Id);
-            Assert.AreEqual(SeedFor(NextDay) + 1, day2Id);
-        }
+        TimeProvider.SetCurrentTime(AfternoonSession);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-        [Test]
-        public void IntradayClose_DayOrderSurvives()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
 
-            // act - closing for a break, with a session still to come today
-            var events = Book.CloseTrading(endsTradingDay: false);
+        // assert
+        var matched = events.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+    }
 
-            // assert
-            Assert.AreEqual(1, events.Count);
-            Assert.IsInstanceOf<StatusChanged>(events[0]);
-            Assert.AreEqual(0, events.OfType<ExpireOrderConfirmed>().Count(), "a break does not retire day orders");
-        }
+    [Test]
+    public void FinalClose_DayOrderExpires()
+    {
+        // arrange - survives the break, then meets the close that ends the day
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.CloseTrading(endsTradingDay: false);
 
-        [Test]
-        public void IntradayClose_DayOrderStillTradesInTheNextSession()
-        {
-            // arrange - the surviving order has to be genuinely resting, not merely unexpired
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.CloseTrading(endsTradingDay: false);
+        TimeProvider.SetCurrentTime(AfternoonSession);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-            TimeProvider.SetCurrentTime(AfternoonSession);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
+        // act
+        var events = Book.CloseTrading();
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        // assert
+        var expired = events.OfType<ExpireOrderConfirmed>().Single();
+        Assert.AreEqual(AfternoonSession, expired.Time);
+        Assert.AreEqual(CompanyId1, expired.CompanyId);
+        Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+    }
 
-            // assert
-            var matched = events.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-        }
+    [Test]
+    public void IntradayClose_GoodTilDateOrderDueToday_SurvivesUntilFinalClose()
+    {
+        // arrange - good til today, so the day's last close is what retires it
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var goodTilDate = DateOnly.FromDateTime(MorningSession);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate {Date = goodTilDate},
+            Side.Buy, 5, 100);
 
-        [Test]
-        public void FinalClose_DayOrderExpires()
-        {
-            // arrange - survives the break, then meets the close that ends the day
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.CloseTrading(endsTradingDay: false);
+        // act
+        var breakEvents = Book.CloseTrading(endsTradingDay: false);
 
-            TimeProvider.SetCurrentTime(AfternoonSession);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
+        TimeProvider.SetCurrentTime(AfternoonSession);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var closeEvents = Book.CloseTrading();
 
-            // act
-            var events = Book.CloseTrading();
+        // assert
+        Assert.AreEqual(0, breakEvents.OfType<ExpireOrderConfirmed>().Count(),
+            "not due until the day actually ends");
 
-            // assert
-            var expired = events.OfType<ExpireOrderConfirmed>().Single();
-            Assert.AreEqual(AfternoonSession, expired.Time);
-            Assert.AreEqual(CompanyId1, expired.CompanyId);
-            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-        }
+        var expired = closeEvents.OfType<ExpireOrderConfirmed>().Single();
+        Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+    }
 
-        [Test]
-        public void IntradayClose_GoodTilDateOrderDueToday_SurvivesUntilFinalClose()
-        {
-            // arrange - good til today, so the day's last close is what retires it
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var goodTilDate = DateOnly.FromDateTime(MorningSession);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate {Date = goodTilDate},
-                Side.Buy, 5, 100);
+    [Test]
+    public void GoodTilCanceledOrder_SurvivesFinalCloseToo()
+    {
+        // arrange - the day ending retires day orders, never a GTC one
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
 
-            // act
-            var breakEvents = Book.CloseTrading(endsTradingDay: false);
+        // act
+        var events = Book.CloseTrading();
 
-            TimeProvider.SetCurrentTime(AfternoonSession);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var closeEvents = Book.CloseTrading();
-
-            // assert
-            Assert.AreEqual(0, breakEvents.OfType<ExpireOrderConfirmed>().Count(),
-                "not due until the day actually ends");
-
-            var expired = closeEvents.OfType<ExpireOrderConfirmed>().Single();
-            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-        }
-
-        [Test]
-        public void GoodTilCanceledOrder_SurvivesFinalCloseToo()
-        {
-            // arrange - the day ending retires day orders, never a GTC one
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
-
-            // act
-            var events = Book.CloseTrading();
-
-            // assert
-            Assert.AreEqual(1, events.Count);
-            Assert.IsInstanceOf<StatusChanged>(events[0]);
-        }
+        // assert
+        Assert.AreEqual(1, events.Count);
+        Assert.IsInstanceOf<StatusChanged>(events[0]);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
@@ -1,243 +1,240 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// Paused and Halted are both interruptions within a session, so neither may behave like the
+// start of one (PreOpen) or the end of one (Closed). What separates the two from each other is
+// price discovery: a pause keeps quoting and resolves into a print, a halt publishes nothing.
+[TestFixture]
+public class InMemoryOrderBookPausedHaltedTests
 {
-    // Paused and Halted are both interruptions within a session, so neither may behave like the
-    // start of one (PreOpen) or the end of one (Closed). What separates the two from each other is
-    // price discovery: a pause keeps quoting and resolves into a print, a halt publishes nothing.
-    [TestFixture]
-    public class InMemoryOrderBookPausedHaltedTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime NextDay = new(2000, 1, 2, 12, 0, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string CancelId1 = "Cancel1";
+
+    private TestTimeProvider TimeProvider;
+    private IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime NextDay = new(2000, 1, 2, 12, 0, 0);
+    [TestCase(OrderBookStatus.Paused)]
+    [TestCase(OrderBookStatus.Halted)]
+    public void UpdateStatus_ReachesTheNewStatuses(OrderBookStatus status)
+    {
+        // act
+        var events = Book.UpdateStatus(status);
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
+        // assert
+        Assert.AreEqual(1, events.Count);
+        var statusChanged = events[0] as StatusChanged;
+        Assert.IsNotNull(statusChanged);
+        Assert.AreEqual(status, statusChanged.Status);
+        Assert.AreEqual(Now1, statusChanged.Time);
+        Assert.AreEqual(status, Book.Status);
+    }
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string CancelId1 = "Cancel1";
+    [TestCase(OrderBookStatus.Paused)]
+    [TestCase(OrderBookStatus.Halted)]
+    public void OrderActionsStillAccepted(OrderBookStatus status)
+    {
+        // arrange - resting from before the interruption
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.UpdateStatus(status);
 
-        private TestTimeProvider TimeProvider;
-        private IOrderBook Book;
+        // act - an interruption is not a close, so positions stay manageable
+        var created = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 90);
+        var cancelled = Book.CancelOrder(CompanyId1, CancelId1, OrderId1);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(created[0]);
+        Assert.IsInstanceOf<CancelOrderConfirmed>(cancelled[0]);
+    }
 
-        [TestCase(OrderBookStatus.Paused)]
-        [TestCase(OrderBookStatus.Halted)]
-        public void UpdateStatus_ReachesTheNewStatuses(OrderBookStatus status)
-        {
-            // act
-            var events = Book.UpdateStatus(status);
+    [TestCase(OrderBookStatus.Paused)]
+    [TestCase(OrderBookStatus.Halted)]
+    public void MarketOrdersRejected(OrderBookStatus status)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+        Book.UpdateStatus(status);
 
-            // assert
-            Assert.AreEqual(1, events.Count);
-            var statusChanged = events[0] as StatusChanged;
-            Assert.IsNotNull(statusChanged);
-            Assert.AreEqual(status, statusChanged.Status);
-            Assert.AreEqual(Now1, statusChanged.Time);
-            Assert.AreEqual(status, Book.Status);
-        }
+        // act - nothing is trading, so there is no book to price a market order against
+        var events = Book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5);
 
-        [TestCase(OrderBookStatus.Paused)]
-        [TestCase(OrderBookStatus.Halted)]
-        public void OrderActionsStillAccepted(OrderBookStatus status)
-        {
-            // arrange - resting from before the interruption
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.UpdateStatus(status);
+        // assert
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+    }
 
-            // act - an interruption is not a close, so positions stay manageable
-            var created = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 90);
-            var cancelled = Book.CancelOrder(CompanyId1, CancelId1, OrderId1);
+    [TestCase(OrderBookStatus.Paused)]
+    [TestCase(OrderBookStatus.Halted)]
+    public void DayOrdersSurvive(OrderBookStatus status)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(created[0]);
-            Assert.IsInstanceOf<CancelOrderConfirmed>(cancelled[0]);
-        }
+        // act - only a close that ends the trading day retires day orders
+        var events = Book.UpdateStatus(status);
 
-        [TestCase(OrderBookStatus.Paused)]
-        [TestCase(OrderBookStatus.Halted)]
-        public void MarketOrdersRejected(OrderBookStatus status)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-            Book.UpdateStatus(status);
+        // assert
+        Assert.AreEqual(0, events.OfType<ExpireOrderConfirmed>().Count());
 
-            // act - nothing is trading, so there is no book to price a market order against
-            var events = Book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5);
+        // and the order is genuinely still resting, not merely unexpired
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        Assert.AreEqual(1, crossing.OfType<OrdersMatched>().Count());
+    }
 
-            // assert
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-        }
+    [TestCase(OrderBookStatus.Paused)]
+    [TestCase(OrderBookStatus.Halted)]
+    public void DoesNotStartASession(OrderBookStatus status)
+    {
+        // arrange - sequence numbers are seeded from the date, and a session start on a later
+        // date jumps them to that date's run. An interruption is not a session start, so the
+        // counter must simply carry on. PreOpen on the same setup is the contrast, below.
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
 
-        [TestCase(OrderBookStatus.Paused)]
-        [TestCase(OrderBookStatus.Halted)]
-        public void DayOrdersSurvive(OrderBookStatus status)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
+        // act
+        TimeProvider.SetCurrentTime(NextDay);
+        Book.UpdateStatus(status);
+        var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
 
-            // act - only a close that ends the trading day retires day orders
-            var events = Book.UpdateStatus(status);
+        // assert
+        Assert.AreEqual(beforeId + 1, afterId, "the interruption did not reseed the run of ids");
+    }
 
-            // assert
-            Assert.AreEqual(0, events.OfType<ExpireOrderConfirmed>().Count());
+    [Test]
+    public void PreOpenOnALaterDate_DoesStartASession()
+    {
+        // arrange - the contrast for DoesNotStartASession: the same steps through PreOpen, which
+        // genuinely does start one, so the ids jump to the new date's run
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
 
-            // and the order is genuinely still resting, not merely unexpired
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            Assert.AreEqual(1, crossing.OfType<OrdersMatched>().Count());
-        }
+        // act
+        TimeProvider.SetCurrentTime(NextDay);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
 
-        [TestCase(OrderBookStatus.Paused)]
-        [TestCase(OrderBookStatus.Halted)]
-        public void DoesNotStartASession(OrderBookStatus status)
-        {
-            // arrange - sequence numbers are seeded from the date, and a session start on a later
-            // date jumps them to that date's run. An interruption is not a session start, so the
-            // counter must simply carry on. PreOpen on the same setup is the contrast, below.
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
+        // assert
+        Assert.IsTrue(afterId > beforeId + 1, "a session start reseeds from the new date");
+    }
 
-            // act
-            TimeProvider.SetCurrentTime(NextDay);
-            Book.UpdateStatus(status);
-            var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
+    [Test]
+    public void Paused_QuotesTheCrossedBook_AndPrintsOnResuming()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.UpdateStatus(OrderBookStatus.Paused);
 
-            // assert
-            Assert.AreEqual(beforeId + 1, afterId, "the interruption did not reseed the run of ids");
-        }
+        // act - orders accumulate into a cross while paused
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+        var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
 
-        [Test]
-        public void PreOpenOnALaterDate_DoesStartASession()
-        {
-            // arrange - the contrast for DoesNotStartASession: the same steps through PreOpen, which
-            // genuinely does start one, so the ids jump to the new date's run
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
+        // assert - quoted, not printed
+        var quote = crossing.OfType<IndicativePriceChanged>().Last();
+        Assert.AreEqual(100, quote.Price);
+        Assert.AreEqual(10, quote.Quantity);
+        Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count(), "a pause quotes, it does not trade");
 
-            // act
-            TimeProvider.SetCurrentTime(NextDay);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
+        // act - resuming resolves the accumulated book in one print
+        var resumed = Book.UpdateStatus(OrderBookStatus.Open);
 
-            // assert
-            Assert.IsTrue(afterId > beforeId + 1, "a session start reseeds from the new date");
-        }
+        // assert
+        var matched = resumed.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(10, matched.Quantity);
+    }
 
-        [Test]
-        public void Paused_QuotesTheCrossedBook_AndPrintsOnResuming()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.UpdateStatus(OrderBookStatus.Paused);
+    [Test]
+    public void Halted_PublishesNoQuote_AndDoesNotPrintOnResuming()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.UpdateStatus(OrderBookStatus.Halted);
 
-            // act - orders accumulate into a cross while paused
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
-            var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+        // act - the same crossed book a pause would have been quoting
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
+        var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
 
-            // assert - quoted, not printed
-            var quote = crossing.OfType<IndicativePriceChanged>().Last();
-            Assert.AreEqual(100, quote.Price);
-            Assert.AreEqual(10, quote.Quantity);
-            Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count(), "a pause quotes, it does not trade");
+        // assert - withholding price discovery is what makes this a halt
+        Assert.AreEqual(0, crossing.OfType<IndicativePriceChanged>().Count());
+        Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count());
 
-            // act - resuming resolves the accumulated book in one print
-            var resumed = Book.UpdateStatus(OrderBookStatus.Open);
+        // act - no algorithm means nothing prints on the way out; the cross is resolved by
+        // continuous trading once open, not by an uncrossing auction
+        var resumed = Book.UpdateStatus(OrderBookStatus.Open);
 
-            // assert
-            var matched = resumed.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(10, matched.Quantity);
-        }
+        // assert
+        var matched = resumed.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(10, matched.Quantity);
+    }
 
-        [Test]
-        public void Halted_PublishesNoQuote_AndDoesNotPrintOnResuming()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.UpdateStatus(OrderBookStatus.Halted);
+    [Test]
+    public void VolatilityBandBreach_PausesRatherThanReturningToPreOpen()
+    {
+        // arrange - a reference of 100 and a 5-tick volatility band
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
 
-            // act - the same crossed book a pause would have been quoting
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
-            var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+        // act - the trade at 200 breaches the band
+        var events = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
 
-            // assert - withholding price discovery is what makes this a halt
-            Assert.AreEqual(0, crossing.OfType<IndicativePriceChanged>().Count());
-            Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count());
+        // assert
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        Assert.AreEqual(OrderBookStatus.Paused, events.OfType<StatusChanged>().Single().Status);
+    }
 
-            // act - no algorithm means nothing prints on the way out; the cross is resolved by
-            // continuous trading once open, not by an uncrossing auction
-            var resumed = Book.UpdateStatus(OrderBookStatus.Open);
+    [Test]
+    public void Halted_ThenClosed_ExpiresDayOrdersAsNormal()
+    {
+        // arrange - a halt defers the day's end, it does not cancel it
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.UpdateStatus(OrderBookStatus.Halted);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            var matched = resumed.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(10, matched.Quantity);
-        }
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Closed);
 
-        [Test]
-        public void VolatilityBandBreach_PausesRatherThanReturningToPreOpen()
-        {
-            // arrange - a reference of 100 and a 5-tick volatility band
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+        // assert
+        var expired = events.OfType<ExpireOrderConfirmed>().Single();
+        Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+    }
 
-            // act - the trade at 200 breaches the band
-            var events = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
-
-            // assert
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-            Assert.AreEqual(OrderBookStatus.Paused, events.OfType<StatusChanged>().Single().Status);
-        }
-
-        [Test]
-        public void Halted_ThenClosed_ExpiresDayOrdersAsNormal()
-        {
-            // arrange - a halt defers the day's end, it does not cancel it
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.UpdateStatus(OrderBookStatus.Halted);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Closed);
-
-            // assert
-            var expired = events.OfType<ExpireOrderConfirmed>().Single();
-            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-        }
-
-        private static long ExchangeOrderIdOf(IOrderBook book, string companyId, string clientOrderId, Side side,
-            int quantity, decimal price)
-        {
-            var events = book.CreateLimitOrder(companyId, clientOrderId, new OrderValidity.GoodTilCanceled(), side,
-                quantity, price);
-            return long.Parse(events.OfType<CreateOrderConfirmed>().Single().Order.ExchangeOrderId);
-        }
+    private static long ExchangeOrderIdOf(IOrderBook book, string companyId, string clientOrderId, Side side,
+        int quantity, decimal price)
+    {
+        var events = book.CreateLimitOrder(companyId, clientOrderId, new OrderValidity.GoodTilCanceled(), side,
+            quantity, price);
+        return long.Parse(events.OfType<CreateOrderConfirmed>().Single().Order.ExchangeOrderId);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -1,298 +1,295 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookPriceBandTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookPriceBandTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+    private static readonly string CompanyId4 = "Company4";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+
+    private static TestTimeProvider TimeProvider;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+        TimeProvider = new TestTimeProvider(Now1);
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-        private static readonly string CompanyId4 = "Company4";
+    [Test]
+    public void NoBandConfigured_OrderFarFromReferencePrice_Accepted()
+    {
+        // arrange - no restrictions at all, so banding is off even though a reference price is
+        // seeded. A security without a band leaves the restriction out rather than configuring
+        // one with no width.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
+        // act
+        var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 1000);
 
-        private static TestTimeProvider TimeProvider;
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-        }
+    [Test]
+    public void BothBandsConfigured_EachRestrictionGetsItsOwnThreshold()
+    {
+        // arrange - the entry band wide (1000) and the volatility band narrow (5). Each config
+        // carries its own width, so the mapping in the book's constructor is the only place the
+        // two could be crossed over. A wide entry band must not reject, and a narrow volatility
+        // band must still pause on the resulting trade.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new OrderPriceBand(1000),
+                new VolatilityBand(5)
+            });
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
 
-        [Test]
-        public void NoBandConfigured_OrderFarFromReferencePrice_Accepted()
-        {
-            // arrange - no restrictions at all, so banding is off even though a reference price is
-            // seeded. A security without a band leaves the restriction out rather than configuring
-            // one with no width.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
+        // act - 200 is far outside the narrow volatility band but well inside the wide entry
+        // band, so both orders are accepted and it is the trade between them that pauses
+        var resting = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+        var crossing = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
 
-            // act
-            var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 1000);
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(resting[0],
+            "entry band is 1000 wide - this order is nowhere near it");
+        Assert.IsInstanceOf<CreateOrderConfirmed>(crossing[0]);
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status,
+            "the 5-tick volatility band should have paused the book on the trade");
+    }
 
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        }
+    [Test]
+    public void NoReferencePriceSeeded_NoTradeYet_BandInactive_Accepted()
+    {
+        // arrange - band is configured, but there's no anchor to check against yet
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
 
-        [Test]
-        public void BothBandsConfigured_EachRestrictionGetsItsOwnThreshold()
-        {
-            // arrange - the entry band wide (1000) and the volatility band narrow (5). Each config
-            // carries its own width, so the mapping in the book's constructor is the only place the
-            // two could be crossed over. A wide entry band must not reject, and a narrow volatility
-            // band must still pause on the resulting trade.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new OrderPriceBand(1000),
-                    new VolatilityBand(5)
-                });
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
+        // act
+        var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 1000);
 
-            // act - 200 is far outside the narrow volatility band but well inside the wide entry
-            // band, so both orders are accepted and it is the trade between them that pauses
-            var resting = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
-            var crossing = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+    }
 
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(resting[0],
-                "entry band is 1000 wide - this order is nowhere near it");
-            Assert.IsInstanceOf<CreateOrderConfirmed>(crossing[0]);
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status,
-                "the 5-tick volatility band should have paused the book on the trade");
-        }
+    [Test]
+    public void ReferencePriceSeeded_OrderWithinBand_Accepted_OutsideBand_Rejected()
+    {
+        // arrange - band of 5 ticks (50) around a seeded reference of 100, so [50, 150]
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
 
-        [Test]
-        public void NoReferencePriceSeeded_NoTradeYet_BandInactive_Accepted()
-        {
-            // arrange - band is configured, but there's no anchor to check against yet
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
+        // act/assert - at the reference price
+        var atReference = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(atReference[0]);
 
-            // act
-            var events = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 1000);
+        // act/assert - exactly on the band edge, inclusive
+        var atEdge = book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 150);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(atEdge[0]);
 
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        }
+        // act/assert - one tick beyond the edge
+        var beyondEdge = book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 160);
+        var rejected = beyondEdge[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
+    }
 
-        [Test]
-        public void ReferencePriceSeeded_OrderWithinBand_Accepted_OutsideBand_Rejected()
-        {
-            // arrange - band of 5 ticks (50) around a seeded reference of 100, so [50, 150]
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
+    [Test]
+    public void BandMovesDynamically_AfterATrade_ReanchorsToNewLastTradedPrice()
+    {
+        // arrange - reference seeded at 100, band [50, 150]
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
 
-            // act/assert - at the reference price
-            var atReference = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(atReference[0]);
+        // 160 is outside the original [50, 150] band
+        var beforeTrade = book.CreateLimitOrder(CompanyId2, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 160);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (beforeTrade[0] as CreateOrderRejected)?.Reason);
 
-            // act/assert - exactly on the band edge, inclusive
-            var atEdge = book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 150);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(atEdge[0]);
+        // act - a trade prints at 140, re-anchoring the band to [90, 190]
+        book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 140);
+        var matchEvents = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 140);
+        Assert.IsInstanceOf<OrdersMatched>(matchEvents[^1]);
 
-            // act/assert - one tick beyond the edge
-            var beyondEdge = book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 160);
-            var rejected = beyondEdge[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
-        }
+        // assert - 160 is now within the new [90, 190] band
+        var afterTrade = book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 160);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(afterTrade[0]);
 
-        [Test]
-        public void BandMovesDynamically_AfterATrade_ReanchorsToNewLastTradedPrice()
-        {
-            // arrange - reference seeded at 100, band [50, 150]
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
+        // assert - 60 was within the original [50, 150] band, but is now outside [90, 190]
+        var nowOutOfBand = book.CreateLimitOrder(CompanyId4, "Order5", new OrderValidity.Day(), Side.Buy, 5, 60);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (nowOutOfBand[0] as CreateOrderRejected)?.Reason);
+    }
 
-            // 160 is outside the original [50, 150] band
-            var beforeTrade = book.CreateLimitOrder(CompanyId2, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 160);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (beforeTrade[0] as CreateOrderRejected)?.Reason);
+    [Test]
+    public void UpdateOrder_RepriceOutsideBand_Rejected()
+    {
+        // arrange - reference seeded at 100, band [50, 150]
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
-            // act - a trade prints at 140, re-anchoring the band to [90, 190]
-            book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 140);
-            var matchEvents = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 140);
-            Assert.IsInstanceOf<OrdersMatched>(matchEvents[^1]);
+        // act - reprice to 200, outside the band
+        var events = book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 200);
 
-            // assert - 160 is now within the new [90, 190] band
-            var afterTrade = book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 160);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(afterTrade[0]);
+        // assert
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
 
-            // assert - 60 was within the original [50, 150] band, but is now outside [90, 190]
-            var nowOutOfBand = book.CreateLimitOrder(CompanyId4, "Order5", new OrderValidity.Day(), Side.Buy, 5, 60);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (nowOutOfBand[0] as CreateOrderRejected)?.Reason);
-        }
+        // the original order is untouched, still resting at 100
+        var buyLevels = book.GetLevels(Side.Buy, 10);
+        Assert.AreEqual(1, buyLevels.Count);
+        Assert.AreEqual(100, buyLevels[0].Price);
+    }
 
-        [Test]
-        public void UpdateOrder_RepriceOutsideBand_Rejected()
-        {
-            // arrange - reference seeded at 100, band [50, 150]
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+    // A band of 5 ticks on a tick size of 10 is 50 either side of wherever the reference is.
+    private static Security BandedSecurity() =>
+        new("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
 
-            // act - reprice to 200, outside the band
-            var events = book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 200);
+    [Test]
+    public void PreOpen_ReferenceMovesFromTheSettlementPriceToTheIndicativePrice()
+    {
+        // arrange - settled at 100, so the band starts out [50, 150]
+        var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen, 100);
 
-            // assert
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, rejected.Reason);
+        // assert - 200 is outside the band while the settlement price is still the reference
+        var beforeCross = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 200);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (beforeCross[0] as CreateOrderRejected)?.Reason);
 
-            // the original order is untouched, still resting at 100
-            var buyLevels = book.GetLevels(Side.Buy, 10);
-            Assert.AreEqual(1, buyLevels.Count);
-            Assert.AreEqual(100, buyLevels[0].Price);
-        }
+        // act - the book crosses at 150, so an indicative price exists and takes over as the
+        // reference, moving the band to [100, 200]
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 10, 150);
+        var crossing = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 10, 150);
+        Assert.AreEqual(150, crossing.OfType<IndicativePriceChanged>().Last().Price);
 
-        // A band of 5 ticks on a tick size of 10 is 50 either side of wherever the reference is.
-        private static Security BandedSecurity() =>
-            new("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+        // assert - the same price that was rejected a moment ago is now inside the band
+        var afterCross = book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 200);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(afterCross[0]);
 
-        [Test]
-        public void PreOpen_ReferenceMovesFromTheSettlementPriceToTheIndicativePrice()
-        {
-            // arrange - settled at 100, so the band starts out [50, 150]
-            var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen, 100);
+        // ...and 90, which the old band allowed, is now outside it
+        var belowNewBand = book.CreateLimitOrder(CompanyId4, "Order5", new OrderValidity.Day(), Side.Buy, 5, 90);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (belowNewBand[0] as CreateOrderRejected)?.Reason);
+    }
 
-            // assert - 200 is outside the band while the settlement price is still the reference
-            var beforeCross = book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 200);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (beforeCross[0] as CreateOrderRejected)?.Reason);
+    [Test]
+    public void ContinuousTrading_ReferenceReturnsToTheLastTrade_OnceTheQuoteIsWithdrawn()
+    {
+        // arrange - open on an auction that prints at 150, which withdraws the quote
+        var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
+        book.UpdateStatus(OrderBookStatus.PreOpen, 100);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 150);
+        book.UpdateStatus(OrderBookStatus.Open);
 
-            // act - the book crosses at 150, so an indicative price exists and takes over as the
-            // reference, moving the band to [100, 200]
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 10, 150);
-            var crossing = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 10, 150);
-            Assert.AreEqual(150, crossing.OfType<IndicativePriceChanged>().Last().Price);
+        // act - continuous trading prints at 190, which the band [100, 200] allows
+        book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 190);
+        book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 190);
 
-            // assert - the same price that was rejected a moment ago is now inside the band
-            var afterCross = book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 200);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(afterCross[0]);
+        // assert - the band tracks the last trade, so it is now [140, 240]. Were the withdrawn
+        // indicative price of 150 still the reference, 240 would be well outside it.
+        var atNewEdge = book.CreateLimitOrder(CompanyId1, "Order5", new OrderValidity.Day(), Side.Buy, 5, 240);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(atNewEdge[0]);
 
-            // ...and 90, which the old band allowed, is now outside it
-            var belowNewBand = book.CreateLimitOrder(CompanyId4, "Order5", new OrderValidity.Day(), Side.Buy, 5, 90);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (belowNewBand[0] as CreateOrderRejected)?.Reason);
-        }
+        var belowNewBand = book.CreateLimitOrder(CompanyId1, "Order6", new OrderValidity.Day(), Side.Buy, 5, 130);
+        Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (belowNewBand[0] as CreateOrderRejected)?.Reason);
+    }
 
-        [Test]
-        public void ContinuousTrading_ReferenceReturnsToTheLastTrade_OnceTheQuoteIsWithdrawn()
-        {
-            // arrange - open on an auction that prints at 150, which withdraws the quote
-            var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
-            book.UpdateStatus(OrderBookStatus.PreOpen, 100);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 150);
-            book.UpdateStatus(OrderBookStatus.Open);
+    // Trades at 100 to give stop orders a last traded price, then re-seeds the reference at 200
+    // so the band sits somewhere the last traded price does not. Without that separation the
+    // spread rule cannot be isolated: with the band centred on the last trade, a trigger on the
+    // far side of it can never be more than a band away from a limit price still inside it.
+    private LevelTrackingOrderBook StopSpreadBook(Security security)
+    {
+        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        book.UpdateStatus(OrderBookStatus.Open, 200);
+        return book;
+    }
 
-            // act - continuous trading prints at 190, which the band [100, 200] allows
-            book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 190);
-            book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 190);
+    [Test]
+    public void StopLimit_TriggerAndPriceWithinABandOfEachOther_Accepted()
+    {
+        // arrange - band [150, 250] around the re-seeded reference of 200
+        var book = StopSpreadBook(BandedSecurity());
 
-            // assert - the band tracks the last trade, so it is now [140, 240]. Were the withdrawn
-            // indicative price of 150 still the reference, 240 would be well outside it.
-            var atNewEdge = book.CreateLimitOrder(CompanyId1, "Order5", new OrderValidity.Day(), Side.Buy, 5, 240);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(atNewEdge[0]);
+        // act - trigger 160 and limit 210 are 50 apart, exactly the band width
+        var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
+            Side.Buy, 5, 210, 160);
 
-            var belowNewBand = book.CreateLimitOrder(CompanyId1, "Order6", new OrderValidity.Day(), Side.Buy, 5, 130);
-            Assert.AreEqual(OrderRejectedReason.PriceOutsideBands, (belowNewBand[0] as CreateOrderRejected)?.Reason);
-        }
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+    }
 
-        // Trades at 100 to give stop orders a last traded price, then re-seeds the reference at 200
-        // so the band sits somewhere the last traded price does not. Without that separation the
-        // spread rule cannot be isolated: with the band centred on the last trade, a trigger on the
-        // far side of it can never be more than a band away from a limit price still inside it.
-        private LevelTrackingOrderBook StopSpreadBook(Security security)
-        {
-            var book = new LevelTrackingOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            book.UpdateStatus(OrderBookStatus.Open, 200);
-            return book;
-        }
+    [Test]
+    public void StopLimit_TriggerAndPriceFurtherApartThanTheBand_Rejected()
+    {
+        // arrange
+        var book = StopSpreadBook(BandedSecurity());
 
-        [Test]
-        public void StopLimit_TriggerAndPriceWithinABandOfEachOther_Accepted()
-        {
-            // arrange - band [150, 250] around the re-seeded reference of 200
-            var book = StopSpreadBook(BandedSecurity());
+        // act - trigger 160 and limit 250 are 90 apart, beyond the band
+        var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
+            Side.Buy, 5, 250, 160);
 
-            // act - trigger 160 and limit 210 are 50 apart, exactly the band width
-            var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
-                Side.Buy, 5, 210, 160);
+        // assert - and note the limit price of 250 sits exactly on the band's own edge, so the
+        // entry band alone would have accepted this order. Only the spread rule catches it.
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceTooFarFromPrice, rejected.Reason);
+    }
 
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        }
+    [Test]
+    public void UpdateOrder_RepricingAStopBeyondTheBandFromItsTrigger_Rejected()
+    {
+        // arrange - an accepted stop, trigger 160 and limit 210
+        var book = StopSpreadBook(BandedSecurity());
+        book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 210, 160);
 
-        [Test]
-        public void StopLimit_TriggerAndPriceFurtherApartThanTheBand_Rejected()
-        {
-            // arrange
-            var book = StopSpreadBook(BandedSecurity());
+        // act - repricing to 250 leaves the limit inside the band but 90 from the trigger
+        var events = book.UpdateOrder(CompanyId3, OrderId4, OrderId3, price: 250);
 
-            // act - trigger 160 and limit 250 are 90 apart, beyond the band
-            var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
-                Side.Buy, 5, 250, 160);
+        // assert
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceTooFarFromPrice, rejected.Reason);
+    }
 
-            // assert - and note the limit price of 250 sits exactly on the band's own edge, so the
-            // entry band alone would have accepted this order. Only the spread rule catches it.
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceTooFarFromPrice, rejected.Reason);
-        }
+    [Test]
+    public void NoBandConfigured_StopSpreadUnbounded()
+    {
+        // arrange - nothing to bound the gap with
+        var book = StopSpreadBook(new Security("GCZ6", SecurityType.Future, 10, 10));
 
-        [Test]
-        public void UpdateOrder_RepricingAStopBeyondTheBandFromItsTrigger_Rejected()
-        {
-            // arrange - an accepted stop, trigger 160 and limit 210
-            var book = StopSpreadBook(BandedSecurity());
-            book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 210, 160);
+        // act
+        var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
+            Side.Buy, 5, 1000, 160);
 
-            // act - repricing to 250 leaves the limit inside the band but 90 from the trigger
-            var events = book.UpdateOrder(CompanyId3, OrderId4, OrderId3, price: 250);
-
-            // assert
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceTooFarFromPrice, rejected.Reason);
-        }
-
-        [Test]
-        public void NoBandConfigured_StopSpreadUnbounded()
-        {
-            // arrange - nothing to bound the gap with
-            var book = StopSpreadBook(new Security("GCZ6", SecurityType.Future, 10, 10));
-
-            // act
-            var events = book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(),
-                Side.Buy, 5, 1000, 160);
-
-            // assert
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        }
+        // assert
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
@@ -1,92 +1,90 @@
-﻿using System;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookProcessTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookProcessTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+
+    private static TestTimeProvider TimeProvider;
+    private static LevelTrackingOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+    }
 
-        private static TestTimeProvider TimeProvider;
-        private static LevelTrackingOrderBook Book;
+    [Test]
+    public void Process_CreateOrder_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-        [SetUp]
-        public void SetUp()
+        // act - only Price set, no TriggerPrice: this must rest as a plain working limit
+        // order, not get misrouted into the TriggerPrice slot as a hidden stop order
+        var events = Book.Process(new CreateLimitOrder
         {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
-        }
+            Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId1, OrderValidity = new OrderValidity.Day(),
+            Side = Side.Buy, Quantity = 3, Price = 100
+        });
 
-        [Test]
-        public void Process_CreateOrder_Success()
+        // assert
+        Assert.IsNotNull(events);
+        var created = events[0] as CreateOrderConfirmed;
+        Assert.IsNotNull(created);
+        Assert.AreEqual(OrderStatus.Working, created.Order.Status);
+        Assert.AreEqual(OrderType.Limit, created.Order.Type);
+        Assert.AreEqual(100, created.Order.Price);
+        Assert.IsNull(created.Order.TriggerPrice);
+        Assert.AreEqual(1, Book.GetLevels(Side.Buy, 10).Count);
+    }
+
+    [Test]
+    public void Process_UpdateOrder_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // act - only Price set, no TriggerPrice: this must actually reprice the order
+        var events = Book.Process(new UpdateOrder
         {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
+            Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId2, PreviousClientOrderId = OrderId1,
+            Price = 110
+        });
 
-            // act - only Price set, no TriggerPrice: this must rest as a plain working limit
-            // order, not get misrouted into the TriggerPrice slot as a hidden stop order
-            var events = Book.Process(new CreateLimitOrder
-            {
-                Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId1, OrderValidity = new OrderValidity.Day(),
-                Side = Side.Buy, Quantity = 3, Price = 100
-            });
+        // assert
+        Assert.IsNotNull(events);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(110, updated.Order.Price);
+        Assert.IsNull(updated.Order.TriggerPrice);
+    }
 
-            // assert
-            Assert.IsNotNull(events);
-            var created = events[0] as CreateOrderConfirmed;
-            Assert.IsNotNull(created);
-            Assert.AreEqual(OrderStatus.Working, created.Order.Status);
-            Assert.AreEqual(OrderType.Limit, created.Order.Type);
-            Assert.AreEqual(100, created.Order.Price);
-            Assert.IsNull(created.Order.TriggerPrice);
-            Assert.AreEqual(1, Book.GetLevels(Side.Buy, 10).Count);
-        }
-
-        [Test]
-        public void Process_UpdateOrder_Success()
+    [Test]
+    public void Process_CancelOrder_Success()
+    {
+        // act
+        Book.Process(new CancelOrder
         {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+            Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId3, PreviousClientOrderId = OrderId1
+        });
+    }
 
-            // act - only Price set, no TriggerPrice: this must actually reprice the order
-            var events = Book.Process(new UpdateOrder
-            {
-                Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId2, PreviousClientOrderId = OrderId1,
-                Price = 110
-            });
-
-            // assert
-            Assert.IsNotNull(events);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(110, updated.Order.Price);
-            Assert.IsNull(updated.Order.TriggerPrice);
-        }
-
-        [Test]
-        public void Process_CancelOrder_Success()
-        {
-            // act
-            Book.Process(new CancelOrder
-            {
-                Security = Sec, CompanyId = CompanyId1, ClientOrderId = OrderId3, PreviousClientOrderId = OrderId1
-            });
-        }
-
-        [Test]
-        public void Process_UpdateStatus_Success()
-        {
-            // act
-            Book.Process(new OpenTrading { Security = Sec });
-        }
+    [Test]
+    public void Process_UpdateStatus_Success()
+    {
+        // act
+        Book.Process(new OpenTrading { Security = Sec });
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
@@ -1,367 +1,365 @@
-using System;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookSelfTradePreventionTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookSelfTradePreventionTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+
+    private static readonly string Smp1 = "Smp1";
+    private static readonly string Smp2 = "Smp2";
+
+    private static TestTimeProvider TimeProvider;
+    private static LevelTrackingOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    [Test]
+    public void CancelResting_CancelsRestingOrder_AggressorContinuesMatching()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
+        // act - same SMP id as the first (older) resting sell, so that one is prevented and
+        // the aggressor should fall through to the second (different company) resting sell
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
 
-        private static readonly string Smp1 = "Smp1";
-        private static readonly string Smp2 = "Smp2";
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-        private static TestTimeProvider TimeProvider;
-        private static LevelTrackingOrderBook Book;
+        var cancelled = events[1] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
+        Assert.AreEqual(OrderId1, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(CompanyId1, cancelled.Order.CompanyId);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new LevelTrackingOrderBook(Sec, TimeProvider);
-        }
+        var matched = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(CompanyId1, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
 
-        [Test]
-        public void CancelResting_CancelsRestingOrder_AggressorContinuesMatching()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            TimeProvider.SetCurrentTime(Now3);
+        Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
 
-            // act - same SMP id as the first (older) resting sell, so that one is prevented and
-            // the aggressor should fall through to the second (different company) resting sell
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
+    [Test]
+    public void CancelAggressor_CancelsIncomingOrder_RestingOrderUntouched()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
 
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
 
-            var cancelled = events[1] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
-            Assert.AreEqual(OrderId1, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(CompanyId1, cancelled.Order.CompanyId);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-            var matched = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(CompanyId1, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        var cancelled = events[1] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
+        Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
 
-            Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
+        // the resting sell was never touched
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(100, sellLevels[0].Price);
+        Assert.AreEqual(5, sellLevels[0].Quantity);
+    }
 
-        [Test]
-        public void CancelAggressor_CancelsIncomingOrder_RestingOrderUntouched()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
+    [Test]
+    public void CancelBoth_CancelsBothOrders()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
 
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-            var cancelled = events[1] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
-            Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        var cancelledResting = events[1] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelledResting);
+        Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelledResting.Reason);
+        Assert.AreEqual(OrderId1, cancelledResting.Order.ClientOrderId);
 
-            // the resting sell was never touched
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(100, sellLevels[0].Price);
-            Assert.AreEqual(5, sellLevels[0].Quantity);
-        }
+        var cancelledAggressor = events[2] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelledAggressor);
+        Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelledAggressor.Reason);
+        Assert.AreEqual(OrderId2, cancelledAggressor.Order.ClientOrderId);
 
-        [Test]
-        public void CancelBoth_CancelsBothOrders()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
+        Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
+    [Test]
+    public void DifferentSelfMatchPreventionId_SameCompany_MatchesNormally()
+    {
+        // arrange - proves the check is id-based, not company-based: same CompanyId on both
+        // sides, but different SMP ids, so it should NOT be prevented
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp2);
 
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-            var cancelledResting = events[1] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelledResting);
-            Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelledResting.Reason);
-            Assert.AreEqual(OrderId1, cancelledResting.Order.ClientOrderId);
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(5, matched.Quantity);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+    }
 
-            var cancelledAggressor = events[2] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelledAggressor);
-            Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelledAggressor.Reason);
-            Assert.AreEqual(OrderId2, cancelledAggressor.Order.ClientOrderId);
+    [Test]
+    public void NeitherSideSetsId_MatchesNormally()
+    {
+        // arrange - same company, neither order opts into STP at all - confirms it's opt-in,
+        // not automatic for same-company orders
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-            Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
 
-        [Test]
-        public void DifferentSelfMatchPreventionId_SameCompany_MatchesNormally()
-        {
-            // arrange - proves the check is id-based, not company-based: same CompanyId on both
-            // sides, but different SMP ids, so it should NOT be prevented
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp2);
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(5, matched.Quantity);
+    }
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+    [Test]
+    public void IdSetOnBothSides_InstructionOmitted_DefaultsToCancelResting()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
 
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(5, matched.Quantity);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-        }
+        // act - neither side specifies an instruction
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
 
-        [Test]
-        public void NeitherSideSetsId_MatchesNormally()
-        {
-            // arrange - same company, neither order opts into STP at all - confirms it's opt-in,
-            // not automatic for same-company orders
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+        var cancelled = events[1] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
+        Assert.AreEqual(OrderId1, cancelled.Order.ClientOrderId);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        // the aggressor survives (CancelResting), still resting on the buy side
+        var buyLevels = Book.GetLevels(Side.Buy, 10);
+        Assert.AreEqual(1, buyLevels.Count);
+        Assert.AreEqual(100, buyLevels[0].Price);
+        Assert.AreEqual(5, buyLevels[0].Quantity);
+    }
 
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(5, matched.Quantity);
-        }
+    [Test]
+    public void OnlyRestingSetsInstruction_UsedAsFallback()
+    {
+        // arrange - the aggressor shares the SMP id but doesn't specify an instruction, so
+        // the resting order's instruction should govern
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
+        TimeProvider.SetCurrentTime(Now2);
 
-        [Test]
-        public void IdSetOnBothSides_InstructionOmitted_DefaultsToCancelResting()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
 
-            // act - neither side specifies an instruction
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+        Assert.IsInstanceOf<CancelOrderConfirmed>(events[1]);
+        Assert.IsInstanceOf<CancelOrderConfirmed>(events[2]);
+        Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
+    [Test]
+    public void ImmediateOrCancel_OnlyLiquidityIsSelfMatchPrevented_Rejected()
+    {
+        // arrange - the only resting liquidity shares the incoming order's SMP id, so it
+        // must be excluded from the upfront liquidity check rather than partially filled
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
 
-            var cancelled = events[1] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
-            Assert.AreEqual(OrderId1, cancelled.Order.ClientOrderId);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
 
-            // the aggressor survives (CancelResting), still resting on the buy side
-            var buyLevels = Book.GetLevels(Side.Buy, 10);
-            Assert.AreEqual(1, buyLevels.Count);
-            Assert.AreEqual(100, buyLevels[0].Price);
-            Assert.AreEqual(5, buyLevels[0].Quantity);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
 
-        [Test]
-        public void OnlyRestingSetsInstruction_UsedAsFallback()
-        {
-            // arrange - the aggressor shares the SMP id but doesn't specify an instruction, so
-            // the resting order's instruction should govern
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
-            TimeProvider.SetCurrentTime(Now2);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
+        // book is untouched - no partial fill leaked through
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(5, sellLevels[0].Quantity);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-            Assert.IsInstanceOf<CancelOrderConfirmed>(events[1]);
-            Assert.IsInstanceOf<CancelOrderConfirmed>(events[2]);
-            Assert.AreEqual(0, Book.GetLevels(Side.Sell, 10).Count);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
+    [Test]
+    public void ImmediateOrCancel_CancelResting_SkipsSelfMatchedOrder_CountsLiquidityBeyondIt()
+    {
+        // arrange - a self-matched order at the front of the queue, with real liquidity
+        // from a different company right behind it. CancelResting only kills the resting
+        // order, so the incoming order should keep going and see the liquidity behind it.
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-        [Test]
-        public void ImmediateOrCancel_OnlyLiquidityIsSelfMatchPrevented_Rejected()
-        {
-            // arrange - the only resting liquidity shares the incoming order's SMP id, so it
-            // must be excluded from the upfront liquidity check rather than partially filled
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
+        // assert - accepted: the 2@100 self-match is skipped, the 5@100 behind it is enough
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
+        var cancelled = events[1] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
+        Assert.AreEqual(OrderId1, cancelled.Order.ClientOrderId);
 
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
+        var matched = events[2] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(5, matched.Quantity);
+        Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+    }
 
-            // book is untouched - no partial fill leaked through
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(5, sellLevels[0].Quantity);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
+    [Test]
+    public void ImmediateOrCancel_CancelAggressor_StopsCountingAtSelfMatch_RejectedDespiteLaterLiquidity()
+    {
+        // arrange - same shape as above, but with CancelAggressor/CancelBoth the incoming
+        // order itself would be cancelled the instant it reaches the self-matched order, so
+        // it can never actually reach the 10@100 sitting right behind it. The liquidity
+        // check must reflect that and reject upfront, not just skip the self-matched
+        // quantity and keep counting past it.
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-        [Test]
-        public void ImmediateOrCancel_CancelResting_SkipsSelfMatchedOrder_CountsLiquidityBeyondIt()
-        {
-            // arrange - a self-matched order at the front of the queue, with real liquidity
-            // from a different company right behind it. CancelResting only kills the resting
-            // order, so the incoming order should keep going and see the liquidity behind it.
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            TimeProvider.SetCurrentTime(Now3);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
+        // assert - rejected: reachable liquidity before the self-match is 0, well short of 5,
+        // even though 10 more sits just behind it in the queue
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
 
-            // assert - accepted: the 2@100 self-match is skipped, the 5@100 behind it is enough
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
 
-            var cancelled = events[1] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
-            Assert.AreEqual(OrderId1, cancelled.Order.ClientOrderId);
+        // book is completely untouched - both resting orders survive, nothing was cancelled
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(1, sellLevels.Count);
+        Assert.AreEqual(100, sellLevels[0].Price);
+        Assert.AreEqual(12, sellLevels[0].Quantity);
+        Assert.AreEqual(2, sellLevels[0].Count);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
+    }
 
-            var matched = events[2] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(5, matched.Quantity);
-            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderId3, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-        }
+    [Test]
+    public void ImmediateOrCancel_CancelAggressor_StopsAtSelfMatch_AcrossPriceLevels_Rejected()
+    {
+        // arrange - the self-match sits at the best price level; genuine liquidity sits at
+        // the next (worse but still-crossing) price level. CancelAggressor kills the
+        // incoming order the instant it reaches the self-match, so it never gets to the
+        // second price level at all, no matter how much liquidity is sitting there.
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 110);
+        TimeProvider.SetCurrentTime(Now3);
 
-        [Test]
-        public void ImmediateOrCancel_CancelAggressor_StopsCountingAtSelfMatch_RejectedDespiteLaterLiquidity()
-        {
-            // arrange - same shape as above, but with CancelAggressor/CancelBoth the incoming
-            // order itself would be cancelled the instant it reaches the self-matched order, so
-            // it can never actually reach the 10@100 sitting right behind it. The liquidity
-            // check must reflect that and reject upfront, not just skip the self-matched
-            // quantity and keep counting past it.
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
-            TimeProvider.SetCurrentTime(Now3);
+        // act
+        var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 110, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
 
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
+        // assert - rejected: the self-match at 100 stops the search cold, so the 20 sitting
+        // at 110 is never even considered
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
 
-            // assert - rejected: reachable liquidity before the self-match is 0, well short of 5,
-            // even though 10 more sits just behind it in the queue
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
 
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
-
-            // book is completely untouched - both resting orders survive, nothing was cancelled
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(1, sellLevels.Count);
-            Assert.AreEqual(100, sellLevels[0].Price);
-            Assert.AreEqual(12, sellLevels[0].Quantity);
-            Assert.AreEqual(2, sellLevels[0].Count);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
-
-        [Test]
-        public void ImmediateOrCancel_CancelAggressor_StopsAtSelfMatch_AcrossPriceLevels_Rejected()
-        {
-            // arrange - the self-match sits at the best price level; genuine liquidity sits at
-            // the next (worse but still-crossing) price level. CancelAggressor kills the
-            // incoming order the instant it reaches the self-match, so it never gets to the
-            // second price level at all, no matter how much liquidity is sitting there.
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 110);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 110, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
-
-            // assert - rejected: the self-match at 100 stops the search cold, so the 20 sitting
-            // at 110 is never even considered
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-
-            var rejected = events[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.InsufficientLiquidityForMinQuantity, rejected.Reason);
-
-            // book is completely untouched - both price levels survive, nothing was cancelled
-            var sellLevels = Book.GetLevels(Side.Sell, 10);
-            Assert.AreEqual(2, sellLevels.Count);
-            Assert.AreEqual(100, sellLevels[0].Price);
-            Assert.AreEqual(2, sellLevels[0].Quantity);
-            Assert.AreEqual(110, sellLevels[1].Price);
-            Assert.AreEqual(20, sellLevels[1].Quantity);
-            Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
-        }
+        // book is completely untouched - both price levels survive, nothing was cancelled
+        var sellLevels = Book.GetLevels(Side.Sell, 10);
+        Assert.AreEqual(2, sellLevels.Count);
+        Assert.AreEqual(100, sellLevels[0].Price);
+        Assert.AreEqual(2, sellLevels[0].Quantity);
+        Assert.AreEqual(110, sellLevels[1].Price);
+        Assert.AreEqual(20, sellLevels[1].Quantity);
+        Assert.AreEqual(0, Book.GetLevels(Side.Buy, 10).Count);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
@@ -1,258 +1,255 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookStopTriggerTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookStopTriggerTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+    private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
+    private static readonly DateTime Now6 = new(2000, 1, 1, 12, 5, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+    private static readonly string CompanyId4 = "Company4";
+    private static readonly string CompanyId5 = "Company5";
+    private static readonly string CompanyId6 = "Company6";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+    private static readonly string OrderId6 = "Order6";
+    private static readonly string OrderId7 = "Order7";
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
-        private static readonly DateTime Now5 = new(2000, 1, 1, 12, 4, 0);
-        private static readonly DateTime Now6 = new(2000, 1, 1, 12, 5, 0);
+    [Test]
+    public void BuyStopLimit_TriggersAndMatchesWhenPriceRisesToTrigger_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-        private static readonly string CompanyId4 = "Company4";
-        private static readonly string CompanyId5 = "Company5";
-        private static readonly string CompanyId6 = "Company6";
+        TimeProvider.SetCurrentTime(Now3);
+        var restingOffer = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
-        private static readonly string OrderId6 = "Order6";
-        private static readonly string OrderId7 = "Order7";
+        TimeProvider.SetCurrentTime(Now4);
+        var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
+        Assert.AreEqual(1, stopEvents.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
+        Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
 
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        TimeProvider.SetCurrentTime(Now5);
+        var restingBid = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510); // to be hit
+        Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+        // act - trade at the trigger price
+        TimeProvider.SetCurrentTime(Now6);
+        var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
 
-        [Test]
-        public void BuyStopLimit_TriggersAndMatchesWhenPriceRisesToTrigger_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
+        // assert
+        var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 510);
+        Assert.IsNotNull(tradedAtTrigger, "expected a trade at the trigger price of 510");
 
-            TimeProvider.SetCurrentTime(Now3);
-            var restingOffer = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
+        var triggerConversion = events.OfType<UpdateOrderConfirmed>()
+            .FirstOrDefault(u => u.Order.ClientOrderId == OrderId4);
+        Assert.IsNotNull(triggerConversion, "expected the stop order to be converted to a working limit order");
+        Assert.AreEqual(OrderType.Limit, triggerConversion.Order.Type);
+        Assert.AreEqual(OrderStatus.Working, triggerConversion.Order.Status);
+        Assert.AreEqual(530, triggerConversion.Order.Price);
+        Assert.IsNull(triggerConversion.PreviousPrice,
+            "it was resting in the stops ladder, not the working book - this is an arrival, not a move");
 
-            TimeProvider.SetCurrentTime(Now4);
-            var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
-            Assert.AreEqual(1, stopEvents.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
-            Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
+        var tradedAtLimit = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 520);
+        Assert.IsNotNull(tradedAtLimit, "expected the newly triggered order to match against the resting offer at 520");
+        Assert.AreEqual(5, tradedAtLimit.Quantity);
+        Assert.IsTrue(tradedAtLimit.Fills.Any(f => f.Order.ClientOrderId == OrderId4 && f.Order.Status == OrderStatus.Filled));
+    }
 
-            TimeProvider.SetCurrentTime(Now5);
-            var restingBid = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510); // to be hit
-            Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
+    [Test]
+    public void SellStopLimit_TriggersAndMatchesWhenPriceFallsToTrigger_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-            // act - trade at the trigger price
-            TimeProvider.SetCurrentTime(Now6);
-            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
+        TimeProvider.SetCurrentTime(Now3);
+        var restingBid = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 480);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
 
-            // assert
-            var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 510);
-            Assert.IsNotNull(tradedAtTrigger, "expected a trade at the trigger price of 510");
+        TimeProvider.SetCurrentTime(Now4);
+        var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 470, 490);
+        Assert.AreEqual(1, stopEvents.Count);
+        Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
+        Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
 
-            var triggerConversion = events.OfType<UpdateOrderConfirmed>()
-                .FirstOrDefault(u => u.Order.ClientOrderId == OrderId4);
-            Assert.IsNotNull(triggerConversion, "expected the stop order to be converted to a working limit order");
-            Assert.AreEqual(OrderType.Limit, triggerConversion.Order.Type);
-            Assert.AreEqual(OrderStatus.Working, triggerConversion.Order.Status);
-            Assert.AreEqual(530, triggerConversion.Order.Price);
-            Assert.IsNull(triggerConversion.PreviousPrice,
-                "it was resting in the stops ladder, not the working book - this is an arrival, not a move");
+        TimeProvider.SetCurrentTime(Now5);
+        var restingOffer = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 490); // to be hit
+        Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
 
-            var tradedAtLimit = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 520);
-            Assert.IsNotNull(tradedAtLimit, "expected the newly triggered order to match against the resting offer at 520");
-            Assert.AreEqual(5, tradedAtLimit.Quantity);
-            Assert.IsTrue(tradedAtLimit.Fills.Any(f => f.Order.ClientOrderId == OrderId4 && f.Order.Status == OrderStatus.Filled));
-        }
+        // act - trade at the trigger price
+        TimeProvider.SetCurrentTime(Now6);
+        var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 2, 490);
 
-        [Test]
-        public void SellStopLimit_TriggersAndMatchesWhenPriceFallsToTrigger_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
+        // assert
+        var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 490);
+        Assert.IsNotNull(tradedAtTrigger, "expected a trade at the trigger price of 490");
 
-            TimeProvider.SetCurrentTime(Now3);
-            var restingBid = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 480);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
+        var triggerConversion = events.OfType<UpdateOrderConfirmed>()
+            .FirstOrDefault(u => u.Order.ClientOrderId == OrderId4);
+        Assert.IsNotNull(triggerConversion, "expected the stop order to be converted to a working limit order");
+        Assert.AreEqual(OrderType.Limit, triggerConversion.Order.Type);
+        Assert.AreEqual(OrderStatus.Working, triggerConversion.Order.Status);
+        Assert.AreEqual(470, triggerConversion.Order.Price);
 
-            TimeProvider.SetCurrentTime(Now4);
-            var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 470, 490);
-            Assert.AreEqual(1, stopEvents.Count);
-            Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
-            Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
+        var tradedAtLimit = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 480);
+        Assert.IsNotNull(tradedAtLimit, "expected the newly triggered order to match against the resting bid at 480");
+        Assert.AreEqual(5, tradedAtLimit.Quantity);
+        Assert.IsTrue(tradedAtLimit.Fills.Any(f => f.Order.ClientOrderId == OrderId4 && f.Order.Status == OrderStatus.Filled));
+    }
 
-            TimeProvider.SetCurrentTime(Now5);
-            var restingOffer = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 490); // to be hit
-            Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
+    [Test]
+    public void BuyStop_DoesNotTriggerWhenPriceMovesAwayFromTrigger_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-            // act - trade at the trigger price
-            TimeProvider.SetCurrentTime(Now6);
-            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 2, 490);
+        // buy stop above market: only triggers once price rises to/through 510
+        TimeProvider.SetCurrentTime(Now3);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 520, 510);
 
-            // assert
-            var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 490);
-            Assert.IsNotNull(tradedAtTrigger, "expected a trade at the trigger price of 490");
+        // act - trade at a lower price, moving further away from the trigger
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 490);
+        TimeProvider.SetCurrentTime(Now5);
+        var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 490);
 
-            var triggerConversion = events.OfType<UpdateOrderConfirmed>()
-                .FirstOrDefault(u => u.Order.ClientOrderId == OrderId4);
-            Assert.IsNotNull(triggerConversion, "expected the stop order to be converted to a working limit order");
-            Assert.AreEqual(OrderType.Limit, triggerConversion.Order.Type);
-            Assert.AreEqual(OrderStatus.Working, triggerConversion.Order.Status);
-            Assert.AreEqual(470, triggerConversion.Order.Price);
+        // assert
+        Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 490));
+        Assert.IsFalse(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
+            "the stop order should still be pending, not triggered, since price moved away from the trigger");
 
-            var tradedAtLimit = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 480);
-            Assert.IsNotNull(tradedAtLimit, "expected the newly triggered order to match against the resting bid at 480");
-            Assert.AreEqual(5, tradedAtLimit.Quantity);
-            Assert.IsTrue(tradedAtLimit.Fills.Any(f => f.Order.ClientOrderId == OrderId4 && f.Order.Status == OrderStatus.Filled));
-        }
+        // the stop can still be cancelled while pending, proving it's still tracked correctly
+        var cancelEvents = Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
+        var cancelled = cancelEvents.OfType<CancelOrderConfirmed>().FirstOrDefault();
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+    }
 
-        [Test]
-        public void BuyStop_DoesNotTriggerWhenPriceMovesAwayFromTrigger_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
+    [Test]
+    public void SellStop_DoesNotTriggerWhenPriceMovesAwayFromTrigger_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-            // buy stop above market: only triggers once price rises to/through 510
-            TimeProvider.SetCurrentTime(Now3);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 520, 510);
+        // sell stop below market: only triggers once price falls to/through 490
+        TimeProvider.SetCurrentTime(Now3);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 480, 490);
 
-            // act - trade at a lower price, moving further away from the trigger
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 490);
-            TimeProvider.SetCurrentTime(Now5);
-            var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 490);
+        // act - trade at a higher price, moving further away from the trigger
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 510);
+        TimeProvider.SetCurrentTime(Now5);
+        var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 510);
 
-            // assert
-            Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 490));
-            Assert.IsFalse(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
-                "the stop order should still be pending, not triggered, since price moved away from the trigger");
+        // assert
+        Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
+        Assert.IsFalse(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
+            "the stop order should still be pending, not triggered, since price moved away from the trigger");
 
-            // the stop can still be cancelled while pending, proving it's still tracked correctly
-            var cancelEvents = Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
-            var cancelled = cancelEvents.OfType<CancelOrderConfirmed>().FirstOrDefault();
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-        }
+        // the stop can still be cancelled while pending, proving it's still tracked correctly
+        var cancelEvents = Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
+        var cancelled = cancelEvents.OfType<CancelOrderConfirmed>().FirstOrDefault();
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+    }
 
-        [Test]
-        public void SellStop_DoesNotTriggerWhenPriceMovesAwayFromTrigger_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
+    [Test]
+    public void StopMarketOrder_CancelledWhenOpposingBookEmptyOnTrigger_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-            // sell stop below market: only triggers once price falls to/through 490
-            TimeProvider.SetCurrentTime(Now3);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 480, 490);
+        // buy stop market above market; when it triggers there must be resting sell orders for it to
+        // convert into a priced limit order - here there are none, so it should be cancelled, not throw
+        TimeProvider.SetCurrentTime(Now3);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 510);
 
-            // act - trade at a higher price, moving further away from the trigger
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 510);
-            TimeProvider.SetCurrentTime(Now5);
-            var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 510);
+        // act - trade at the trigger price with no resting sell orders left in the book afterwards
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 510);
+        TimeProvider.SetCurrentTime(Now5);
+        var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 510);
 
-            // assert
-            Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
-            Assert.IsFalse(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
-                "the stop order should still be pending, not triggered, since price moved away from the trigger");
+        // assert
+        Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
 
-            // the stop can still be cancelled while pending, proving it's still tracked correctly
-            var cancelEvents = Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
-            var cancelled = cancelEvents.OfType<CancelOrderConfirmed>().FirstOrDefault();
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-        }
+        var cancelled = events.OfType<CancelOrderConfirmed>().FirstOrDefault(c => c.Order.ClientOrderId == OrderId3);
+        Assert.IsNotNull(cancelled, "expected the triggered stop market order to be cancelled since the book was empty");
+        Assert.AreEqual(OrderCancelledReason.NoOrdersToMatchMarketOrder, cancelled.Reason);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
 
-        [Test]
-        public void StopMarketOrder_CancelledWhenOpposingBookEmptyOnTrigger_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
+        // an order id is a permanent identity once it completes - reuse is rejected, not silently
+        // accepted (see issue #1), and book state remains consistent either way
+        TimeProvider.SetCurrentTime(Now6);
+        var recreate = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 510);
+        var rejected = recreate[0] as CreateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(OrderRejectedReason.OrderIdAlreadyUsed, rejected.Reason);
+    }
 
-            // buy stop market above market; when it triggers there must be resting sell orders for it to
-            // convert into a priced limit order - here there are none, so it should be cancelled, not throw
-            TimeProvider.SetCurrentTime(Now3);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 510);
+    [Test]
+    public void MultipleBuyStops_AllTriggerWhenPriceGapsThroughTheirLevels_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-            // act - trade at the trigger price with no resting sell orders left in the book afterwards
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 510);
-            TimeProvider.SetCurrentTime(Now5);
-            var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 510);
+        TimeProvider.SetCurrentTime(Now3);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 530, 510);
 
-            // assert
-            Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
+        TimeProvider.SetCurrentTime(Now4);
+        Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 540, 520);
 
-            var cancelled = events.OfType<CancelOrderConfirmed>().FirstOrDefault(c => c.Order.ClientOrderId == OrderId3);
-            Assert.IsNotNull(cancelled, "expected the triggered stop market order to be cancelled since the book was empty");
-            Assert.AreEqual(OrderCancelledReason.NoOrdersToMatchMarketOrder, cancelled.Reason);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        TimeProvider.SetCurrentTime(Now5);
+        Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 520); // resting offer for the gap trade
 
-            // an order id is a permanent identity once it completes - reuse is rejected, not silently
-            // accepted (see issue #1), and book state remains consistent either way
-            TimeProvider.SetCurrentTime(Now6);
-            var recreate = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 510);
-            var rejected = recreate[0] as CreateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(OrderRejectedReason.OrderIdAlreadyUsed, rejected.Reason);
-        }
+        // act - price gaps straight from 500 to 520, passing through both trigger levels
+        TimeProvider.SetCurrentTime(Now6);
+        var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 520);
 
-        [Test]
-        public void MultipleBuyStops_AllTriggerWhenPriceGapsThroughTheirLevels_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
-
-            TimeProvider.SetCurrentTime(Now3);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 530, 510);
-
-            TimeProvider.SetCurrentTime(Now4);
-            Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 540, 520);
-
-            TimeProvider.SetCurrentTime(Now5);
-            Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 520); // resting offer for the gap trade
-
-            // act - price gaps straight from 500 to 520, passing through both trigger levels
-            TimeProvider.SetCurrentTime(Now6);
-            var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 520);
-
-            // assert
-            Assert.IsTrue(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
-                "the 510 trigger stop should have fired");
-            Assert.IsTrue(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId4),
-                "the 520 trigger stop should have fired");
-        }
+        // assert
+        Assert.IsTrue(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
+            "the 510 trigger stop should have fired");
+        Assert.IsTrue(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId4),
+            "the 520 trigger stop should have fired");
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
@@ -1,239 +1,236 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// An interruption that ends on its own, and the reason a consumer reads off the status change.
+[TestFixture]
+public class InMemoryOrderBookTimedResumeTests
 {
-    // An interruption that ends on its own, and the reason a consumer reads off the status change.
-    [TestFixture]
-    public class InMemoryOrderBookTimedResumeTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+
+    private TestTimeProvider TimeProvider;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+        TimeProvider = new TestTimeProvider(Now1);
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
+    // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it.
+    private IOrderBook PausingBook(TimeSpan? duration)
+    {
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, duration)});
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        return book;
+    }
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
+    // Drives the book into a volatility pause, leaving the two orders that caused it crossed
+    // and unfilled - the trade is prevented, not executed.
+    private void Breach(IOrderBook book)
+    {
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+    }
 
-        private TestTimeProvider TimeProvider;
+    [Test]
+    public void PauseWithDuration_ResumesOnceElapsed()
+    {
+        // arrange
+        var book = PausingBook(PauseFor);
+        Breach(book);
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
 
-        [SetUp]
-        public void SetUp()
+        // act
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        var events = book.AdvanceTime();
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        var resumed = events.OfType<StatusChanged>().Single();
+        Assert.AreEqual(OrderBookStatus.Open, resumed.Status);
+        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+    }
+
+    [Test]
+    public void PauseWithDuration_NotYetElapsed_StaysPaused()
+    {
+        // arrange
+        var book = PausingBook(PauseFor);
+        Breach(book);
+
+        // act - one second short
+        TimeProvider.SetCurrentTime(Now1 + PauseFor - TimeSpan.FromSeconds(1));
+        var events = book.AdvanceTime();
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        Assert.AreEqual(0, events.Count);
+    }
+
+    [Test]
+    public void PauseWithoutDuration_StandsUntilEndedExplicitly()
+    {
+        // arrange - no duration configured, which is the older open-ended behaviour
+        var book = PausingBook(null);
+        Breach(book);
+
+        // act - however long passes
+        TimeProvider.SetCurrentTime(Now1.AddDays(1));
+        var events = book.AdvanceTime();
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        Assert.AreEqual(0, events.Count);
+    }
+
+    [Test]
+    public void Resuming_PrintsWhatAccumulatedDuringThePause()
+    {
+        // arrange - the orders that caused the breach are still crossed and unfilled
+        var book = PausingBook(PauseFor);
+        Breach(book);
+
+        // act
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        var events = book.AdvanceTime();
+
+        // assert - the pause resolves into one uncrossing print rather than resuming mid-sweep
+        var matched = events.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(200, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+    }
+
+    [Test]
+    public void ResumeAlsoFiresOnOrdinaryOrderFlow_NotOnlyAdvanceTime()
+    {
+        // arrange - a book being traded should not need poking to notice its pause has run out
+        var book = PausingBook(PauseFor);
+        Breach(book);
+
+        // act
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        var events = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 90);
+
+        // assert - resumed first, so the order arrived into an open book
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
+            events.OfType<StatusChanged>().Single().Reason);
+        Assert.AreEqual(1, events.OfType<CreateOrderConfirmed>().Count());
+    }
+
+    [Test]
+    public void ExplicitTransitionDuringPause_CancelsThePendingResume()
+    {
+        // arrange - the session closes while a pause is still running
+        var book = PausingBook(PauseFor);
+        Breach(book);
+        book.CloseTrading();
+
+        // act - the deadline the pause had set comes and goes
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        var events = book.AdvanceTime();
+
+        // assert - a closed book must not spring back open
+        Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+        Assert.AreEqual(0, events.Count);
+    }
+
+    [Test]
+    public void AdvanceTime_WithNothingPending_DoesNothing()
+    {
+        // arrange
+        var book = PausingBook(PauseFor);
+
+        // act
+        TimeProvider.SetCurrentTime(Now1.AddDays(1));
+        var events = book.AdvanceTime();
+
+        // assert
+        Assert.AreEqual(0, events.Count);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void BreachReportsPriceRestriction_ExplicitTransitionReportsRequested()
+    {
+        // arrange
+        var book = PausingBook(PauseFor);
+
+        // act
+        var opened = book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+        var breached = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+
+        // assert
+        Assert.AreEqual(StatusChangeReason.Requested, opened.OfType<StatusChanged>().Single().Reason);
+        Assert.AreEqual(StatusChangeReason.PriceRestriction,
+            breached.OfType<StatusChanged>().Single().Reason);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void SeverestBreachWins_WhicheverOrderTheRestrictionsAreDeclaredIn(bool haltingFirst)
+    {
+        // arrange - two trade-scoped restrictions breached by the same price, disagreeing about
+        // what it costs. The severer must win either way round, so declaration order cannot be
+        // what decides whether a halt is served or shadowed by a pause.
+        var pausing = new AlwaysBreaches(RestrictionBreachAction.Pause, PauseFor);
+        var halting = new AlwaysBreaches(RestrictionBreachAction.Halt, null);
+        var restrictions = haltingFirst
+            ? new IPriceRestriction[] {halting, pausing}
+            : new IPriceRestriction[] {pausing, halting};
+
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10);
+        var book = new InMemoryOrderBook(security, TimeProvider, restrictions);
+        book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+
+        // and the halting restriction's own (absent) duration is the one that applies, so
+        // nothing resumes when the pausing restriction's would have elapsed
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        book.AdvanceTime();
+        Assert.AreEqual(OrderBookStatus.Halted, book.Status);
+    }
+
+    private sealed class AlwaysBreaches : IPriceRestriction
+    {
+        private readonly RestrictionBreachAction _action;
+        private readonly TimeSpan? _resumeAfter;
+
+        public AlwaysBreaches(RestrictionBreachAction action, TimeSpan? resumeAfter)
         {
-            TimeProvider = new TestTimeProvider(Now1);
+            _action = action;
+            _resumeAfter = resumeAfter;
         }
 
-        // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it.
-        private IOrderBook PausingBook(TimeSpan? duration)
-        {
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, duration)});
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            return book;
-        }
-
-        // Drives the book into a volatility pause, leaving the two orders that caused it crossed
-        // and unfilled - the trade is prevented, not executed.
-        private void Breach(IOrderBook book)
-        {
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
-        }
-
-        [Test]
-        public void PauseWithDuration_ResumesOnceElapsed()
-        {
-            // arrange
-            var book = PausingBook(PauseFor);
-            Breach(book);
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-
-            // act
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            var events = book.AdvanceTime();
-
-            // assert
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-            var resumed = events.OfType<StatusChanged>().Single();
-            Assert.AreEqual(OrderBookStatus.Open, resumed.Status);
-            Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
-        }
-
-        [Test]
-        public void PauseWithDuration_NotYetElapsed_StaysPaused()
-        {
-            // arrange
-            var book = PausingBook(PauseFor);
-            Breach(book);
-
-            // act - one second short
-            TimeProvider.SetCurrentTime(Now1 + PauseFor - TimeSpan.FromSeconds(1));
-            var events = book.AdvanceTime();
-
-            // assert
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-            Assert.AreEqual(0, events.Count);
-        }
-
-        [Test]
-        public void PauseWithoutDuration_StandsUntilEndedExplicitly()
-        {
-            // arrange - no duration configured, which is the older open-ended behaviour
-            var book = PausingBook(null);
-            Breach(book);
-
-            // act - however long passes
-            TimeProvider.SetCurrentTime(Now1.AddDays(1));
-            var events = book.AdvanceTime();
-
-            // assert
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-            Assert.AreEqual(0, events.Count);
-        }
-
-        [Test]
-        public void Resuming_PrintsWhatAccumulatedDuringThePause()
-        {
-            // arrange - the orders that caused the breach are still crossed and unfilled
-            var book = PausingBook(PauseFor);
-            Breach(book);
-
-            // act
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            var events = book.AdvanceTime();
-
-            // assert - the pause resolves into one uncrossing print rather than resuming mid-sweep
-            var matched = events.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(200, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-        }
-
-        [Test]
-        public void ResumeAlsoFiresOnOrdinaryOrderFlow_NotOnlyAdvanceTime()
-        {
-            // arrange - a book being traded should not need poking to notice its pause has run out
-            var book = PausingBook(PauseFor);
-            Breach(book);
-
-            // act
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            var events = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 90);
-
-            // assert - resumed first, so the order arrived into an open book
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-            Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
-                events.OfType<StatusChanged>().Single().Reason);
-            Assert.AreEqual(1, events.OfType<CreateOrderConfirmed>().Count());
-        }
-
-        [Test]
-        public void ExplicitTransitionDuringPause_CancelsThePendingResume()
-        {
-            // arrange - the session closes while a pause is still running
-            var book = PausingBook(PauseFor);
-            Breach(book);
-            book.CloseTrading();
-
-            // act - the deadline the pause had set comes and goes
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            var events = book.AdvanceTime();
-
-            // assert - a closed book must not spring back open
-            Assert.AreEqual(OrderBookStatus.Closed, book.Status);
-            Assert.AreEqual(0, events.Count);
-        }
-
-        [Test]
-        public void AdvanceTime_WithNothingPending_DoesNothing()
-        {
-            // arrange
-            var book = PausingBook(PauseFor);
-
-            // act
-            TimeProvider.SetCurrentTime(Now1.AddDays(1));
-            var events = book.AdvanceTime();
-
-            // assert
-            Assert.AreEqual(0, events.Count);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        }
-
-        [Test]
-        public void BreachReportsPriceRestriction_ExplicitTransitionReportsRequested()
-        {
-            // arrange
-            var book = PausingBook(PauseFor);
-
-            // act
-            var opened = book.UpdateStatus(OrderBookStatus.Open);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
-            var breached = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
-
-            // assert
-            Assert.AreEqual(StatusChangeReason.Requested, opened.OfType<StatusChanged>().Single().Reason);
-            Assert.AreEqual(StatusChangeReason.PriceRestriction,
-                breached.OfType<StatusChanged>().Single().Reason);
-        }
-
-        [TestCase(true)]
-        [TestCase(false)]
-        public void SeverestBreachWins_WhicheverOrderTheRestrictionsAreDeclaredIn(bool haltingFirst)
-        {
-            // arrange - two trade-scoped restrictions breached by the same price, disagreeing about
-            // what it costs. The severer must win either way round, so declaration order cannot be
-            // what decides whether a halt is served or shadowed by a pause.
-            var pausing = new AlwaysBreaches(RestrictionBreachAction.Pause, PauseFor);
-            var halting = new AlwaysBreaches(RestrictionBreachAction.Halt, null);
-            var restrictions = haltingFirst
-                ? new IPriceRestriction[] {halting, pausing}
-                : new IPriceRestriction[] {pausing, halting};
-
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-            var book = new InMemoryOrderBook(security, TimeProvider, restrictions);
-            book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
-
-            // assert
-            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
-
-            // and the halting restriction's own (absent) duration is the one that applies, so
-            // nothing resumes when the pausing restriction's would have elapsed
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            book.AdvanceTime();
-            Assert.AreEqual(OrderBookStatus.Halted, book.Status);
-        }
-
-        private sealed class AlwaysBreaches : IPriceRestriction
-        {
-            private readonly RestrictionBreachAction _action;
-            private readonly TimeSpan? _resumeAfter;
-
-            public AlwaysBreaches(RestrictionBreachAction action, TimeSpan? resumeAfter)
-            {
-                _action = action;
-                _resumeAfter = resumeAfter;
-            }
-
-            public RestrictionScope Scope => RestrictionScope.Trade;
-            public RestrictionBreachAction OnBreach => _action;
-            public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
-            public TimeSpan? ResumeAfter => _resumeAfter;
-            public bool Allows(long priceTicks, DateTime time) => false;
-            public bool AllowsStopSpread(long spreadTicks) => true;
-            public bool AllowsResumption(long priceTicks, DateTime time) => true;
-            public void OnTrade(long priceTicks, DateTime time) { }
-            public void OnSessionChange(long? referencePriceTicks) { }
-            public void OnIndicativePrice(long? priceTicks) { }
-        }
+        public RestrictionScope Scope => RestrictionScope.Trade;
+        public RestrictionBreachAction OnBreach => _action;
+        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
+        public TimeSpan? ResumeAfter => _resumeAfter;
+        public bool Allows(long priceTicks, DateTime time) => false;
+        public bool AllowsStopSpread(long spreadTicks) => true;
+        public bool AllowsResumption(long priceTicks, DateTime time) => true;
+        public void OnTrade(long priceTicks, DateTime time) { }
+        public void OnSessionChange(long? referencePriceTicks) { }
+        public void OnIndicativePrice(long? priceTicks) { }
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
@@ -1,1004 +1,1001 @@
-﻿using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookUpdateOrderTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookUpdateOrderTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+    private static readonly string OrderId4 = "Order4";
+    private static readonly string OrderId5 = "Order5";
+    private static readonly string OrderId6 = "Order6";
+    private static readonly string OrderId7 = "Order7";
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
-
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
-
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        private static readonly string OrderId4 = "Order4";
-        private static readonly string OrderId5 = "Order5";
-        private static readonly string OrderId6 = "Order6";
-        private static readonly string OrderId7 = "Order7";
-        
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
-
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
-        
-        [Test]
-        public void ExchangeOrderId_ChangesOnReprice_MatchingRealExchangeBehaviorForLostPriority()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
-                .OfType<CreateOrderConfirmed>().Single();
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act - reprice loses time priority, so ExchangeOrderId is re-derived (the order is
-            // functionally a new entry at the back of the queue), same as a real exchange's own
-            // drop-copy and public depth feed would both show
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: 110);
-
-            // assert
-            var updated = events.OfType<UpdateOrderConfirmed>().Single();
-            Assert.AreNotEqual(created.Order.ExchangeOrderId, updated.Order.ExchangeOrderId);
-            Assert.AreEqual(created.Order.ExchangeOrderId, updated.PreviousExchangeOrderId);
-            Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
-            Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
-            Assert.AreNotEqual(OrderId1, updated.Order.ClientOrderId);
-        }
-
-        [Test]
-        public void ExchangeOrderId_StaysConstantAcrossQuantityDecrease_WhichPreservesPriority()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100)
-                .OfType<CreateOrderConfirmed>().Single();
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act - a quantity decrease alone preserves time priority, so ExchangeOrderId must not change
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, newTotalQuantity: 3);
-
-            // assert
-            var updated = events.OfType<UpdateOrderConfirmed>().Single();
-            Assert.AreEqual(created.Order.ExchangeOrderId, updated.Order.ExchangeOrderId);
-            Assert.AreEqual(updated.Order.ExchangeOrderId, updated.PreviousExchangeOrderId);
-        }
-
-        [Test]
-        public void Reprice_SetsPreviousPriceAndPreviousQuantity()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: 110);
-
-            // assert
-            var updated = events.OfType<UpdateOrderConfirmed>().Single();
-            Assert.AreEqual(100, updated.PreviousPrice);
-            Assert.AreEqual(3, updated.PreviousQuantity);
-        }
-
-        [Test]
-        public void QuantityOnlyUpdate_PreviousPriceIsThePriceItStillRestsAt()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, newTotalQuantity: 8);
-
-            // assert
-            var updated = events.OfType<UpdateOrderConfirmed>().Single();
-            Assert.AreEqual(100, updated.PreviousPrice);
-            Assert.AreEqual(3, updated.PreviousQuantity);
-        }
-
-        [TestCase(5)]
-        [TestCase(1)]
-        public void LimitOrder_UpdateQuantity_Success(int quantity)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, quantity);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId1, updated.CompanyId);
-            Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId1, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
-            Assert.AreEqual(OrderType.Limit, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, updated.Order.Side);
-            Assert.AreEqual(100, updated.Order.Price);
-            Assert.IsNull(updated.Order.TriggerPrice);
-            Assert.AreEqual(quantity, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(quantity, updated.Order.RemainingQuantity);
-        }
-
-        [TestCase(5)]
-        [TestCase(1)]
-        public void StopOrder_UpdateQuantity_Success(int quantity)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, quantity);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId3, updated.CompanyId);
-            Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
-            Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, updated.Order.Side);
-            Assert.IsNull(updated.Order.Price);
-            Assert.AreEqual(110, updated.Order.TriggerPrice);
-            Assert.AreEqual(quantity, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(quantity, updated.Order.RemainingQuantity);
-        }
-        
-        [TestCase(Side.Buy, 110)]
-        [TestCase(Side.Buy, 90)]
-        [TestCase(Side.Sell, 110)]
-        [TestCase(Side.Sell, 90)]
-        public void LimitOrder_UpdatePrice_Success(Side side, decimal price)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: price);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId1, updated.CompanyId);
-            Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId1, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
-            Assert.AreEqual(OrderType.Limit, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(side, updated.Order.Side);
-            Assert.AreEqual(price, updated.Order.Price);
-            Assert.IsNull(updated.Order.TriggerPrice);
-            Assert.AreEqual(3, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(3, updated.Order.RemainingQuantity);
-        }
-        
-        [TestCase(Side.Buy, 130, 110, 120)]
-        [TestCase(Side.Buy, 130, 110, 140)]
-        [TestCase(Side.Sell, 70, 90, 60)]
-        [TestCase(Side.Sell, 70, 90, 80)]
-        public void StopOrder_UpdatePrice_Success(Side side, decimal price, decimal triggerPrice, decimal newPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, triggerPrice, triggerPrice);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: newPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId3, updated.CompanyId);
-            Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
-            Assert.AreEqual(OrderType.StopLimit, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(side, updated.Order.Side);
-            Assert.AreEqual(newPrice, updated.Order.Price);
-            Assert.AreEqual(triggerPrice, updated.Order.TriggerPrice);
-            Assert.AreEqual(3, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(3, updated.Order.RemainingQuantity);
-        }
-        
-        [TestCase(Side.Buy, 130, 120, 130)]
-        [TestCase(Side.Buy, 130, 120, 110)]
-        [TestCase(Side.Sell, 70, 80, 70)]
-        [TestCase(Side.Sell, 70, 80, 90)]
-        public void StopOrder_UpdateTriggerPrice_Success(Side side, decimal price, decimal triggerPrice,
-            decimal newTriggerPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, price, triggerPrice);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: newTriggerPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId3, updated.CompanyId);
-            Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
-            Assert.AreEqual(OrderType.StopLimit, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(side, updated.Order.Side);
-            Assert.AreEqual(price, updated.Order.Price);
-            Assert.AreEqual(newTriggerPrice, updated.Order.TriggerPrice);
-            Assert.AreEqual(3, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(3, updated.Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void LimitOrder_UpdateTriggerPrice_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, triggerPrice: 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId1, updated.CompanyId);
-            Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId1, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
-            Assert.AreEqual(OrderType.Limit, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, updated.Order.Side);
-            Assert.AreEqual(100, updated.Order.Price);
-            Assert.IsNull(updated.Order.TriggerPrice);
-            Assert.AreEqual(3, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(3, updated.Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void UpdateStopMarketOrder_IncreaseQuantity_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId3, updated.CompanyId);
-            Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
-            Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, updated.Order.Side);
-            Assert.IsNull(updated.Order.Price);
-            Assert.AreEqual(110, updated.Order.TriggerPrice);
-            Assert.AreEqual(5, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(5, updated.Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void UpdateStopMarketOrder_DecreaseQuantity_Success()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 90);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 1);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(Sec, updated.Security);
-            Assert.AreEqual(Now2, updated.Time);
-            Assert.AreEqual(CompanyId3, updated.CompanyId);
-            Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
-            Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
-            Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
-            Assert.AreEqual(Sec, updated.Order.Security);
-            Assert.AreEqual(Now1, updated.Order.CreatedTime);
-            Assert.AreEqual(Now2, updated.Order.ModifiedTime);
-            Assert.IsNull(updated.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
-            Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, updated.Order.Side);
-            Assert.IsNull(updated.Order.Price);
-            Assert.AreEqual(90, updated.Order.TriggerPrice);
-            Assert.AreEqual(1, updated.Order.Quantity);
-            Assert.AreEqual(0, updated.Order.FilledQuantity);
-            Assert.AreEqual(1, updated.Order.RemainingQuantity);
-        }
-        
-        [Test]
-        public void DecreaseQuantityBelowFilled_Cancelled()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 2, 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var cancelled = events[0] as CancelOrderConfirmed;
-            Assert.IsNotNull(cancelled);
-            Assert.AreEqual(Sec, cancelled.Security);
-            Assert.AreEqual(Now2, cancelled.Time);
-            Assert.AreEqual(CompanyId1, cancelled.CompanyId);
-            Assert.AreEqual(OrderId1, cancelled.PreviousClientOrderId);
-            Assert.AreEqual(OrderCancelledReason.UpdatedQuantityLowerThanFilledQuantity, cancelled.Reason);
-            Assert.AreEqual(CompanyId1, cancelled.Order.CompanyId);
-            Assert.AreEqual(OrderId4, cancelled.Order.ClientOrderId);
-            Assert.AreEqual(Sec, cancelled.Order.Security);
-            Assert.AreEqual(Now1, cancelled.Order.CreatedTime);
-            Assert.AreEqual(Now1, cancelled.Order.ModifiedTime);
-            Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
-            Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, cancelled.Order.Side);
-            Assert.AreEqual(100, cancelled.Order.Price);
-            Assert.IsNull(cancelled.Order.TriggerPrice);
-            Assert.AreEqual(5, cancelled.Order.Quantity);
-            Assert.AreEqual(4, cancelled.Order.FilledQuantity);
-            Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void UpdateQuantityAfterPartialFill_RemainingReflectsNewTotalMinusFilled()
-        {
-            // arrange - quantity on UpdateOrder is the order's new TOTAL size (filled + remaining),
-            // not the new remaining/resting amount (see issue #1, finding 2)
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 10, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 100); // partial fill: 4@100
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            var updated = events[0] as UpdateOrderConfirmed;
-            Assert.IsNotNull(updated);
-            Assert.AreEqual(6, updated.Order.Quantity);
-            Assert.AreEqual(4, updated.Order.FilledQuantity);
-            Assert.AreEqual(2, updated.Order.RemainingQuantity);
-
-            // a follow-up buy for the full new total should only find the 2 that remain
-            var matched = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 6, 110)
-                .OfType<OrdersMatched>().Single();
-            Assert.AreEqual(2, matched.Quantity);
-        }
-
-        [Test]
-        public void MatchAgainstOrderByTime()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 80);
-            TimeProvider.SetCurrentTime(Now3);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 3, 70);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now3, matched.Time);
-            Assert.AreEqual(80, matched.Price);
-            Assert.AreEqual(3, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
-
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(80, matched.Fills[0].Price);
-            Assert.AreEqual(3, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
-            Assert.IsNull(matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(80, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
-
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId4, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(80, matched.Fills[1].Price);
-            Assert.AreEqual(3, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId4, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(70, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
-
-        [Test]
-        public void MarketClosed_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.UpdateStatus(OrderBookStatus.Closed);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, null, 105, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.MarketClosed, rejected.Reason);
-            Assert.IsNull(rejected.ExchangeOrderId, "rejected before the order was ever looked up");
-        }
-
-        [Test]
-        public void NoChange_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.NoChange, rejected.Reason);
-        }
-
-        [TestCase(0)]
-        [TestCase(-1)]
-        public void InvalidQuantity_Rejected(int quantity)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, quantity, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.InvalidQuantity, rejected.Reason);
-        }
-
-        [TestCase(8)]
-        [TestCase(-8)]
-        [TestCase(-108)]
-        [TestCase(10.01)]
-        public void InvalidPriceIncrement_Rejected(decimal price)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, 100);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, price);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
-        }
-
-        [TestCase(8)]
-        [TestCase(-8)]
-        [TestCase(-108)]
-        [TestCase(10.01)]
-        public void InvalidTriggerPriceIncrement_Rejected(decimal triggerPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, 100);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, null, triggerPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
-        }
-
-        [Test]
-        public void Filled_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
-                .OfType<CreateOrderConfirmed>().Single();
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 5, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now2, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
-            Assert.AreEqual(created.Order.ExchangeOrderId, rejected.ExchangeOrderId,
-                "the order was found (and is now filled), so its ExchangeOrderId is known");
-        }
-
-        [Test]
-        public void LimitOrder_Cancelled_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CancelOrder(CompanyId1, OrderId6, OrderId1);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId6, 5, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now2, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId6, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
-        }
-
-        [Test]
-        public void LimitOrder_Expired_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.UpdateStatus(OrderBookStatus.Closed);
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 5, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
-        }
-
-        [Test]
-        public void StopOrder_Cancelled_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
-            TimeProvider.SetCurrentTime(Now2);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId7, 5);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now2, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId7, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
-        }
-
-        [Test]
-        public void StopOrder_Expired_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
-            Book.UpdateStatus(OrderBookStatus.Closed);
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 5, null, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
-        }
-        
-        // TODO: trigger stop order cancelled + expired
-        
-        [Test]
-        public void NotFound_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 5, 110);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId1, rejected.CompanyId);
-            Assert.AreEqual(OrderId4, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.OrderNotInBook, rejected.Reason);
-        }
-        
-        [Test]
-        public void UpdateTriggerPrice_TriggerPriceMustBeLessThanPrice_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 100);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: 120);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanPrice, rejected.Reason);
-        }
-
-        [Test]
-        public void UpdateTriggerPrice_TriggerPriceMustBeGreaterThanPrice_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 80);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: 60);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, rejected.Reason);
-        }
-
-        [Test]
-        public void UpdatePrice_TriggerPriceMustBeLessThanPrice_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 110);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: 100);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanPrice, rejected.Reason);
-        }
-
-        [Test]
-        public void UpdatePrice_TriggerPriceMustBeGreaterThanPrice_Rejected()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 70);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: 80);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, rejected.Reason);
-        }
-
-        [TestCase(90)]
-        [TestCase(100)]
-        public void StopOrder_TriggerPriceMustBeLessThanLastTraded_Rejected(decimal triggerPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 70);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: triggerPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, rejected.Reason);
-        }
-
-        [TestCase(90)]
-        [TestCase(80)]
-        public void StopOrder_TriggerPriceMustBeGreaterThanLastTraded_Rejected(decimal triggerPrice)
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
-            Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 110);
-
-            // act
-            var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: triggerPrice);
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var rejected = events[0] as UpdateOrderRejected;
-            Assert.IsNotNull(rejected);
-            Assert.AreEqual(Sec, rejected.Security);
-            Assert.AreEqual(Now1, rejected.Time);
-            Assert.AreEqual(CompanyId3, rejected.CompanyId);
-            Assert.AreEqual(OrderId5, rejected.ClientOrderId);
-            Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
-            Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, rejected.Reason);
-        }
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
+
+    [Test]
+    public void ExchangeOrderId_ChangesOnReprice_MatchingRealExchangeBehaviorForLostPriority()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
+            .OfType<CreateOrderConfirmed>().Single();
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act - reprice loses time priority, so ExchangeOrderId is re-derived (the order is
+        // functionally a new entry at the back of the queue), same as a real exchange's own
+        // drop-copy and public depth feed would both show
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: 110);
+
+        // assert
+        var updated = events.OfType<UpdateOrderConfirmed>().Single();
+        Assert.AreNotEqual(created.Order.ExchangeOrderId, updated.Order.ExchangeOrderId);
+        Assert.AreEqual(created.Order.ExchangeOrderId, updated.PreviousExchangeOrderId);
+        Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
+        Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
+        Assert.AreNotEqual(OrderId1, updated.Order.ClientOrderId);
+    }
+
+    [Test]
+    public void ExchangeOrderId_StaysConstantAcrossQuantityDecrease_WhichPreservesPriority()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100)
+            .OfType<CreateOrderConfirmed>().Single();
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act - a quantity decrease alone preserves time priority, so ExchangeOrderId must not change
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, newTotalQuantity: 3);
+
+        // assert
+        var updated = events.OfType<UpdateOrderConfirmed>().Single();
+        Assert.AreEqual(created.Order.ExchangeOrderId, updated.Order.ExchangeOrderId);
+        Assert.AreEqual(updated.Order.ExchangeOrderId, updated.PreviousExchangeOrderId);
+    }
+
+    [Test]
+    public void Reprice_SetsPreviousPriceAndPreviousQuantity()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: 110);
+
+        // assert
+        var updated = events.OfType<UpdateOrderConfirmed>().Single();
+        Assert.AreEqual(100, updated.PreviousPrice);
+        Assert.AreEqual(3, updated.PreviousQuantity);
+    }
+
+    [Test]
+    public void QuantityOnlyUpdate_PreviousPriceIsThePriceItStillRestsAt()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, newTotalQuantity: 8);
+
+        // assert
+        var updated = events.OfType<UpdateOrderConfirmed>().Single();
+        Assert.AreEqual(100, updated.PreviousPrice);
+        Assert.AreEqual(3, updated.PreviousQuantity);
+    }
+
+    [TestCase(5)]
+    [TestCase(1)]
+    public void LimitOrder_UpdateQuantity_Success(int quantity)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, quantity);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId1, updated.CompanyId);
+        Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId1, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
+        Assert.AreEqual(OrderType.Limit, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, updated.Order.Side);
+        Assert.AreEqual(100, updated.Order.Price);
+        Assert.IsNull(updated.Order.TriggerPrice);
+        Assert.AreEqual(quantity, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(quantity, updated.Order.RemainingQuantity);
+    }
+
+    [TestCase(5)]
+    [TestCase(1)]
+    public void StopOrder_UpdateQuantity_Success(int quantity)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, quantity);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId3, updated.CompanyId);
+        Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
+        Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, updated.Order.Side);
+        Assert.IsNull(updated.Order.Price);
+        Assert.AreEqual(110, updated.Order.TriggerPrice);
+        Assert.AreEqual(quantity, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(quantity, updated.Order.RemainingQuantity);
+    }
+
+    [TestCase(Side.Buy, 110)]
+    [TestCase(Side.Buy, 90)]
+    [TestCase(Side.Sell, 110)]
+    [TestCase(Side.Sell, 90)]
+    public void LimitOrder_UpdatePrice_Success(Side side, decimal price)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: price);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId1, updated.CompanyId);
+        Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId1, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
+        Assert.AreEqual(OrderType.Limit, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(side, updated.Order.Side);
+        Assert.AreEqual(price, updated.Order.Price);
+        Assert.IsNull(updated.Order.TriggerPrice);
+        Assert.AreEqual(3, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(3, updated.Order.RemainingQuantity);
+    }
+
+    [TestCase(Side.Buy, 130, 110, 120)]
+    [TestCase(Side.Buy, 130, 110, 140)]
+    [TestCase(Side.Sell, 70, 90, 60)]
+    [TestCase(Side.Sell, 70, 90, 80)]
+    public void StopOrder_UpdatePrice_Success(Side side, decimal price, decimal triggerPrice, decimal newPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, triggerPrice, triggerPrice);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: newPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId3, updated.CompanyId);
+        Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
+        Assert.AreEqual(OrderType.StopLimit, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(side, updated.Order.Side);
+        Assert.AreEqual(newPrice, updated.Order.Price);
+        Assert.AreEqual(triggerPrice, updated.Order.TriggerPrice);
+        Assert.AreEqual(3, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(3, updated.Order.RemainingQuantity);
+    }
+
+    [TestCase(Side.Buy, 130, 120, 130)]
+    [TestCase(Side.Buy, 130, 120, 110)]
+    [TestCase(Side.Sell, 70, 80, 70)]
+    [TestCase(Side.Sell, 70, 80, 90)]
+    public void StopOrder_UpdateTriggerPrice_Success(Side side, decimal price, decimal triggerPrice,
+        decimal newTriggerPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, price, triggerPrice);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: newTriggerPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId3, updated.CompanyId);
+        Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
+        Assert.AreEqual(OrderType.StopLimit, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(side, updated.Order.Side);
+        Assert.AreEqual(price, updated.Order.Price);
+        Assert.AreEqual(newTriggerPrice, updated.Order.TriggerPrice);
+        Assert.AreEqual(3, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(3, updated.Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void LimitOrder_UpdateTriggerPrice_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, triggerPrice: 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId1, updated.CompanyId);
+        Assert.AreEqual(OrderId1, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId1, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId4, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, updated.Order.Status);
+        Assert.AreEqual(OrderType.Limit, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, updated.Order.Side);
+        Assert.AreEqual(100, updated.Order.Price);
+        Assert.IsNull(updated.Order.TriggerPrice);
+        Assert.AreEqual(3, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(3, updated.Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void UpdateStopMarketOrder_IncreaseQuantity_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId3, updated.CompanyId);
+        Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
+        Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, updated.Order.Side);
+        Assert.IsNull(updated.Order.Price);
+        Assert.AreEqual(110, updated.Order.TriggerPrice);
+        Assert.AreEqual(5, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(5, updated.Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void UpdateStopMarketOrder_DecreaseQuantity_Success()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 90);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 1);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(Sec, updated.Security);
+        Assert.AreEqual(Now2, updated.Time);
+        Assert.AreEqual(CompanyId3, updated.CompanyId);
+        Assert.AreEqual(OrderId3, updated.PreviousClientOrderId);
+        Assert.AreEqual(CompanyId3, updated.Order.CompanyId);
+        Assert.AreEqual(OrderId5, updated.Order.ClientOrderId);
+        Assert.AreEqual(Sec, updated.Order.Security);
+        Assert.AreEqual(Now1, updated.Order.CreatedTime);
+        Assert.AreEqual(Now2, updated.Order.ModifiedTime);
+        Assert.IsNull(updated.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Hidden, updated.Order.Status);
+        Assert.AreEqual(OrderType.StopMarket, updated.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), updated.Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, updated.Order.Side);
+        Assert.IsNull(updated.Order.Price);
+        Assert.AreEqual(90, updated.Order.TriggerPrice);
+        Assert.AreEqual(1, updated.Order.Quantity);
+        Assert.AreEqual(0, updated.Order.FilledQuantity);
+        Assert.AreEqual(1, updated.Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void DecreaseQuantityBelowFilled_Cancelled()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 2, 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var cancelled = events[0] as CancelOrderConfirmed;
+        Assert.IsNotNull(cancelled);
+        Assert.AreEqual(Sec, cancelled.Security);
+        Assert.AreEqual(Now2, cancelled.Time);
+        Assert.AreEqual(CompanyId1, cancelled.CompanyId);
+        Assert.AreEqual(OrderId1, cancelled.PreviousClientOrderId);
+        Assert.AreEqual(OrderCancelledReason.UpdatedQuantityLowerThanFilledQuantity, cancelled.Reason);
+        Assert.AreEqual(CompanyId1, cancelled.Order.CompanyId);
+        Assert.AreEqual(OrderId4, cancelled.Order.ClientOrderId);
+        Assert.AreEqual(Sec, cancelled.Order.Security);
+        Assert.AreEqual(Now1, cancelled.Order.CreatedTime);
+        Assert.AreEqual(Now1, cancelled.Order.ModifiedTime);
+        Assert.AreEqual(Now2, cancelled.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
+        Assert.AreEqual(OrderType.Limit, cancelled.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), cancelled.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, cancelled.Order.Side);
+        Assert.AreEqual(100, cancelled.Order.Price);
+        Assert.IsNull(cancelled.Order.TriggerPrice);
+        Assert.AreEqual(5, cancelled.Order.Quantity);
+        Assert.AreEqual(4, cancelled.Order.FilledQuantity);
+        Assert.AreEqual(0, cancelled.Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void UpdateQuantityAfterPartialFill_RemainingReflectsNewTotalMinusFilled()
+    {
+        // arrange - quantity on UpdateOrder is the order's new TOTAL size (filled + remaining),
+        // not the new remaining/resting amount (see issue #1, finding 2)
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 10, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 100); // partial fill: 4@100
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        var updated = events[0] as UpdateOrderConfirmed;
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(6, updated.Order.Quantity);
+        Assert.AreEqual(4, updated.Order.FilledQuantity);
+        Assert.AreEqual(2, updated.Order.RemainingQuantity);
+
+        // a follow-up buy for the full new total should only find the 2 that remain
+        var matched = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 6, 110)
+            .OfType<OrdersMatched>().Single();
+        Assert.AreEqual(2, matched.Quantity);
+    }
+
+    [Test]
+    public void MatchAgainstOrderByTime()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 80);
+        TimeProvider.SetCurrentTime(Now3);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 3, 70);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
+
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now3, matched.Time);
+        Assert.AreEqual(80, matched.Price);
+        Assert.AreEqual(3, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
+
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(80, matched.Fills[0].Price);
+        Assert.AreEqual(3, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[0].Order.ModifiedTime);
+        Assert.IsNull(matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Working, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(80, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(2, matched.Fills[0].Order.RemainingQuantity);
+
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId4, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(80, matched.Fills[1].Price);
+        Assert.AreEqual(3, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId4, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(70, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(3, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(3, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
+
+    [Test]
+    public void MarketClosed_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.UpdateStatus(OrderBookStatus.Closed);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, null, 105, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.MarketClosed, rejected.Reason);
+        Assert.IsNull(rejected.ExchangeOrderId, "rejected before the order was ever looked up");
+    }
+
+    [Test]
+    public void NoChange_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.NoChange, rejected.Reason);
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void InvalidQuantity_Rejected(int quantity)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, quantity, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.InvalidQuantity, rejected.Reason);
+    }
+
+    [TestCase(8)]
+    [TestCase(-8)]
+    [TestCase(-108)]
+    [TestCase(10.01)]
+    public void InvalidPriceIncrement_Rejected(decimal price)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, 100);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, price);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
+    }
+
+    [TestCase(8)]
+    [TestCase(-8)]
+    [TestCase(-108)]
+    [TestCase(10.01)]
+    public void InvalidTriggerPriceIncrement_Rejected(decimal triggerPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateStopMarketOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 6, 100);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, null, triggerPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.InvalidPriceIncrement, rejected.Reason);
+    }
+
+    [Test]
+    public void Filled_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
+            .OfType<CreateOrderConfirmed>().Single();
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 5, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now2, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
+        Assert.AreEqual(created.Order.ExchangeOrderId, rejected.ExchangeOrderId,
+            "the order was found (and is now filled), so its ExchangeOrderId is known");
+    }
+
+    [Test]
+    public void LimitOrder_Cancelled_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CancelOrder(CompanyId1, OrderId6, OrderId1);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId6, 5, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now2, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId6, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
+    }
+
+    [Test]
+    public void LimitOrder_Expired_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.UpdateStatus(OrderBookStatus.Closed);
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 5, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
+    }
+
+    [Test]
+    public void StopOrder_Cancelled_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
+        TimeProvider.SetCurrentTime(Now2);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId7, 5);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now2, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId7, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
+    }
+
+    [Test]
+    public void StopOrder_Expired_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
+        Book.UpdateStatus(OrderBookStatus.Closed);
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 5, null, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TooLateToCancel, rejected.Reason);
+    }
+
+    // TODO: trigger stop order cancelled + expired
+
+    [Test]
+    public void NotFound_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 5, 110);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId1, rejected.CompanyId);
+        Assert.AreEqual(OrderId4, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId1, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.OrderNotInBook, rejected.Reason);
+    }
+
+    [Test]
+    public void UpdateTriggerPrice_TriggerPriceMustBeLessThanPrice_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 100);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: 120);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanPrice, rejected.Reason);
+    }
+
+    [Test]
+    public void UpdateTriggerPrice_TriggerPriceMustBeGreaterThanPrice_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 80);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: 60);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, rejected.Reason);
+    }
+
+    [Test]
+    public void UpdatePrice_TriggerPriceMustBeLessThanPrice_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 110);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: 100);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanPrice, rejected.Reason);
+    }
+
+    [Test]
+    public void UpdatePrice_TriggerPriceMustBeGreaterThanPrice_Rejected()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 70);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: 80);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, rejected.Reason);
+    }
+
+    [TestCase(90)]
+    [TestCase(100)]
+    public void StopOrder_TriggerPriceMustBeLessThanLastTraded_Rejected(decimal triggerPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 70, 70);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: triggerPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, rejected.Reason);
+    }
+
+    [TestCase(90)]
+    [TestCase(80)]
+    public void StopOrder_TriggerPriceMustBeGreaterThanLastTraded_Rejected(decimal triggerPrice)
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 90);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
+        Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110, 110);
+
+        // act
+        var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: triggerPrice);
+
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var rejected = events[0] as UpdateOrderRejected;
+        Assert.IsNotNull(rejected);
+        Assert.AreEqual(Sec, rejected.Security);
+        Assert.AreEqual(Now1, rejected.Time);
+        Assert.AreEqual(CompanyId3, rejected.CompanyId);
+        Assert.AreEqual(OrderId5, rejected.ClientOrderId);
+        Assert.AreEqual(OrderId3, rejected.PreviousClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, rejected.Reason);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
@@ -1,320 +1,318 @@
-﻿using System;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class InMemoryOrderBookUpdateStateTests
 {
-    [TestFixture]
-    public class InMemoryOrderBookUpdateStateTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+    private static readonly string CompanyId3 = "Company3";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+    private static readonly string OrderId3 = "Order3";
+
+    private static TestTimeProvider TimeProvider;
+    private static IOrderBook Book;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        TimeProvider = new TestTimeProvider(Now1);
+        Book = new InMemoryOrderBook(Sec, TimeProvider);
+    }
 
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
-        private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
-        
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-        private static readonly string CompanyId3 = "Company3";
+    [TestCase(OrderBookStatus.PreOpen)]
+    [TestCase(OrderBookStatus.Open)]
+    [TestCase(OrderBookStatus.Closed)]
+    [TestCase(OrderBookStatus.Paused)]
+    [TestCase(OrderBookStatus.Halted)]
+    public void Valid_Success(OrderBookStatus status)
+    {
+        // act
+        var events = Book.UpdateStatus(status);
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
-        private static readonly string OrderId3 = "Order3";
-        
-        private static TestTimeProvider TimeProvider;
-        private static IOrderBook Book;
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
+        var statusChanged = events[0] as StatusChanged;
+        Assert.IsNotNull(statusChanged);
+        Assert.AreEqual(Sec, statusChanged.Security);
+        Assert.AreEqual(status, statusChanged.Status);
+        Assert.AreEqual(Now1, statusChanged.Time);
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-            Book = new InMemoryOrderBook(Sec, TimeProvider);
-        }
+    [Test]
+    public void Open_MatchPreOpenOrders()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        TimeProvider.SetCurrentTime(Now3);
 
-        [TestCase(OrderBookStatus.PreOpen)]
-        [TestCase(OrderBookStatus.Open)]
-        [TestCase(OrderBookStatus.Closed)]
-        [TestCase(OrderBookStatus.Paused)]
-        [TestCase(OrderBookStatus.Halted)]
-        public void Valid_Success(OrderBookStatus status)
-        {
-            // act
-            var events = Book.UpdateStatus(status);
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Open);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
-            var statusChanged = events[0] as StatusChanged;
-            Assert.IsNotNull(statusChanged);
-            Assert.AreEqual(Sec, statusChanged.Security);
-            Assert.AreEqual(status, statusChanged.Status);
-            Assert.AreEqual(Now1, statusChanged.Time);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(3, events.Count);
+        var withdrawn = events[2] as IndicativePriceChanged;
+        Assert.IsNotNull(withdrawn);
+        Assert.IsNull(withdrawn.Price, "the auction it was quoting has printed");
+        var matched = events[1] as OrdersMatched;
+        Assert.IsNotNull(matched);
+        Assert.AreEqual(Sec, matched.Security);
+        Assert.AreEqual(Now3, matched.Time);
+        Assert.AreEqual(100, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+        Assert.IsNotNull(matched.Fills);
+        Assert.AreEqual(2, matched.Fills.Count);
 
-        [Test]
-        public void Open_MatchPreOpenOrders()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            TimeProvider.SetCurrentTime(Now3);
+        Assert.AreEqual(Sec, matched.Fills[0].Security);
+        Assert.AreEqual(Now3, matched.Fills[0].Time);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
+        Assert.AreEqual(100, matched.Fills[0].Price);
+        Assert.AreEqual(5, matched.Fills[0].Quantity);
+        Assert.AreEqual(true, matched.Fills[0].IsResting);
+        Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
+        Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
+        Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched.Fills[0].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
+        Assert.AreEqual(100, matched.Fills[0].Order.Price);
+        Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
+        Assert.AreEqual(5, matched.Fills[0].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
 
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Open);
+        Assert.AreEqual(Sec, matched.Fills[1].Security);
+        Assert.AreEqual(Now3, matched.Fills[1].Time);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
+        Assert.AreEqual(100, matched.Fills[1].Price);
+        Assert.AreEqual(5, matched.Fills[1].Quantity);
+        Assert.AreEqual(false, matched.Fills[1].IsResting);
+        Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
+        Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
+        Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
+        Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
+        Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
+        Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
+        Assert.AreEqual(100, matched.Fills[1].Order.Price);
+        Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
+        Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
+        Assert.AreEqual(5, matched.Fills[1].Order.FilledQuantity);
+        Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
+    }
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(3, events.Count);
-            var withdrawn = events[2] as IndicativePriceChanged;
-            Assert.IsNotNull(withdrawn);
-            Assert.IsNull(withdrawn.Price, "the auction it was quoting has printed");
-            var matched = events[1] as OrdersMatched;
-            Assert.IsNotNull(matched);
-            Assert.AreEqual(Sec, matched.Security);
-            Assert.AreEqual(Now3, matched.Time);
-            Assert.AreEqual(100, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-            Assert.IsNotNull(matched.Fills);
-            Assert.AreEqual(2, matched.Fills.Count);
+    [Test]
+    public void Closed_ExpireDayLimitOrders()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-            Assert.AreEqual(Sec, matched.Fills[0].Security);
-            Assert.AreEqual(Now3, matched.Fills[0].Time);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].ClientOrderId);
-            Assert.AreEqual(100, matched.Fills[0].Price);
-            Assert.AreEqual(5, matched.Fills[0].Quantity);
-            Assert.AreEqual(true, matched.Fills[0].IsResting);
-            Assert.AreEqual(CompanyId1, matched.Fills[0].Order.CompanyId);
-            Assert.AreEqual(OrderId1, matched.Fills[0].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[0].Order.Security);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.CreatedTime);
-            Assert.AreEqual(Now1, matched.Fills[0].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched.Fills[0].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[0].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[0].Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, matched.Fills[0].Order.Side);
-            Assert.AreEqual(100, matched.Fills[0].Order.Price);
-            Assert.IsNull(matched.Fills[0].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[0].Order.Quantity);
-            Assert.AreEqual(5, matched.Fills[0].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[0].Order.RemainingQuantity);
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Closed);
 
-            Assert.AreEqual(Sec, matched.Fills[1].Security);
-            Assert.AreEqual(Now3, matched.Fills[1].Time);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].ClientOrderId);
-            Assert.AreEqual(100, matched.Fills[1].Price);
-            Assert.AreEqual(5, matched.Fills[1].Quantity);
-            Assert.AreEqual(false, matched.Fills[1].IsResting);
-            Assert.AreEqual(CompanyId2, matched.Fills[1].Order.CompanyId);
-            Assert.AreEqual(OrderId2, matched.Fills[1].Order.ClientOrderId);
-            Assert.AreEqual(Sec, matched.Fills[1].Order.Security);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.CreatedTime);
-            Assert.AreEqual(Now2, matched.Fills[1].Order.ModifiedTime);
-            Assert.AreEqual(Now3, matched.Fills[1].Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Filled, matched.Fills[1].Order.Status);
-            Assert.AreEqual(OrderType.Limit, matched.Fills[1].Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), matched.Fills[1].Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, matched.Fills[1].Order.Side);
-            Assert.AreEqual(100, matched.Fills[1].Order.Price);
-            Assert.IsNull(matched.Fills[1].Order.TriggerPrice);
-            Assert.AreEqual(5, matched.Fills[1].Order.Quantity);
-            Assert.AreEqual(5, matched.Fills[1].Order.FilledQuantity);
-            Assert.AreEqual(0, matched.Fills[1].Order.RemainingQuantity);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
 
-        [Test]
-        public void Closed_ExpireDayLimitOrders()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
+        var expired = events[1] as ExpireOrderConfirmed;
+        Assert.IsNotNull(expired);
+        Assert.AreEqual(Sec, expired.Security);
+        Assert.AreEqual(Now2, expired.Time);
+        Assert.AreEqual(CompanyId1, expired.CompanyId);
+        Assert.AreEqual(100, expired.PreviousPrice, "the working-book price it's being removed from");
+        Assert.AreEqual(5, expired.PreviousQuantity, "the working-book displayed quantity being removed");
+        Assert.AreEqual(CompanyId1, expired.Order.CompanyId);
+        Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+        Assert.AreEqual(Sec, expired.Order.Security);
+        Assert.AreEqual(Now1, expired.Order.CreatedTime);
+        Assert.AreEqual(Now1, expired.Order.ModifiedTime);
+        Assert.AreEqual(Now2, expired.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+        Assert.AreEqual(OrderType.Limit, expired.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), expired.Order.OrderValidity);
+        Assert.AreEqual(Side.Buy, expired.Order.Side);
+        Assert.AreEqual(100, expired.Order.Price);
+        Assert.IsNull(expired.Order.TriggerPrice);
+        Assert.AreEqual(5, expired.Order.Quantity);
+        Assert.AreEqual(0, expired.Order.FilledQuantity);
+        Assert.AreEqual(0, expired.Order.RemainingQuantity);
+    }
 
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Closed);
+    [Test]
+    public void Closed_ExpireDayStopOrders()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
+        Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
+        Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 90);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Closed);
 
-            var expired = events[1] as ExpireOrderConfirmed;
-            Assert.IsNotNull(expired);
-            Assert.AreEqual(Sec, expired.Security);
-            Assert.AreEqual(Now2, expired.Time);
-            Assert.AreEqual(CompanyId1, expired.CompanyId);
-            Assert.AreEqual(100, expired.PreviousPrice, "the working-book price it's being removed from");
-            Assert.AreEqual(5, expired.PreviousQuantity, "the working-book displayed quantity being removed");
-            Assert.AreEqual(CompanyId1, expired.Order.CompanyId);
-            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
-            Assert.AreEqual(Sec, expired.Order.Security);
-            Assert.AreEqual(Now1, expired.Order.CreatedTime);
-            Assert.AreEqual(Now1, expired.Order.ModifiedTime);
-            Assert.AreEqual(Now2, expired.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-            Assert.AreEqual(OrderType.Limit, expired.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), expired.Order.OrderValidity);
-            Assert.AreEqual(Side.Buy, expired.Order.Side);
-            Assert.AreEqual(100, expired.Order.Price);
-            Assert.IsNull(expired.Order.TriggerPrice);
-            Assert.AreEqual(5, expired.Order.Quantity);
-            Assert.AreEqual(0, expired.Order.FilledQuantity);
-            Assert.AreEqual(0, expired.Order.RemainingQuantity);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
 
-        [Test]
-        public void Closed_ExpireDayStopOrders()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-            Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-            Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 90);
-            TimeProvider.SetCurrentTime(Now2);
+        var expired = events[1] as ExpireOrderConfirmed;
+        Assert.IsNotNull(expired);
+        Assert.AreEqual(Sec, expired.Security);
+        Assert.AreEqual(Now2, expired.Time);
+        Assert.AreEqual(CompanyId3, expired.CompanyId);
+        Assert.IsNull(expired.PreviousPrice, "still Hidden - never resting in the working book");
+        Assert.AreEqual(5, expired.PreviousQuantity, "the working-book displayed quantity being removed");
+        Assert.AreEqual(CompanyId3, expired.Order.CompanyId);
+        Assert.AreEqual(OrderId3, expired.Order.ClientOrderId);
+        Assert.AreEqual(Sec, expired.Order.Security);
+        Assert.AreEqual(Now1, expired.Order.CreatedTime);
+        Assert.AreEqual(Now1, expired.Order.ModifiedTime);
+        Assert.AreEqual(Now2, expired.Order.CompletedTime);
+        Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+        Assert.AreEqual(OrderType.StopMarket, expired.Order.Type);
+        Assert.AreEqual(new OrderValidity.Day(), expired.Order.OrderValidity);
+        Assert.AreEqual(Side.Sell, expired.Order.Side);
+        Assert.IsNull(expired.Order.Price);
+        Assert.AreEqual(90, expired.Order.TriggerPrice);
+        Assert.AreEqual(5, expired.Order.Quantity);
+        Assert.AreEqual(0, expired.Order.FilledQuantity);
+        Assert.AreEqual(0, expired.Order.RemainingQuantity);
+    }
 
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Closed);
+    [Test]
+    public void Closed_DontExpireGoodTilCanceledOrders()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Closed);
 
-            var expired = events[1] as ExpireOrderConfirmed;
-            Assert.IsNotNull(expired);
-            Assert.AreEqual(Sec, expired.Security);
-            Assert.AreEqual(Now2, expired.Time);
-            Assert.AreEqual(CompanyId3, expired.CompanyId);
-            Assert.IsNull(expired.PreviousPrice, "still Hidden - never resting in the working book");
-            Assert.AreEqual(5, expired.PreviousQuantity, "the working-book displayed quantity being removed");
-            Assert.AreEqual(CompanyId3, expired.Order.CompanyId);
-            Assert.AreEqual(OrderId3, expired.Order.ClientOrderId);
-            Assert.AreEqual(Sec, expired.Order.Security);
-            Assert.AreEqual(Now1, expired.Order.CreatedTime);
-            Assert.AreEqual(Now1, expired.Order.ModifiedTime);
-            Assert.AreEqual(Now2, expired.Order.CompletedTime);
-            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-            Assert.AreEqual(OrderType.StopMarket, expired.Order.Type);
-            Assert.AreEqual(new OrderValidity.Day(), expired.Order.OrderValidity);
-            Assert.AreEqual(Side.Sell, expired.Order.Side);
-            Assert.IsNull(expired.Order.Price);
-            Assert.AreEqual(90, expired.Order.TriggerPrice);
-            Assert.AreEqual(5, expired.Order.Quantity);
-            Assert.AreEqual(0, expired.Order.FilledQuantity);
-            Assert.AreEqual(0, expired.Order.RemainingQuantity);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
 
-        [Test]
-        public void Closed_DontExpireGoodTilCanceledOrders()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
+        var statusChanged = events[0] as StatusChanged;
+        Assert.IsNotNull(statusChanged);
+        Assert.AreEqual(Sec, statusChanged.Security);
+        Assert.AreEqual(OrderBookStatus.Closed, statusChanged.Status);
+        Assert.AreEqual(Now2, statusChanged.Time);
+    }
 
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Closed);
+    [Test]
+    public void Closed_DontExpireGoodTilDateOrdersBeforeDate()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(1);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Closed);
 
-            var statusChanged = events[0] as StatusChanged;
-            Assert.IsNotNull(statusChanged);
-            Assert.AreEqual(Sec, statusChanged.Security);
-            Assert.AreEqual(OrderBookStatus.Closed, statusChanged.Status);
-            Assert.AreEqual(Now2, statusChanged.Time);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(1, events.Count);
 
-        [Test]
-        public void Closed_DontExpireGoodTilDateOrdersBeforeDate()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(1);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
+        var statusChanged = events[0] as StatusChanged;
+        Assert.IsNotNull(statusChanged);
+        Assert.AreEqual(Sec, statusChanged.Security);
+        Assert.AreEqual(OrderBookStatus.Closed, statusChanged.Status);
+        Assert.AreEqual(Now2, statusChanged.Time);
+    }
 
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Closed);
+    [Test]
+    public void Closed_ExpireGoodTilDateOrdersOnDate()
+    {
+        // arrange
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var goodTilDate = DateOnly.FromDateTime(Now1);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
+        TimeProvider.SetCurrentTime(Now2);
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(1, events.Count);
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Closed);
 
-            var statusChanged = events[0] as StatusChanged;
-            Assert.IsNotNull(statusChanged);
-            Assert.AreEqual(Sec, statusChanged.Security);
-            Assert.AreEqual(OrderBookStatus.Closed, statusChanged.Status);
-            Assert.AreEqual(Now2, statusChanged.Time);
-        }
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
 
-        [Test]
-        public void Closed_ExpireGoodTilDateOrdersOnDate()
-        {
-            // arrange
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var goodTilDate = DateOnly.FromDateTime(Now1);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
-            TimeProvider.SetCurrentTime(Now2);
+        var expired = events[1] as ExpireOrderConfirmed;
+        Assert.IsNotNull(expired);
+        Assert.AreEqual(Sec, expired.Security);
+        Assert.AreEqual(Now2, expired.Time);
+        Assert.AreEqual(CompanyId1, expired.CompanyId);
+        Assert.AreEqual(CompanyId1, expired.Order.CompanyId);
+        Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+        Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, expired.Order.OrderValidity);
+    }
 
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Closed);
+    [Test]
+    public void Closed_ExpireGoodTilDateOrdersOnceDateReachedAcrossSessions()
+    {
+        // arrange - order survives close on days before its good-til-date, then expires
+        // on the close of the session where the date is reached
+        Book.UpdateStatus(OrderBookStatus.Open);
+        var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(2);
+        Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
+        Book.UpdateStatus(OrderBookStatus.Closed); // day 1 close, not due
 
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
+        var day2 = Now1.AddDays(1);
+        TimeProvider.SetCurrentTime(day2);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
+        Book.UpdateStatus(OrderBookStatus.Closed); // day 2 close, still not due
 
-            var expired = events[1] as ExpireOrderConfirmed;
-            Assert.IsNotNull(expired);
-            Assert.AreEqual(Sec, expired.Security);
-            Assert.AreEqual(Now2, expired.Time);
-            Assert.AreEqual(CompanyId1, expired.CompanyId);
-            Assert.AreEqual(CompanyId1, expired.Order.CompanyId);
-            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, expired.Order.OrderValidity);
-        }
+        var day3 = Now1.AddDays(2);
+        TimeProvider.SetCurrentTime(day3);
+        Book.UpdateStatus(OrderBookStatus.PreOpen);
+        Book.UpdateStatus(OrderBookStatus.Open);
 
-        [Test]
-        public void Closed_ExpireGoodTilDateOrdersOnceDateReachedAcrossSessions()
-        {
-            // arrange - order survives close on days before its good-til-date, then expires
-            // on the close of the session where the date is reached
-            Book.UpdateStatus(OrderBookStatus.Open);
-            var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(2);
-            Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
-            Book.UpdateStatus(OrderBookStatus.Closed); // day 1 close, not due
+        // act
+        var events = Book.UpdateStatus(OrderBookStatus.Closed); // day 3 close, due
 
-            var day2 = Now1.AddDays(1);
-            TimeProvider.SetCurrentTime(day2);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-            Book.UpdateStatus(OrderBookStatus.Closed); // day 2 close, still not due
+        // assert
+        Assert.IsNotNull(events);
+        Assert.AreEqual(2, events.Count);
 
-            var day3 = Now1.AddDays(2);
-            TimeProvider.SetCurrentTime(day3);
-            Book.UpdateStatus(OrderBookStatus.PreOpen);
-            Book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            var events = Book.UpdateStatus(OrderBookStatus.Closed); // day 3 close, due
-
-            // assert
-            Assert.IsNotNull(events);
-            Assert.AreEqual(2, events.Count);
-
-            var expired = events[1] as ExpireOrderConfirmed;
-            Assert.IsNotNull(expired);
-            Assert.AreEqual(Sec, expired.Security);
-            Assert.AreEqual(day3, expired.Time);
-            Assert.AreEqual(CompanyId1, expired.CompanyId);
-            Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
-            Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
-            Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, expired.Order.OrderValidity);
-        }
+        var expired = events[1] as ExpireOrderConfirmed;
+        Assert.IsNotNull(expired);
+        Assert.AreEqual(Sec, expired.Security);
+        Assert.AreEqual(day3, expired.Time);
+        Assert.AreEqual(CompanyId1, expired.CompanyId);
+        Assert.AreEqual(OrderId1, expired.Order.ClientOrderId);
+        Assert.AreEqual(OrderStatus.Expired, expired.Order.Status);
+        Assert.AreEqual(new OrderValidity.GoodTilDate { Date = goodTilDate }, expired.Order.OrderValidity);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
@@ -1,140 +1,137 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// What a velocity limit catches that a range around the last trade does not: a run of steps
+// each unremarkable next to the one before it, arriving too quickly. The same steps spread out
+// are ordinary trading, so every test here turns on timing rather than on price.
+[TestFixture]
+public class InMemoryOrderBookVelocityLogicTests
 {
-    // What a velocity limit catches that a range around the last trade does not: a run of steps
-    // each unremarkable next to the one before it, arriving too quickly. The same steps spread out
-    // are ordinary trading, so every test here turns on timing rather than on price.
-    [TestFixture]
-    public class InMemoryOrderBookVelocityLogicTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(10);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+
+    private TestTimeProvider TimeProvider;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly TimeSpan Window = TimeSpan.FromSeconds(10);
+        TimeProvider = new TestTimeProvider(Now1);
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
-
-        private TestTimeProvider TimeProvider;
-
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-        }
-
-        // 5 ticks on a tick size of 10, so 50 of price movement inside ten seconds is too fast.
-        private IOrderBook VelocityBook(TimeSpan? pauseFor = null) =>
-            new InMemoryOrderBook(
-                new Security("GCZ6", SecurityType.Future, 10, 10,
-                    PriceRestrictions: new PriceRestrictionConfig[]
-                    {
-                        new VelocityLimit(5, Window, pauseFor)
-                    }),
-                TimeProvider);
-
-        [Test]
-        public void StepsArrivingTooQuickly_TripTheLimit()
-        {
-            // arrange
-            var book = VelocityBook();
-            book.UpdateStatus(OrderBookStatus.Open);
-
-            // act + assert - nothing has traded, so the first print is unmeasurable and allowed
-            Trade(book, 1, 100);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-
-            // two seconds later, 40 from the first trade and inside the range
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
-            Trade(book, 2, 140);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-
-            // two seconds later again. This step is only 40 from the last trade, but the trade at
-            // 100 is still inside the window and 80 away, which is what the limit is watching for
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
-            Trade(book, 3, 180);
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-        }
-
-        [Test]
-        public void TheSameStepsSpreadOut_DoNot()
-        {
-            // arrange - identical prices to the test above, twenty seconds apart instead of two
-            var book = VelocityBook();
-            book.UpdateStatus(OrderBookStatus.Open);
-
-            // act
-            Trade(book, 1, 100);
-
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(20));
-            Trade(book, 2, 140);
-
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(40));
-            Trade(book, 3, 180);
-
-            // assert - by the third print the first has long left the window, so nothing measures
-            // the whole 80 of movement and the market simply traded
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        }
-
-        [Test]
-        public void CatchesWhatAWideRangeAroundTheLastTradeMisses()
-        {
-            // arrange - a wide volatility band with no window of its own alongside the velocity
-            // limit. The band is four times the width, so nothing below comes close to it.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+    // 5 ticks on a tick size of 10, so 50 of price movement inside ten seconds is too fast.
+    private IOrderBook VelocityBook(TimeSpan? pauseFor = null) =>
+        new InMemoryOrderBook(
+            new Security("GCZ6", SecurityType.Future, 10, 10,
                 PriceRestrictions: new PriceRestrictionConfig[]
                 {
-                    new VolatilityBand(20),
-                    new VelocityLimit(5, Window)
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open);
+                    new VelocityLimit(5, Window, pauseFor)
+                }),
+            TimeProvider);
 
-            // act
-            Trade(book, 1, 100);
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
-            Trade(book, 2, 140);
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
-            Trade(book, 3, 180);
+    [Test]
+    public void StepsArrivingTooQuickly_TripTheLimit()
+    {
+        // arrange
+        var book = VelocityBook();
+        book.UpdateStatus(OrderBookStatus.Open);
 
-            // assert - every step was 40, well inside the band's 200, so the band never had an
-            // opinion. Going too fast is the only thing wrong here.
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-        }
+        // act + assert - nothing has traded, so the first print is unmeasurable and allowed
+        Trade(book, 1, 100);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
 
-        [Test]
-        public void PauseIsBriefAndEndsOnItsOwn()
-        {
-            // arrange - velocity pauses are measured in seconds, not minutes
-            var pauseFor = TimeSpan.FromSeconds(5);
-            var book = VelocityBook(pauseFor);
-            book.UpdateStatus(OrderBookStatus.Open);
+        // two seconds later, 40 from the first trade and inside the range
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+        Trade(book, 2, 140);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
 
-            Trade(book, 1, 100);
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
-            Trade(book, 2, 140);
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
-            Trade(book, 3, 180);
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        // two seconds later again. This step is only 40 from the last trade, but the trade at
+        // 100 is still inside the window and 80 away, which is what the limit is watching for
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+        Trade(book, 3, 180);
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+    }
 
-            // act - the orders that tripped it are still crossed, so ending the pause prints them
-            TimeProvider.SetCurrentTime(Now1.AddSeconds(4) + pauseFor);
-            var events = book.AdvanceTime();
+    [Test]
+    public void TheSameStepsSpreadOut_DoNot()
+    {
+        // arrange - identical prices to the test above, twenty seconds apart instead of two
+        var book = VelocityBook();
+        book.UpdateStatus(OrderBookStatus.Open);
 
-            // assert
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-            var matched = events.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(180, matched.Price);
-        }
+        // act
+        Trade(book, 1, 100);
 
-        private void Trade(IOrderBook book, int n, decimal price)
-        {
-            book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
-            book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
-        }
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(20));
+        Trade(book, 2, 140);
+
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(40));
+        Trade(book, 3, 180);
+
+        // assert - by the third print the first has long left the window, so nothing measures
+        // the whole 80 of movement and the market simply traded
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void CatchesWhatAWideRangeAroundTheLastTradeMisses()
+    {
+        // arrange - a wide volatility band with no window of its own alongside the velocity
+        // limit. The band is four times the width, so nothing below comes close to it.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new VolatilityBand(20),
+                new VelocityLimit(5, Window)
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open);
+
+        // act
+        Trade(book, 1, 100);
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+        Trade(book, 2, 140);
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+        Trade(book, 3, 180);
+
+        // assert - every step was 40, well inside the band's 200, so the band never had an
+        // opinion. Going too fast is the only thing wrong here.
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+    }
+
+    [Test]
+    public void PauseIsBriefAndEndsOnItsOwn()
+    {
+        // arrange - velocity pauses are measured in seconds, not minutes
+        var pauseFor = TimeSpan.FromSeconds(5);
+        var book = VelocityBook(pauseFor);
+        book.UpdateStatus(OrderBookStatus.Open);
+
+        Trade(book, 1, 100);
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+        Trade(book, 2, 140);
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+        Trade(book, 3, 180);
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+
+        // act - the orders that tripped it are still crossed, so ending the pause prints them
+        TimeProvider.SetCurrentTime(Now1.AddSeconds(4) + pauseFor);
+        var events = book.AdvanceTime();
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        var matched = events.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(180, matched.Price);
+    }
+
+    private void Trade(IOrderBook book, int n, decimal price)
+    {
+        book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
+        book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
     }
 }

--- a/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
+++ b/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
@@ -1,133 +1,130 @@
-using System;
-using System.Linq;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// The two things a volatility interruption does beyond pausing: it can refuse to end at a price
+// still too far out, and a range anchored on the session catches drift that one following the
+// market never sees.
+[TestFixture]
+public class InMemoryOrderBookVolatilityInterruptionTests
 {
-    // The two things a volatility interruption does beyond pausing: it can refuse to end at a price
-    // still too far out, and a range anchored on the session catches drift that one following the
-    // market never sees.
-    [TestFixture]
-    public class InMemoryOrderBookVolatilityInterruptionTests
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+    private static readonly string CompanyId1 = "Company1";
+    private static readonly string CompanyId2 = "Company2";
+
+    private static readonly string OrderId1 = "Order1";
+    private static readonly string OrderId2 = "Order2";
+
+    private TestTimeProvider TimeProvider;
+
+    [SetUp]
+    public void SetUp()
     {
-        private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
-        private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+        TimeProvider = new TestTimeProvider(Now1);
+    }
 
-        private static readonly string CompanyId1 = "Company1";
-        private static readonly string CompanyId2 = "Company2";
+    // Ordinary range 5 ticks, extended range 8, pausing for two minutes. On a tick size of 10
+    // that is 50 and 80 either side of the reference.
+    private static Security ExtendingSecurity() =>
+        new("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new VolatilityBand(5, PauseFor: PauseFor, ExtendedRangeTicks: 8)
+            });
 
-        private static readonly string OrderId1 = "Order1";
-        private static readonly string OrderId2 = "Order2";
+    [Test]
+    public void InterruptionExtends_WhenItWouldEndBeyondTheExtendedRange()
+    {
+        // arrange - referenced at 100, then a trade at 200 breaches the ordinary range and
+        // pauses the book, leaving the two orders crossed and unfilled
+        var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
 
-        private TestTimeProvider TimeProvider;
+        // act - the pause runs out, but the auction would still print at 200, which is 100 from
+        // the reference and so outside the extended range of 80
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        var events = book.AdvanceTime();
 
-        [SetUp]
-        public void SetUp()
-        {
-            TimeProvider = new TestTimeProvider(Now1);
-        }
+        // assert - the interruption keeps running rather than resolving out there
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+        Assert.AreEqual(0, events.OfType<OrdersMatched>().Count(), "nothing printed");
 
-        // Ordinary range 5 ticks, extended range 8, pausing for two minutes. On a tick size of 10
-        // that is 50 and 80 either side of the reference.
-        private static Security ExtendingSecurity() =>
-            new("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new VolatilityBand(5, PauseFor: PauseFor, ExtendedRangeTicks: 8)
-                });
+        var stillPaused = events.OfType<StatusChanged>().Single();
+        Assert.AreEqual(OrderBookStatus.Paused, stillPaused.Status);
+        Assert.AreEqual(StatusChangeReason.PriceRestriction, stillPaused.Reason);
+    }
 
-        [Test]
-        public void InterruptionExtends_WhenItWouldEndBeyondTheExtendedRange()
-        {
-            // arrange - referenced at 100, then a trade at 200 breaches the ordinary range and
-            // pauses the book, leaving the two orders crossed and unfilled
-            var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+    [Test]
+    public void InterruptionEnds_OnceItWouldPrintInsideTheExtendedRange()
+    {
+        // arrange - as above, paused with a would-be print at 200
+        var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
+        book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
+        book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
 
-            // act - the pause runs out, but the auction would still print at 200, which is 100 from
-            // the reference and so outside the extended range of 80
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            var events = book.AdvanceTime();
+        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        book.AdvanceTime();
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status, "extended once");
 
-            // assert - the interruption keeps running rather than resolving out there
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-            Assert.AreEqual(0, events.OfType<OrdersMatched>().Count(), "nothing printed");
+        // act - the orders that would have printed out there are pulled, and a cross at 180
+        // takes their place. 180 is 80 from the reference: outside the ordinary range that
+        // caused the interruption, but exactly on the edge of the extended one.
+        book.CancelOrder(CompanyId1, "Cancel1", OrderId1);
+        book.CancelOrder(CompanyId2, "Cancel2", OrderId2);
+        book.CreateLimitOrder(CompanyId1, "Order3", new OrderValidity.Day(), Side.Sell, 5, 180);
+        book.CreateLimitOrder(CompanyId2, "Order4", new OrderValidity.Day(), Side.Buy, 5, 180);
 
-            var stillPaused = events.OfType<StatusChanged>().Single();
-            Assert.AreEqual(OrderBookStatus.Paused, stillPaused.Status);
-            Assert.AreEqual(StatusChangeReason.PriceRestriction, stillPaused.Reason);
-        }
+        TimeProvider.SetCurrentTime(Now1 + PauseFor + PauseFor);
+        var events = book.AdvanceTime();
 
-        [Test]
-        public void InterruptionEnds_OnceItWouldPrintInsideTheExtendedRange()
-        {
-            // arrange - as above, paused with a would-be print at 200
-            var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-            book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
-            book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
+        // assert - the interruption resolves, printing at a price the ordinary range would
+        // never have allowed to trade continuously
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+        var matched = events.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(180, matched.Price);
+        Assert.AreEqual(5, matched.Quantity);
+    }
 
-            TimeProvider.SetCurrentTime(Now1 + PauseFor);
-            book.AdvanceTime();
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status, "extended once");
+    [Test]
+    public void StaticRange_CatchesDriftThatTheDynamicRangeDoesNot()
+    {
+        // arrange - a dynamic range of 3 ticks alongside a static range of 5, referenced at 100.
+        // Each step below is well inside the dynamic range; it is the distance from where the
+        // day started that eventually trips.
+        var security = new Security("GCZ6", SecurityType.Future, 10, 10,
+            PriceRestrictions: new PriceRestrictionConfig[]
+            {
+                new VolatilityBand(3),
+                new StaticPriceRange(5)
+            });
+        var book = new InMemoryOrderBook(security, TimeProvider);
+        book.UpdateStatus(OrderBookStatus.Open, 100);
 
-            // act - the orders that would have printed out there are pulled, and a cross at 180
-            // takes their place. 180 is 80 from the reference: outside the ordinary range that
-            // caused the interruption, but exactly on the edge of the extended one.
-            book.CancelOrder(CompanyId1, "Cancel1", OrderId1);
-            book.CancelOrder(CompanyId2, "Cancel2", OrderId2);
-            book.CreateLimitOrder(CompanyId1, "Order3", new OrderValidity.Day(), Side.Sell, 5, 180);
-            book.CreateLimitOrder(CompanyId2, "Order4", new OrderValidity.Day(), Side.Buy, 5, 180);
+        // act + assert - 120 is 2 ticks from the reference, inside both
+        Trade(book, 1, 120);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
 
-            TimeProvider.SetCurrentTime(Now1 + PauseFor + PauseFor);
-            var events = book.AdvanceTime();
+        // 140 is 2 ticks from the last trade and 4 from the reference, still inside both
+        Trade(book, 2, 140);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
 
-            // assert - the interruption resolves, printing at a price the ordinary range would
-            // never have allowed to trade continuously
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-            var matched = events.OfType<OrdersMatched>().Single();
-            Assert.AreEqual(180, matched.Price);
-            Assert.AreEqual(5, matched.Quantity);
-        }
+        // 160 is 2 ticks from the last trade - the dynamic range is content - but 6 from the
+        // reference, which the static range is not
+        Trade(book, 3, 160);
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+    }
 
-        [Test]
-        public void StaticRange_CatchesDriftThatTheDynamicRangeDoesNot()
-        {
-            // arrange - a dynamic range of 3 ticks alongside a static range of 5, referenced at 100.
-            // Each step below is well inside the dynamic range; it is the distance from where the
-            // day started that eventually trips.
-            var security = new Security("GCZ6", SecurityType.Future, 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
-                {
-                    new VolatilityBand(3),
-                    new StaticPriceRange(5)
-                });
-            var book = new InMemoryOrderBook(security, TimeProvider);
-            book.UpdateStatus(OrderBookStatus.Open, 100);
-
-            // act + assert - 120 is 2 ticks from the reference, inside both
-            Trade(book, 1, 120);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-
-            // 140 is 2 ticks from the last trade and 4 from the reference, still inside both
-            Trade(book, 2, 140);
-            Assert.AreEqual(OrderBookStatus.Open, book.Status);
-
-            // 160 is 2 ticks from the last trade - the dynamic range is content - but 6 from the
-            // reference, which the static range is not
-            Trade(book, 3, 160);
-            Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-        }
-
-        private void Trade(IOrderBook book, int n, decimal price)
-        {
-            book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
-            book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
-        }
+    private void Trade(IOrderBook book, int n, decimal price)
+    {
+        book.CreateLimitOrder(CompanyId1, $"Sell{n}", new OrderValidity.Day(), Side.Sell, 5, price);
+        book.CreateLimitOrder(CompanyId2, $"Buy{n}", new OrderValidity.Day(), Side.Buy, 5, price);
     }
 }

--- a/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
+++ b/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
@@ -1,46 +1,42 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.TimeProviders;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// An InMemoryOrderBook plus the level view a subscriber would keep beside it. The book
+// answers no questions about its own levels, so a test that needs to know where orders ended
+// up rebuilds them from the event stream - which also means these assertions are against what
+// a market data consumer can actually see, not the book's internals.
+internal sealed class LevelTrackingOrderBook : IOrderBook
 {
-    // An InMemoryOrderBook plus the level view a subscriber would keep beside it. The book
-    // answers no questions about its own levels, so a test that needs to know where orders ended
-    // up rebuilds them from the event stream - which also means these assertions are against what
-    // a market data consumer can actually see, not the book's internals.
-    internal sealed class LevelTrackingOrderBook : IOrderBook
+    // Deeper than any test asks for, so a level is only ever missing because the caller's own
+    // maxPrices cut it off.
+    private const int MaxLevels = 100;
+
+    private readonly IOrderBook _book;
+    private readonly LevelDataProducer _levelDataProducer = new(MaxLevels);
+    private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
+
+    public LevelTrackingOrderBook(Security security, ITimeProvider timeProvider)
     {
-        // Deeper than any test asks for, so a level is only ever missing because the caller's own
-        // maxPrices cut it off.
-        private const int MaxLevels = 100;
-
-        private readonly IOrderBook _book;
-        private readonly LevelDataProducer _levelDataProducer = new(MaxLevels);
-        private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
-
-        public LevelTrackingOrderBook(Security security, ITimeProvider timeProvider)
-        {
-            _book = new InMemoryOrderBook(security, timeProvider);
-        }
-
-        public Security Security => _book.Security;
-
-        public OrderBookStatus Status => _book.Status;
-
-        public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
-        {
-            var events = _book.Process(action);
-
-            foreach (var levels in _levelDataProducer.Process(_book, events))
-                _levels = levels;
-
-            return events;
-        }
-
-        public IReadOnlyList<Level> GetLevels(Side side, int maxPrices) =>
-            (side == Side.Buy ? _levels.Bids : _levels.Offers).Take(maxPrices).ToList();
+        _book = new InMemoryOrderBook(security, timeProvider);
     }
+
+    public Security Security => _book.Security;
+
+    public OrderBookStatus Status => _book.Status;
+
+    public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
+    {
+        var events = _book.Process(action);
+
+        foreach (var levels in _levelDataProducer.Process(_book, events))
+            _levels = levels;
+
+        return events;
+    }
+
+    public IReadOnlyList<Level> GetLevels(Side side, int maxPrices) =>
+        (side == Side.Buy ? _levels.Bids : _levels.Offers).Take(maxPrices).ToList();
 }

--- a/Circus.Tests/OrderBook/MatcherTests.cs
+++ b/Circus.Tests/OrderBook/MatcherTests.cs
@@ -1,198 +1,194 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Circus.OrderBook;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+// Drives Matcher directly rather than through InMemoryOrderBook, which is the only way to run
+// it against a matching algorithm the book doesn't itself construct. Covers the seam
+// IMatchingAlgorithm.SelectNext opens up: an algorithm choosing a counterparty other than the
+// FIFO-earliest order at the level, which is what any non-price-time algorithm (pro-rata and
+// friends) needs and what the loop used to decide for itself.
+[TestFixture]
+public class MatcherTests
 {
-    // Drives Matcher directly rather than through InMemoryOrderBook, which is the only way to run
-    // it against a matching algorithm the book doesn't itself construct. Covers the seam
-    // IMatchingAlgorithm.SelectNext opens up: an algorithm choosing a counterparty other than the
-    // FIFO-earliest order at the level, which is what any non-price-time algorithm (pro-rata and
-    // friends) needs and what the loop used to decide for itself.
-    [TestFixture]
-    public class MatcherTests
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly DateTime Early = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Late = new(2000, 1, 1, 12, 1, 0);
+
+    private const long Tick = 100;
+
+    // Nothing yielded by Run is applied here, so the book is never mutated and the loop would
+    // re-offer the same crossing forever. Every test below takes only as many outcomes as the
+    // lazy iterator has to produce, which is safe precisely because Run yields.
+    private static MatchOutcome? FirstOutcome(Matcher matcher, IMatchingAlgorithm algorithm) =>
+        matcher.Run(algorithm, algorithm, _ => null).FirstOrDefault();
+
+    private static InternalOrder Order(long sequenceNumber, Side side, int quantity, DateTime time) =>
+        new(sequenceNumber, $"Company{sequenceNumber}", $"Order{sequenceNumber}", Sec, time,
+            OrderStatus.Working, OrderType.Limit, new OrderValidity.Day(), side, quantity, Tick, null);
+
+    // Three resting buys at one price, then a later sell that crosses all of them - the shape
+    // every allocation algorithm differs over.
+    private static Matcher BookWithThreeRestingBuys(out InternalOrder first, out InternalOrder second,
+        out InternalOrder third, int aggressorQuantity = 50)
     {
-        private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+        var matcher = new Matcher();
 
-        private static readonly DateTime Early = new(2000, 1, 1, 12, 0, 0);
-        private static readonly DateTime Late = new(2000, 1, 1, 12, 1, 0);
+        first = Order(1, Side.Buy, 60, Early);
+        second = Order(2, Side.Buy, 30, Early);
+        third = Order(3, Side.Buy, 10, Early);
 
-        private const long Tick = 100;
+        matcher.Rest(first);
+        matcher.Rest(second);
+        matcher.Rest(third);
+        matcher.Rest(Order(4, Side.Sell, aggressorQuantity, Late));
 
-        // Nothing yielded by Run is applied here, so the book is never mutated and the loop would
-        // re-offer the same crossing forever. Every test below takes only as many outcomes as the
-        // lazy iterator has to produce, which is safe precisely because Run yields.
-        private static MatchOutcome? FirstOutcome(Matcher matcher, IMatchingAlgorithm algorithm) =>
-            matcher.Run(algorithm, algorithm, _ => null).FirstOrDefault();
+        return matcher;
+    }
 
-        private static InternalOrder Order(long sequenceNumber, Side side, int quantity, DateTime time) =>
-            new(sequenceNumber, $"Company{sequenceNumber}", $"Order{sequenceNumber}", Sec, time,
-                OrderStatus.Working, OrderType.Limit, new OrderValidity.Day(), side, quantity, Tick, null);
+    [Test]
+    public void SelectNext_ChoosingBehindTheHead_IsHonoured()
+    {
+        // arrange - the head is offered, as always, but this algorithm allocates to the order
+        // behind it. Under the old shape the loop picked the counterparty itself and this was
+        // simply not expressible.
+        var matcher = BookWithThreeRestingBuys(out var first, out var second, out _);
 
-        // Three resting buys at one price, then a later sell that crosses all of them - the shape
-        // every allocation algorithm differs over.
-        private static Matcher BookWithThreeRestingBuys(out InternalOrder first, out InternalOrder second,
-            out InternalOrder third, int aggressorQuantity = 50)
+        // act
+        var outcome = FirstOutcome(matcher, new SelectsBehindTheHead());
+
+        // assert
+        var trade = outcome as TradeExecuted;
+        Assert.IsNotNull(trade);
+        Assert.AreSame(second, trade.Resting, "the algorithm's choice should decide the counterparty");
+        Assert.AreNotSame(first, trade.Resting, "the FIFO-earliest order should have been passed over");
+        Assert.AreEqual(30, trade.Quantity);
+    }
+
+    [Test]
+    public void PriceTime_TakesTheHeadOfTheLevel()
+    {
+        // arrange - the default algorithm must still be strict price-time: head first, sized
+        // off displayed quantity, printed at the resting order's own limit.
+        var matcher = BookWithThreeRestingBuys(out var first, out _, out _);
+
+        // act
+        var outcome = FirstOutcome(matcher, new PriceTime());
+
+        // assert
+        var trade = outcome as TradeExecuted;
+        Assert.IsNotNull(trade);
+        Assert.AreSame(first, trade.Resting);
+        Assert.AreEqual(50, trade.Quantity, "capped by the aggressor's 50, not the head's 60");
+        Assert.AreEqual(Tick, trade.PriceTicks);
+        Assert.IsFalse(trade.UsesFullRemainingQuantity);
+    }
+
+    [Test]
+    public void SelectNext_DecliningToMatch_EndsTheRunWithoutTrading()
+    {
+        // arrange - a crossed book an algorithm refuses to act on should terminate rather than
+        // spin, since the loop would otherwise keep re-offering the same crossing.
+        var matcher = BookWithThreeRestingBuys(out _, out _, out _);
+
+        // act
+        var outcomes = matcher.Run(new DeclinesToMatch(), new PriceTime(), _ => null).ToList();
+
+        // assert
+        Assert.IsEmpty(outcomes);
+    }
+
+    [Test]
+    public void TryBegin_ReturningFalse_YieldsNothing()
+    {
+        // arrange - how an uncrossing pass over an uncrossed book stays a no-op.
+        var matcher = BookWithThreeRestingBuys(out _, out _, out _);
+
+        // act
+        var outcomes = matcher.Run(new DeclinesToBegin(), new PriceTime(), _ => null).ToList();
+
+        // assert
+        Assert.IsEmpty(outcomes);
+    }
+
+    private sealed class SelectsBehindTheHead : IMatchingAlgorithm
+    {
+        public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
+
+        public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor)
         {
-            var matcher = new Matcher();
-
-            first = Order(1, Side.Buy, 60, Early);
-            second = Order(2, Side.Buy, 30, Early);
-            third = Order(3, Side.Buy, 10, Early);
-
-            matcher.Rest(first);
-            matcher.Rest(second);
-            matcher.Rest(third);
-            matcher.Rest(Order(4, Side.Sell, aggressorQuantity, Late));
-
-            return matcher;
+            var behind = restingHead.LevelNext ?? restingHead;
+            return new Allocation(behind, Math.Min(behind.RemainingQuantity, aggressor.RemainingQuantity),
+                behind.Price!.Value);
         }
 
-        [Test]
-        public void SelectNext_ChoosingBehindTheHead_IsHonoured()
+        public bool UsesFullRemainingQuantity => true;
+        public bool ChecksTradeRestrictions => false;
+
+        public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+            out long priceTicks, out int quantity)
         {
-            // arrange - the head is offered, as always, but this algorithm allocates to the order
-            // behind it. Under the old shape the loop picked the counterparty itself and this was
-            // simply not expressible.
-            var matcher = BookWithThreeRestingBuys(out var first, out var second, out _);
-
-            // act
-            var outcome = FirstOutcome(matcher, new SelectsBehindTheHead());
-
-            // assert
-            var trade = outcome as TradeExecuted;
-            Assert.IsNotNull(trade);
-            Assert.AreSame(second, trade.Resting, "the algorithm's choice should decide the counterparty");
-            Assert.AreNotSame(first, trade.Resting, "the FIFO-earliest order should have been passed over");
-            Assert.AreEqual(30, trade.Quantity);
+            priceTicks = 0;
+            quantity = 0;
+            return false;
         }
 
-        [Test]
-        public void PriceTime_TakesTheHeadOfTheLevel()
+        public void OnTrade(long priceTicks)
         {
-            // arrange - the default algorithm must still be strict price-time: head first, sized
-            // off displayed quantity, printed at the resting order's own limit.
-            var matcher = BookWithThreeRestingBuys(out var first, out _, out _);
-
-            // act
-            var outcome = FirstOutcome(matcher, new PriceTime());
-
-            // assert
-            var trade = outcome as TradeExecuted;
-            Assert.IsNotNull(trade);
-            Assert.AreSame(first, trade.Resting);
-            Assert.AreEqual(50, trade.Quantity, "capped by the aggressor's 50, not the head's 60");
-            Assert.AreEqual(Tick, trade.PriceTicks);
-            Assert.IsFalse(trade.UsesFullRemainingQuantity);
         }
 
-        [Test]
-        public void SelectNext_DecliningToMatch_EndsTheRunWithoutTrading()
+        public void OnSessionChange(long? referencePriceTicks)
         {
-            // arrange - a crossed book an algorithm refuses to act on should terminate rather than
-            // spin, since the loop would otherwise keep re-offering the same crossing.
-            var matcher = BookWithThreeRestingBuys(out _, out _, out _);
+        }
+    }
 
-            // act
-            var outcomes = matcher.Run(new DeclinesToMatch(), new PriceTime(), _ => null).ToList();
+    private sealed class DeclinesToMatch : IMatchingAlgorithm
+    {
+        public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
+        public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) => null;
+        public bool UsesFullRemainingQuantity => false;
+        public bool ChecksTradeRestrictions => false;
 
-            // assert
-            Assert.IsEmpty(outcomes);
+        public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+            out long priceTicks, out int quantity)
+        {
+            priceTicks = 0;
+            quantity = 0;
+            return false;
         }
 
-        [Test]
-        public void TryBegin_ReturningFalse_YieldsNothing()
+        public void OnTrade(long priceTicks)
         {
-            // arrange - how an uncrossing pass over an uncrossed book stays a no-op.
-            var matcher = BookWithThreeRestingBuys(out _, out _, out _);
-
-            // act
-            var outcomes = matcher.Run(new DeclinesToBegin(), new PriceTime(), _ => null).ToList();
-
-            // assert
-            Assert.IsEmpty(outcomes);
         }
 
-        private sealed class SelectsBehindTheHead : IMatchingAlgorithm
+        public void OnSessionChange(long? referencePriceTicks)
         {
-            public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
+        }
+    }
 
-            public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor)
-            {
-                var behind = restingHead.LevelNext ?? restingHead;
-                return new Allocation(behind, Math.Min(behind.RemainingQuantity, aggressor.RemainingQuantity),
-                    behind.Price!.Value);
-            }
+    private sealed class DeclinesToBegin : IMatchingAlgorithm
+    {
+        public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => false;
+        public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
+            throw new InvalidOperationException("must not be consulted once TryBegin declines");
+        public bool UsesFullRemainingQuantity => false;
+        public bool ChecksTradeRestrictions => false;
 
-            public bool UsesFullRemainingQuantity => true;
-            public bool ChecksTradeRestrictions => false;
-
-            public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
-                out long priceTicks, out int quantity)
-            {
-                priceTicks = 0;
-                quantity = 0;
-                return false;
-            }
-
-            public void OnTrade(long priceTicks)
-            {
-            }
-
-            public void OnSessionChange(long? referencePriceTicks)
-            {
-            }
+        public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+            out long priceTicks, out int quantity)
+        {
+            priceTicks = 0;
+            quantity = 0;
+            return false;
         }
 
-        private sealed class DeclinesToMatch : IMatchingAlgorithm
+        public void OnTrade(long priceTicks)
         {
-            public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
-            public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) => null;
-            public bool UsesFullRemainingQuantity => false;
-            public bool ChecksTradeRestrictions => false;
-
-            public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
-                out long priceTicks, out int quantity)
-            {
-                priceTicks = 0;
-                quantity = 0;
-                return false;
-            }
-
-            public void OnTrade(long priceTicks)
-            {
-            }
-
-            public void OnSessionChange(long? referencePriceTicks)
-            {
-            }
         }
 
-        private sealed class DeclinesToBegin : IMatchingAlgorithm
+        public void OnSessionChange(long? referencePriceTicks)
         {
-            public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => false;
-            public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
-                throw new InvalidOperationException("must not be consulted once TryBegin declines");
-            public bool UsesFullRemainingQuantity => false;
-            public bool ChecksTradeRestrictions => false;
-
-            public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
-                out long priceTicks, out int quantity)
-            {
-                priceTicks = 0;
-                quantity = 0;
-                return false;
-            }
-
-            public void OnTrade(long priceTicks)
-            {
-            }
-
-            public void OnSessionChange(long? referencePriceTicks)
-            {
-            }
         }
     }
 }

--- a/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
@@ -1,166 +1,165 @@
 using Circus.OrderBook;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class OrderPriceRestrictionTests
 {
-    [TestFixture]
-    public class OrderPriceRestrictionTests
+    [Test]
+    public void Scope_IsOrderEntry_OnBreach_IsReject()
     {
-        [Test]
-        public void Scope_IsOrderEntry_OnBreach_IsReject()
-        {
-            var restriction = new OrderPriceRestriction(5);
+        var restriction = new OrderPriceRestriction(5);
 
-            Assert.AreEqual(RestrictionScope.OrderEntry, restriction.Scope);
-            Assert.AreEqual(RestrictionBreachAction.Reject, restriction.OnBreach);
-        }
+        Assert.AreEqual(RestrictionScope.OrderEntry, restriction.Scope);
+        Assert.AreEqual(RestrictionBreachAction.Reject, restriction.OnBreach);
+    }
 
-        [Test]
-        public void RejectionInterruptsNothing_SoThereIsNothingToResumeFrom()
-        {
-            var restriction = new OrderPriceRestriction(5);
+    [Test]
+    public void RejectionInterruptsNothing_SoThereIsNothingToResumeFrom()
+    {
+        var restriction = new OrderPriceRestriction(5);
 
-            Assert.IsNull(restriction.ResumeAfter);
-        }
+        Assert.IsNull(restriction.ResumeAfter);
+    }
 
-        [Test]
-        public void NoReferencePriceYet_AlwaysAllows()
-        {
-            var restriction = new OrderPriceRestriction(5);
+    [Test]
+    public void NoReferencePriceYet_AlwaysAllows()
+    {
+        var restriction = new OrderPriceRestriction(5);
 
-            Assert.IsTrue(restriction.Allows(1_000_000, default));
-        }
+        Assert.IsTrue(restriction.Allows(1_000_000, default));
+    }
 
-        [Test]
-        public void WithinBand_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
-        {
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnSessionChange(100);
+    [Test]
+    public void WithinBand_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
+    {
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnSessionChange(100);
 
-            Assert.IsTrue(restriction.Allows(100, default));
-            Assert.IsTrue(restriction.Allows(105, default));
-            Assert.IsTrue(restriction.Allows(95, default));
-            Assert.IsFalse(restriction.Allows(106, default));
-            Assert.IsFalse(restriction.Allows(94, default));
-        }
+        Assert.IsTrue(restriction.Allows(100, default));
+        Assert.IsTrue(restriction.Allows(105, default));
+        Assert.IsTrue(restriction.Allows(95, default));
+        Assert.IsFalse(restriction.Allows(106, default));
+        Assert.IsFalse(restriction.Allows(94, default));
+    }
 
-        [Test]
-        public void OnSessionChange_Null_DoesNotClearExistingReference()
-        {
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnSessionChange(100);
-            restriction.OnSessionChange(null);
+    [Test]
+    public void OnSessionChange_Null_DoesNotClearExistingReference()
+    {
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnSessionChange(100);
+        restriction.OnSessionChange(null);
 
-            Assert.IsTrue(restriction.Allows(105, default));
-            Assert.IsFalse(restriction.Allows(106, default));
-        }
+        Assert.IsTrue(restriction.Allows(105, default));
+        Assert.IsFalse(restriction.Allows(106, default));
+    }
 
-        [Test]
-        public void OnTrade_MovesReferenceToLastTrade()
-        {
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnSessionChange(100);
+    [Test]
+    public void OnTrade_MovesReferenceToLastTrade()
+    {
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnSessionChange(100);
 
-            restriction.OnTrade(200, default);
+        restriction.OnTrade(200, default);
 
-            // band now tracks the last trade (200), no longer the seed (100)
-            Assert.IsTrue(restriction.Allows(205, default));
-            Assert.IsFalse(restriction.Allows(206, default));
-            Assert.IsFalse(restriction.Allows(100, default));
-        }
+        // band now tracks the last trade (200), no longer the seed (100)
+        Assert.IsTrue(restriction.Allows(205, default));
+        Assert.IsFalse(restriction.Allows(206, default));
+        Assert.IsFalse(restriction.Allows(100, default));
+    }
 
-        [Test]
-        public void IndicativePrice_OutranksTheLastTrade()
-        {
-            // an auction is quoting, so that is what an order is judged against - CME's banding
-            // reference follows the IOP once one exists
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnSessionChange(100);
-            restriction.OnTrade(200, default);
+    [Test]
+    public void IndicativePrice_OutranksTheLastTrade()
+    {
+        // an auction is quoting, so that is what an order is judged against - CME's banding
+        // reference follows the IOP once one exists
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnSessionChange(100);
+        restriction.OnTrade(200, default);
 
-            restriction.OnIndicativePrice(300);
+        restriction.OnIndicativePrice(300);
 
-            Assert.IsTrue(restriction.Allows(305, default));
-            Assert.IsFalse(restriction.Allows(306, default));
-            Assert.IsFalse(restriction.Allows(200, default), "the last trade no longer decides");
-        }
+        Assert.IsTrue(restriction.Allows(305, default));
+        Assert.IsFalse(restriction.Allows(306, default));
+        Assert.IsFalse(restriction.Allows(200, default), "the last trade no longer decides");
+    }
 
-        [Test]
-        public void IndicativePrice_OutranksTheSessionReference_WithNoTradeYet()
-        {
-            // pre-open on a fresh session: settled at 100, then the book crosses at 300
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnSessionChange(100);
+    [Test]
+    public void IndicativePrice_OutranksTheSessionReference_WithNoTradeYet()
+    {
+        // pre-open on a fresh session: settled at 100, then the book crosses at 300
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnSessionChange(100);
 
-            restriction.OnIndicativePrice(300);
+        restriction.OnIndicativePrice(300);
 
-            Assert.IsTrue(restriction.Allows(300, default));
-            Assert.IsFalse(restriction.Allows(100, default));
-        }
+        Assert.IsTrue(restriction.Allows(300, default));
+        Assert.IsFalse(restriction.Allows(100, default));
+    }
 
-        [Test]
-        public void IndicativePriceWithdrawn_FallsBackToTheLastTrade()
-        {
-            // the auction ends and continuous trading takes over, which quotes nothing
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnSessionChange(100);
-            restriction.OnTrade(200, default);
-            restriction.OnIndicativePrice(300);
+    [Test]
+    public void IndicativePriceWithdrawn_FallsBackToTheLastTrade()
+    {
+        // the auction ends and continuous trading takes over, which quotes nothing
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnSessionChange(100);
+        restriction.OnTrade(200, default);
+        restriction.OnIndicativePrice(300);
 
-            restriction.OnIndicativePrice(null);
+        restriction.OnIndicativePrice(null);
 
-            Assert.IsTrue(restriction.Allows(205, default));
-            Assert.IsFalse(restriction.Allows(300, default));
-        }
+        Assert.IsTrue(restriction.Allows(205, default));
+        Assert.IsFalse(restriction.Allows(300, default));
+    }
 
-        [Test]
-        public void IndicativePriceWithdrawn_NoTradeYet_FallsBackToTheSessionReference()
-        {
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnSessionChange(100);
-            restriction.OnIndicativePrice(300);
+    [Test]
+    public void IndicativePriceWithdrawn_NoTradeYet_FallsBackToTheSessionReference()
+    {
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnSessionChange(100);
+        restriction.OnIndicativePrice(300);
 
-            restriction.OnIndicativePrice(null);
+        restriction.OnIndicativePrice(null);
 
-            Assert.IsTrue(restriction.Allows(105, default));
-            Assert.IsFalse(restriction.Allows(300, default));
-        }
+        Assert.IsTrue(restriction.Allows(105, default));
+        Assert.IsFalse(restriction.Allows(300, default));
+    }
 
-        [Test]
-        public void OnSessionChange_ClearsWhatItSupersedes()
-        {
-            // a new session's settlement price has to beat the previous session's last trade, so
-            // an explicit reference clears the anchors above it rather than sitting underneath them
-            var restriction = new OrderPriceRestriction(5);
-            restriction.OnTrade(200, default);
-            restriction.OnIndicativePrice(300);
+    [Test]
+    public void OnSessionChange_ClearsWhatItSupersedes()
+    {
+        // a new session's settlement price has to beat the previous session's last trade, so
+        // an explicit reference clears the anchors above it rather than sitting underneath them
+        var restriction = new OrderPriceRestriction(5);
+        restriction.OnTrade(200, default);
+        restriction.OnIndicativePrice(300);
 
-            restriction.OnSessionChange(100);
+        restriction.OnSessionChange(100);
 
-            Assert.IsTrue(restriction.Allows(105, default));
-            Assert.IsFalse(restriction.Allows(200, default));
-            Assert.IsFalse(restriction.Allows(300, default));
-        }
+        Assert.IsTrue(restriction.Allows(105, default));
+        Assert.IsFalse(restriction.Allows(200, default));
+        Assert.IsFalse(restriction.Allows(300, default));
+    }
 
-        [Test]
-        public void AllowsStopSpread_WithinWidth_AtWidth_BeyondWidth()
-        {
-            var restriction = new OrderPriceRestriction(5);
+    [Test]
+    public void AllowsStopSpread_WithinWidth_AtWidth_BeyondWidth()
+    {
+        var restriction = new OrderPriceRestriction(5);
 
-            Assert.IsTrue(restriction.AllowsStopSpread(0));
-            Assert.IsTrue(restriction.AllowsStopSpread(4));
-            Assert.IsTrue(restriction.AllowsStopSpread(5));
-            Assert.IsFalse(restriction.AllowsStopSpread(6));
-        }
+        Assert.IsTrue(restriction.AllowsStopSpread(0));
+        Assert.IsTrue(restriction.AllowsStopSpread(4));
+        Assert.IsTrue(restriction.AllowsStopSpread(5));
+        Assert.IsFalse(restriction.AllowsStopSpread(6));
+    }
 
-        [Test]
-        public void AllowsStopSpread_DoesNotDependOnAReference()
-        {
-            // it measures a width, not a distance from anywhere
-            var restriction = new OrderPriceRestriction(5);
+    [Test]
+    public void AllowsStopSpread_DoesNotDependOnAReference()
+    {
+        // it measures a width, not a distance from anywhere
+        var restriction = new OrderPriceRestriction(5);
 
-            Assert.IsTrue(restriction.AllowsStopSpread(5));
-            Assert.IsFalse(restriction.AllowsStopSpread(6));
-        }
+        Assert.IsTrue(restriction.AllowsStopSpread(5));
+        Assert.IsFalse(restriction.AllowsStopSpread(6));
     }
 }

--- a/Circus.Tests/OrderBook/StaticPriceRangeRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/StaticPriceRangeRestrictionTests.cs
@@ -1,85 +1,83 @@
-using System;
 using Circus.OrderBook;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class StaticPriceRangeRestrictionTests
 {
-    [TestFixture]
-    public class StaticPriceRangeRestrictionTests
+    private static readonly DateTime T = new(2000, 1, 1, 12, 0, 0);
+
+    [Test]
+    public void Scope_IsTrade_OnBreach_IsPause()
     {
-        private static readonly DateTime T = new(2000, 1, 1, 12, 0, 0);
+        var restriction = new StaticPriceRangeRestriction(5);
 
-        [Test]
-        public void Scope_IsTrade_OnBreach_IsPause()
-        {
-            var restriction = new StaticPriceRangeRestriction(5);
+        Assert.AreEqual(RestrictionScope.Trade, restriction.Scope);
+        Assert.AreEqual(RestrictionBreachAction.Pause, restriction.OnBreach);
+    }
 
-            Assert.AreEqual(RestrictionScope.Trade, restriction.Scope);
-            Assert.AreEqual(RestrictionBreachAction.Pause, restriction.OnBreach);
-        }
+    [Test]
+    public void NoReferenceYet_AlwaysAllows()
+    {
+        var restriction = new StaticPriceRangeRestriction(5);
 
-        [Test]
-        public void NoReferenceYet_AlwaysAllows()
-        {
-            var restriction = new StaticPriceRangeRestriction(5);
+        Assert.IsTrue(restriction.Allows(1_000_000, T));
+    }
 
-            Assert.IsTrue(restriction.Allows(1_000_000, T));
-        }
+    [Test]
+    public void WithinRange_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
+    {
+        var restriction = new StaticPriceRangeRestriction(5);
+        restriction.OnSessionChange(100);
 
-        [Test]
-        public void WithinRange_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
-        {
-            var restriction = new StaticPriceRangeRestriction(5);
-            restriction.OnSessionChange(100);
+        Assert.IsTrue(restriction.Allows(105, T));
+        Assert.IsTrue(restriction.Allows(95, T));
+        Assert.IsFalse(restriction.Allows(106, T));
+        Assert.IsFalse(restriction.Allows(94, T));
+    }
 
-            Assert.IsTrue(restriction.Allows(105, T));
-            Assert.IsTrue(restriction.Allows(95, T));
-            Assert.IsFalse(restriction.Allows(106, T));
-            Assert.IsFalse(restriction.Allows(94, T));
-        }
+    [Test]
+    public void TradesDoNotMoveIt()
+    {
+        // the whole point: a range that followed the market could be walked anywhere over a day
+        // without ever being breached, because every step is small next to the last one
+        var restriction = new StaticPriceRangeRestriction(5);
+        restriction.OnSessionChange(100);
 
-        [Test]
-        public void TradesDoNotMoveIt()
-        {
-            // the whole point: a range that followed the market could be walked anywhere over a day
-            // without ever being breached, because every step is small next to the last one
-            var restriction = new StaticPriceRangeRestriction(5);
-            restriction.OnSessionChange(100);
+        restriction.OnTrade(105, T);
+        restriction.OnTrade(110, T.AddSeconds(1));
 
-            restriction.OnTrade(105, T);
-            restriction.OnTrade(110, T.AddSeconds(1));
+        Assert.IsFalse(restriction.Allows(111, T.AddSeconds(2)),
+            "still measured from 100, however far the market has walked");
+    }
 
-            Assert.IsFalse(restriction.Allows(111, T.AddSeconds(2)),
-                "still measured from 100, however far the market has walked");
-        }
+    [Test]
+    public void IndicativePrice_Ignored()
+    {
+        var restriction = new StaticPriceRangeRestriction(5);
+        restriction.OnSessionChange(100);
 
-        [Test]
-        public void IndicativePrice_Ignored()
-        {
-            var restriction = new StaticPriceRangeRestriction(5);
-            restriction.OnSessionChange(100);
+        restriction.OnIndicativePrice(300);
 
-            restriction.OnIndicativePrice(300);
+        Assert.IsFalse(restriction.Allows(300, T));
+    }
 
-            Assert.IsFalse(restriction.Allows(300, T));
-        }
+    [Test]
+    public void HasNoOpinionOnResumptionOrStopSpreads()
+    {
+        var restriction = new StaticPriceRangeRestriction(5);
+        restriction.OnSessionChange(100);
 
-        [Test]
-        public void HasNoOpinionOnResumptionOrStopSpreads()
-        {
-            var restriction = new StaticPriceRangeRestriction(5);
-            restriction.OnSessionChange(100);
+        Assert.IsTrue(restriction.AllowsResumption(1_000_000, T));
+        Assert.IsTrue(restriction.AllowsStopSpread(1_000_000));
+    }
 
-            Assert.IsTrue(restriction.AllowsResumption(1_000_000, T));
-            Assert.IsTrue(restriction.AllowsStopSpread(1_000_000));
-        }
+    [Test]
+    public void DurationConfigured_IsWhatThePauseResumesAfter()
+    {
+        var restriction = new StaticPriceRangeRestriction(5, TimeSpan.FromMinutes(2));
 
-        [Test]
-        public void DurationConfigured_IsWhatThePauseResumesAfter()
-        {
-            var restriction = new StaticPriceRangeRestriction(5, TimeSpan.FromMinutes(2));
-
-            Assert.AreEqual(TimeSpan.FromMinutes(2), restriction.ResumeAfter);
-        }
+        Assert.AreEqual(TimeSpan.FromMinutes(2), restriction.ResumeAfter);
     }
 }

--- a/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
+++ b/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
@@ -1,187 +1,185 @@
-using System;
 using Circus.OrderBook;
 using NUnit.Framework;
 
-namespace Circus.Tests.OrderBook
+namespace Circus.Tests.OrderBook;
+
+[TestFixture]
+public class VolatilityBandRestrictionTests
 {
-    [TestFixture]
-    public class VolatilityBandRestrictionTests
+    private static readonly DateTime T = new(2000, 1, 1, 12, 0, 0);
+
+    [Test]
+    public void Scope_IsTrade_OnBreach_IsPause()
     {
-        private static readonly DateTime T = new(2000, 1, 1, 12, 0, 0);
+        var restriction = new VolatilityBandRestriction(5);
 
-        [Test]
-        public void Scope_IsTrade_OnBreach_IsPause()
-        {
-            var restriction = new VolatilityBandRestriction(5);
+        Assert.AreEqual(RestrictionScope.Trade, restriction.Scope);
+        Assert.AreEqual(RestrictionBreachAction.Pause, restriction.OnBreach);
+    }
 
-            Assert.AreEqual(RestrictionScope.Trade, restriction.Scope);
-            Assert.AreEqual(RestrictionBreachAction.Pause, restriction.OnBreach);
-        }
+    [Test]
+    public void Window_MeasuresAgainstEveryTradeStillInIt()
+    {
+        // arrange - two trades 10 seconds apart, both inside a 30-second window
+        var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+        restriction.OnTrade(100, T);
+        restriction.OnTrade(103, T.AddSeconds(10));
 
-        [Test]
-        public void Window_MeasuresAgainstEveryTradeStillInIt()
-        {
-            // arrange - two trades 10 seconds apart, both inside a 30-second window
-            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
-            restriction.OnTrade(100, T);
-            restriction.OnTrade(103, T.AddSeconds(10));
+        // assert - 107 is within range of the newer trade but not of the older one, and the
+        // older one still counts
+        Assert.IsTrue(restriction.Allows(105, T.AddSeconds(11)), "in range of both");
+        Assert.IsFalse(restriction.Allows(107, T.AddSeconds(11)), "in range of 103 but not of 100");
+    }
 
-            // assert - 107 is within range of the newer trade but not of the older one, and the
-            // older one still counts
-            Assert.IsTrue(restriction.Allows(105, T.AddSeconds(11)), "in range of both");
-            Assert.IsFalse(restriction.Allows(107, T.AddSeconds(11)), "in range of 103 but not of 100");
-        }
+    [Test]
+    public void Window_TradesAgeOutOfIt()
+    {
+        // arrange - the same pair
+        var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+        restriction.OnTrade(100, T);
+        restriction.OnTrade(103, T.AddSeconds(10));
 
-        [Test]
-        public void Window_TradesAgeOutOfIt()
-        {
-            // arrange - the same pair
-            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
-            restriction.OnTrade(100, T);
-            restriction.OnTrade(103, T.AddSeconds(10));
+        // act - far enough on that only the newer trade is still inside the window
+        var laterOn = T.AddSeconds(31);
 
-            // act - far enough on that only the newer trade is still inside the window
-            var laterOn = T.AddSeconds(31);
+        // assert - the price refused a moment ago is allowed now, purely because time passed
+        Assert.IsTrue(restriction.Allows(107, laterOn));
+    }
 
-            // assert - the price refused a moment ago is allowed now, purely because time passed
-            Assert.IsTrue(restriction.Allows(107, laterOn));
-        }
+    [Test]
+    public void Window_NeverEmptiesCompletely()
+    {
+        // arrange - a market that has gone quiet is still measured against where it last
+        // traded, not against nothing at all
+        var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+        restriction.OnTrade(100, T);
 
-        [Test]
-        public void Window_NeverEmptiesCompletely()
-        {
-            // arrange - a market that has gone quiet is still measured against where it last
-            // traded, not against nothing at all
-            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
-            restriction.OnTrade(100, T);
+        // assert
+        Assert.IsTrue(restriction.Allows(105, T.AddDays(1)));
+        Assert.IsFalse(restriction.Allows(106, T.AddDays(1)));
+    }
 
-            // assert
-            Assert.IsTrue(restriction.Allows(105, T.AddDays(1)));
-            Assert.IsFalse(restriction.Allows(106, T.AddDays(1)));
-        }
+    [Test]
+    public void NoWindow_MeasuresAgainstTheLastTradeAlone()
+    {
+        // arrange - the older trade is discarded outright rather than kept and aged
+        var restriction = new VolatilityBandRestriction(5);
+        restriction.OnTrade(100, T);
+        restriction.OnTrade(103, T.AddSeconds(10));
 
-        [Test]
-        public void NoWindow_MeasuresAgainstTheLastTradeAlone()
-        {
-            // arrange - the older trade is discarded outright rather than kept and aged
-            var restriction = new VolatilityBandRestriction(5);
-            restriction.OnTrade(100, T);
-            restriction.OnTrade(103, T.AddSeconds(10));
+        // assert - 107 is out of range of 100, which no longer counts for anything
+        Assert.IsTrue(restriction.Allows(107, T.AddSeconds(11)));
+    }
 
-            // assert - 107 is out of range of 100, which no longer counts for anything
-            Assert.IsTrue(restriction.Allows(107, T.AddSeconds(11)));
-        }
+    [Test]
+    public void OnSessionChange_ClearsTheWindow()
+    {
+        // arrange - an explicit reference supersedes what the market did before it
+        var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
+        restriction.OnTrade(200, T);
 
-        [Test]
-        public void OnSessionChange_ClearsTheWindow()
-        {
-            // arrange - an explicit reference supersedes what the market did before it
-            var restriction = new VolatilityBandRestriction(5, window: TimeSpan.FromSeconds(30));
-            restriction.OnTrade(200, T);
+        restriction.OnSessionChange(100);
 
-            restriction.OnSessionChange(100);
+        // assert - measured from the new reference, with the trade at 200 forgotten
+        Assert.IsTrue(restriction.Allows(105, T.AddSeconds(1)));
+        Assert.IsFalse(restriction.Allows(200, T.AddSeconds(1)));
+    }
 
-            // assert - measured from the new reference, with the trade at 200 forgotten
-            Assert.IsTrue(restriction.Allows(105, T.AddSeconds(1)));
-            Assert.IsFalse(restriction.Allows(200, T.AddSeconds(1)));
-        }
+    [Test]
+    public void NoExtendedRange_AnInterruptionAlwaysEnds()
+    {
+        var restriction = new VolatilityBandRestriction(5);
+        restriction.OnTrade(100, T);
 
-        [Test]
-        public void NoExtendedRange_AnInterruptionAlwaysEnds()
-        {
-            var restriction = new VolatilityBandRestriction(5);
-            restriction.OnTrade(100, T);
+        Assert.IsFalse(restriction.Allows(1_000, T), "well outside the ordinary range");
+        Assert.IsTrue(restriction.AllowsResumption(1_000, T), "but nothing holds the resumption back");
+    }
 
-            Assert.IsFalse(restriction.Allows(1_000, T), "well outside the ordinary range");
-            Assert.IsTrue(restriction.AllowsResumption(1_000, T), "but nothing holds the resumption back");
-        }
+    [Test]
+    public void ExtendedRange_HoldsTheClosingPriceToAWiderRange()
+    {
+        // arrange - ordinary range 5, extended range 10
+        var restriction = new VolatilityBandRestriction(5, extendedRangeTicks: 10);
+        restriction.OnTrade(100, T);
 
-        [Test]
-        public void ExtendedRange_HoldsTheClosingPriceToAWiderRange()
-        {
-            // arrange - ordinary range 5, extended range 10
-            var restriction = new VolatilityBandRestriction(5, extendedRangeTicks: 10);
-            restriction.OnTrade(100, T);
+        // assert - between the two ranges: enough to have caused the interruption, not enough
+        // to keep it running
+        Assert.IsFalse(restriction.Allows(106, T));
+        Assert.IsTrue(restriction.AllowsResumption(106, T));
 
-            // assert - between the two ranges: enough to have caused the interruption, not enough
-            // to keep it running
-            Assert.IsFalse(restriction.Allows(106, T));
-            Assert.IsTrue(restriction.AllowsResumption(106, T));
+        // beyond the extended range: the interruption keeps running
+        Assert.IsFalse(restriction.AllowsResumption(111, T));
+    }
 
-            // beyond the extended range: the interruption keeps running
-            Assert.IsFalse(restriction.AllowsResumption(111, T));
-        }
+    [Test]
+    public void NoDurationConfigured_PauseIsOpenEnded()
+    {
+        var restriction = new VolatilityBandRestriction(5);
 
-        [Test]
-        public void NoDurationConfigured_PauseIsOpenEnded()
-        {
-            var restriction = new VolatilityBandRestriction(5);
+        Assert.IsNull(restriction.ResumeAfter);
+    }
 
-            Assert.IsNull(restriction.ResumeAfter);
-        }
+    [Test]
+    public void DurationConfigured_IsWhatThePauseResumesAfter()
+    {
+        var restriction = new VolatilityBandRestriction(5, TimeSpan.FromMinutes(2));
 
-        [Test]
-        public void DurationConfigured_IsWhatThePauseResumesAfter()
-        {
-            var restriction = new VolatilityBandRestriction(5, TimeSpan.FromMinutes(2));
+        Assert.AreEqual(TimeSpan.FromMinutes(2), restriction.ResumeAfter);
+    }
 
-            Assert.AreEqual(TimeSpan.FromMinutes(2), restriction.ResumeAfter);
-        }
+    [Test]
+    public void NoReferencePriceYet_AlwaysAllows()
+    {
+        var restriction = new VolatilityBandRestriction(5);
 
-        [Test]
-        public void NoReferencePriceYet_AlwaysAllows()
-        {
-            var restriction = new VolatilityBandRestriction(5);
+        Assert.IsTrue(restriction.Allows(1_000_000, default));
+    }
 
-            Assert.IsTrue(restriction.Allows(1_000_000, default));
-        }
+    [Test]
+    public void WithinBand_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
+    {
+        var restriction = new VolatilityBandRestriction(5);
+        restriction.OnSessionChange(100);
 
-        [Test]
-        public void WithinBand_Allowed_AtEdge_Allowed_BeyondEdge_Disallowed()
-        {
-            var restriction = new VolatilityBandRestriction(5);
-            restriction.OnSessionChange(100);
+        Assert.IsTrue(restriction.Allows(100, default));
+        Assert.IsTrue(restriction.Allows(105, default));
+        Assert.IsTrue(restriction.Allows(95, default));
+        Assert.IsFalse(restriction.Allows(106, default));
+        Assert.IsFalse(restriction.Allows(94, default));
+    }
 
-            Assert.IsTrue(restriction.Allows(100, default));
-            Assert.IsTrue(restriction.Allows(105, default));
-            Assert.IsTrue(restriction.Allows(95, default));
-            Assert.IsFalse(restriction.Allows(106, default));
-            Assert.IsFalse(restriction.Allows(94, default));
-        }
+    [Test]
+    public void IndicativePrice_Ignored()
+    {
+        // volatility is measured against prices that actually traded, not one an auction is
+        // only quoting - the entry band is the restriction that follows the indicative price
+        var restriction = new VolatilityBandRestriction(5);
+        restriction.OnSessionChange(100);
 
-        [Test]
-        public void IndicativePrice_Ignored()
-        {
-            // volatility is measured against prices that actually traded, not one an auction is
-            // only quoting - the entry band is the restriction that follows the indicative price
-            var restriction = new VolatilityBandRestriction(5);
-            restriction.OnSessionChange(100);
+        restriction.OnIndicativePrice(300);
 
-            restriction.OnIndicativePrice(300);
+        Assert.IsTrue(restriction.Allows(105, default));
+        Assert.IsFalse(restriction.Allows(300, default));
+    }
 
-            Assert.IsTrue(restriction.Allows(105, default));
-            Assert.IsFalse(restriction.Allows(300, default));
-        }
+    [Test]
+    public void StopSpread_Unconstrained_NotAnEntryRestriction()
+    {
+        var restriction = new VolatilityBandRestriction(5);
 
-        [Test]
-        public void StopSpread_Unconstrained_NotAnEntryRestriction()
-        {
-            var restriction = new VolatilityBandRestriction(5);
+        Assert.IsTrue(restriction.AllowsStopSpread(1_000_000));
+    }
 
-            Assert.IsTrue(restriction.AllowsStopSpread(1_000_000));
-        }
+    [Test]
+    public void OnTrade_MovesReferenceToLastTrade()
+    {
+        var restriction = new VolatilityBandRestriction(5);
+        restriction.OnSessionChange(100);
 
-        [Test]
-        public void OnTrade_MovesReferenceToLastTrade()
-        {
-            var restriction = new VolatilityBandRestriction(5);
-            restriction.OnSessionChange(100);
+        restriction.OnTrade(200, default);
 
-            restriction.OnTrade(200, default);
-
-            Assert.IsTrue(restriction.Allows(205, default));
-            Assert.IsFalse(restriction.Allows(206, default));
-            Assert.IsFalse(restriction.Allows(100, default));
-        }
+        Assert.IsTrue(restriction.Allows(205, default));
+        Assert.IsFalse(restriction.Allows(206, default));
+        Assert.IsFalse(restriction.Allows(100, default));
     }
 }

--- a/Circus.Tests/SessionProviderTests.cs
+++ b/Circus.Tests/SessionProviderTests.cs
@@ -1,524 +1,521 @@
-﻿using System;
-using System.Collections.Generic;
 using Circus.OrderBook;
 using Circus.SessionProviders;
 using NUnit.Framework;
 
-namespace Circus.Tests
+namespace Circus.Tests;
+
+[TestFixture]
+public class SessionProviderTests
 {
-    [TestFixture]
-    public class SessionProviderTests
+    [Test]
+    public void Constructor_Valid_Success()
     {
-        [Test]
-        public void Constructor_Valid_Success()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-
-            // assert
-            new SessionProvider(preOpen, open, close);
-        }
-
-        [Test]
-        public void Constructor_OpenBeforePreOpen_ArgumentException()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 20, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-
-            // assert
-            Assert.Catch<ArgumentException>(
-                () => new SessionProvider(preOpen, open, close)
-            );
-        }
-
-        [Test]
-        public void Constructor_CloseBeforeOpen_ArgumentException()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 00, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(1, 5, 0);
-
-            // assert
-            Assert.Catch<ArgumentException>(
-                () => new SessionProvider(preOpen, open, close)
-            );
-        }
-
-        [Test]
-        public void Update_BeforePreOpen_Closed()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now = new DateTime(2000, 1, 1, 0, 0, 0);
-
-            // act
-            sessionProvider.Update(now);
-
-            // assert
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.AreEqual(now, statuses[0].Time);
-        }
-
-        [Test]
-        public void Update_AfterClosed_PreOpen()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Update(new DateTime(2000, 1, 1, 0, 0, 0));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-            
-            var now = new DateTime(2000, 1, 1, 1, 0, 0);
-
-            // act
-            sessionProvider.Update(now);
-
-            // assert
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[0].Status);
-            Assert.AreEqual(now, statuses[0].Time);
-        }
-
-        [Test]
-        public void Update_AfterPreOpen_Open()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Update(new DateTime(2000, 1, 1, 0, 0, 0));
-            sessionProvider.Update(new DateTime(2000, 1, 1, 1, 0, 0));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now = new DateTime(2000, 1, 1, 1, 10, 0);
-            
-            // act
-            sessionProvider.Update(now);
-
-            // assert
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[0].Status);
-            Assert.AreEqual(now, statuses[0].Time);
-        }
-
-        [Test]
-        public void Update_AfterOpen_Closed()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            sessionProvider.Update(new DateTime(2000, 1, 1, 0, 0, 0));
-            sessionProvider.Update(new DateTime(2000, 1, 1, 1, 0, 0));
-            sessionProvider.Update(new DateTime(2000, 1, 1, 1, 10, 0));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now = new DateTime(2000, 1, 1, 22, 10, 0);
-            
-            // act
-            sessionProvider.Update(now);
-
-            // assert
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.AreEqual(now, statuses[0].Time);
-        }
-
-        [Test]
-        public void Update_SkipToAfterPreOpen_ClosedPreOpen()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now = new DateTime(2000, 1, 1, 1, 0, 0);
-            
-            // act
-            sessionProvider.Update(now);
-
-            // assert
-            Assert.AreEqual(2, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.AreEqual(now, statuses[0].Time);
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
-            Assert.AreEqual(now, statuses[0].Time);
-        }
-
-        [Test]
-        public void Update_SkipToAfterOpen_ClosedPreOpenOpen()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now = new DateTime(2000, 1, 1, 1, 10, 0);
-            
-            // act
-            sessionProvider.Update(now);
-
-            // assert
-            Assert.AreEqual(3, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.AreEqual(now, statuses[0].Time);
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
-            Assert.AreEqual(now.Date.Add(preOpen), statuses[1].Time);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
-            Assert.AreEqual(now.Date.Add(open), statuses[2].Time);
-        }
-
-        [Test]
-        public void Update_Closed_SkipToAfterClosed_Closed()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now = new DateTime(2000, 1, 1, 22, 10, 0);
-            
-            // act
-            sessionProvider.Update(now);
-
-            // assert
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-        }
-
-        [Test]
-        public void Update_PreOpen_SkipToAfterClosed_OpenClosed()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            var now1 = new DateTime(2000, 1, 1, 1, 0, 0);
-            sessionProvider.Update(now1);
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now2 = new DateTime(2000, 1, 1, 22, 11, 0);
-            
-            // act
-            sessionProvider.Update(now2);
-
-            // assert
-            Assert.AreEqual(2, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[0].Status);
-            Assert.AreEqual(now1.Date.Add(open), statuses[0].Time);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[1].Status);
-            Assert.AreEqual(now2.Date.Add(close), statuses[1].Time);
-        }
-
-        [Test]
-        public void Update_OpenNextDay_ClosedOpen()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            var now1 = new DateTime(2000, 1, 1, 1, 10, 0);
-            sessionProvider.Update(now1);
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now2 = new DateTime(2000, 1, 2, 1, 10, 0);
-            
-            // act
-            sessionProvider.Update(now2);
-
-            // assert
-            Assert.AreEqual(3, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.AreEqual(now1.Date.Add(close), statuses[0].Time);
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
-            Assert.AreEqual(now2.Date.Add(preOpen), statuses[1].Time);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
-            Assert.AreEqual(now2.Date.Add(open), statuses[2].Time);
-        }
-
-        // A day with a morning and an afternoon session, closing for a break in between.
-        private static readonly TradingSession Morning =
-            new(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(11, 0, 0));
-
-        private static readonly TradingSession Afternoon =
-            new(new TimeSpan(13, 0, 0), new TimeSpan(13, 30, 0), new TimeSpan(16, 0, 0));
-
-        private static SessionProvider TwoSessionProvider() =>
-            new(new[] {Morning, Afternoon});
-
-        [Test]
-        public void Constructor_NoSessions_ArgumentException()
-        {
-            // assert
-            Assert.Catch<ArgumentException>(
-                () => new SessionProvider(Array.Empty<TradingSession>())
-            );
-        }
-
-        [Test]
-        public void Constructor_OverlappingSessions_ArgumentException()
-        {
-            // arrange - the afternoon pre-opens before the morning has closed
-            var overlapping = new TradingSession(new TimeSpan(10, 0, 0), new TimeSpan(13, 30, 0),
-                new TimeSpan(16, 0, 0));
-
-            // assert
-            Assert.Catch<ArgumentException>(
-                () => new SessionProvider(new[] {Morning, overlapping})
-            );
-        }
-
-        [Test]
-        public void Constructor_UnorderedSessions_ArgumentException()
-        {
-            // assert
-            Assert.Catch<ArgumentException>(
-                () => new SessionProvider(new[] {Afternoon, Morning})
-            );
-        }
-
-        [Test]
-        public void Constructor_TouchingSessions_Success()
-        {
-            // arrange - a session may begin the moment the previous one closes
-            var touching = new TradingSession(new TimeSpan(11, 0, 0), new TimeSpan(11, 30, 0),
-                new TimeSpan(16, 0, 0));
-
-            // assert
-            new SessionProvider(new[] {Morning, touching});
-        }
-
-        [Test]
-        public void Update_TwoSessions_FullDayCycle()
-        {
-            // arrange
-            var sessionProvider = TwoSessionProvider();
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var day = new DateTime(2000, 1, 1);
-
-            // act - walk the whole day past the last close
-            sessionProvider.Update(day.Add(new TimeSpan(7, 0, 0)));
-            sessionProvider.Update(day.Add(new TimeSpan(8, 30, 0)));
-            sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
-            sessionProvider.Update(day.Add(new TimeSpan(13, 30, 0)));
-            sessionProvider.Update(day.Add(new TimeSpan(16, 0, 0)));
-
-            // assert
-            Assert.AreEqual(7, statuses.Count);
-
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
-            Assert.AreEqual(day.Add(Morning.PreOpen), statuses[1].Time);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
-            Assert.AreEqual(day.Add(Morning.Open), statuses[2].Time);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[3].Status);
-            Assert.AreEqual(day.Add(Morning.Close), statuses[3].Time);
-
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[4].Status);
-            Assert.AreEqual(day.Add(Afternoon.PreOpen), statuses[4].Time);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[5].Status);
-            Assert.AreEqual(day.Add(Afternoon.Open), statuses[5].Time);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[6].Status);
-            Assert.AreEqual(day.Add(Afternoon.Close), statuses[6].Time);
-        }
-
-        [Test]
-        public void Update_IntradayClose_DoesNotEndTradingDay()
-        {
-            // arrange
-            var sessionProvider = TwoSessionProvider();
-            var day = new DateTime(2000, 1, 1);
-            sessionProvider.Update(day.Add(new TimeSpan(8, 30, 0)));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            // act
-            sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
-
-            // assert - the afternoon is still to come, so day orders must survive this close
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.IsFalse(statuses[0].EndsTradingDay);
-        }
-
-        [Test]
-        public void Update_FinalClose_EndsTradingDay()
-        {
-            // arrange
-            var sessionProvider = TwoSessionProvider();
-            var day = new DateTime(2000, 1, 1);
-            sessionProvider.Update(day.Add(new TimeSpan(13, 30, 0)));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            // act
-            sessionProvider.Update(day.Add(new TimeSpan(16, 0, 0)));
-
-            // assert
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.IsTrue(statuses[0].EndsTradingDay);
-        }
-
-        [Test]
-        public void Update_SingleSession_CloseEndsTradingDay()
-        {
-            // arrange - a lone session is also the day's last
-            var sessionProvider = new SessionProvider(new TimeSpan(1, 0, 0), new TimeSpan(1, 10, 0),
-                new TimeSpan(22, 10, 0));
-            sessionProvider.Update(new DateTime(2000, 1, 1, 1, 10, 0));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            // act
-            sessionProvider.Update(new DateTime(2000, 1, 1, 22, 10, 0));
-
-            // assert
-            Assert.AreEqual(1, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.IsTrue(statuses[0].EndsTradingDay);
-        }
-
-        [Test]
-        public void Update_BetweenSessions_StaysClosed()
-        {
-            // arrange
-            var sessionProvider = TwoSessionProvider();
-            var day = new DateTime(2000, 1, 1);
-            sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            // act - the middle of the break
-            sessionProvider.Update(day.Add(new TimeSpan(12, 0, 0)));
-
-            // assert - nothing happens until the afternoon pre-opens
-            Assert.AreEqual(0, statuses.Count);
-        }
-
-        [Test]
-        public void Update_CatchUpIntoSecondSession_SkipsStraightToOpen()
-        {
-            // arrange - the first Update lands mid-afternoon, having missed the whole morning
-            var sessionProvider = TwoSessionProvider();
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now = new DateTime(2000, 1, 1, 14, 0, 0);
-
-            // act
-            sessionProvider.Update(now);
-
-            // assert - the session in progress wins; the morning is not replayed
-            Assert.AreEqual(3, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
-            Assert.AreEqual(now.Date.Add(Afternoon.PreOpen), statuses[1].Time);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
-            Assert.AreEqual(now.Date.Add(Afternoon.Open), statuses[2].Time);
-        }
-
-        [Test]
-        public void Update_TwoSessions_NextDay_WrapsToFirstSession()
-        {
-            // arrange - closed after the afternoon of day 1
-            var sessionProvider = TwoSessionProvider();
-            var day1 = new DateTime(2000, 1, 1);
-            sessionProvider.Update(day1.Add(new TimeSpan(16, 0, 0)));
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var day2 = new DateTime(2000, 1, 2);
-
-            // act
-            sessionProvider.Update(day2.Add(new TimeSpan(8, 30, 0)));
-
-            // assert - day 2 begins with the morning session again
-            Assert.AreEqual(2, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[0].Status);
-            Assert.AreEqual(day2.Add(Morning.PreOpen), statuses[0].Time);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[1].Status);
-            Assert.AreEqual(day2.Add(Morning.Open), statuses[1].Time);
-        }
-
-        [Test]
-        public void Update_OpenTwoDaysLater_SkipsEmptyDay()
-        {
-            // arrange
-            var preOpen = new TimeSpan(1, 0, 0);
-            var open = new TimeSpan(1, 10, 0);
-            var close = new TimeSpan(22, 10, 0);
-            var sessionProvider = new SessionProvider(preOpen, open, close);
-            var now1 = new DateTime(2000, 1, 1, 1, 10, 0);
-            sessionProvider.Update(now1);
-
-            var statuses = new List<SessionStatusChangedArgs>();
-            sessionProvider.Changed += (_, status) => statuses.Add(status);
-
-            var now2 = new DateTime(2000, 1, 3, 1, 10, 0);
-            
-            // act
-            sessionProvider.Update(now2);
-
-            // assert
-            Assert.AreEqual(3, statuses.Count);
-            Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
-            Assert.AreEqual(now1.Date.Add(close), statuses[0].Time);
-            Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
-            Assert.AreEqual(now2.Date.Add(preOpen), statuses[1].Time);
-            Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
-            Assert.AreEqual(now2.Date.Add(open), statuses[2].Time);
-        }
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+
+        // assert
+        new SessionProvider(preOpen, open, close);
+    }
+
+    [Test]
+    public void Constructor_OpenBeforePreOpen_ArgumentException()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 20, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+
+        // assert
+        Assert.Catch<ArgumentException>(
+            () => new SessionProvider(preOpen, open, close)
+        );
+    }
+
+    [Test]
+    public void Constructor_CloseBeforeOpen_ArgumentException()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 00, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(1, 5, 0);
+
+        // assert
+        Assert.Catch<ArgumentException>(
+            () => new SessionProvider(preOpen, open, close)
+        );
+    }
+
+    [Test]
+    public void Update_BeforePreOpen_Closed()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 0, 0, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.AreEqual(now, statuses[0].Time);
+    }
+
+    [Test]
+    public void Update_AfterClosed_PreOpen()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        sessionProvider.Update(new DateTime(2000, 1, 1, 0, 0, 0));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 1, 0, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[0].Status);
+        Assert.AreEqual(now, statuses[0].Time);
+    }
+
+    [Test]
+    public void Update_AfterPreOpen_Open()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        sessionProvider.Update(new DateTime(2000, 1, 1, 0, 0, 0));
+        sessionProvider.Update(new DateTime(2000, 1, 1, 1, 0, 0));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 1, 10, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[0].Status);
+        Assert.AreEqual(now, statuses[0].Time);
+    }
+
+    [Test]
+    public void Update_AfterOpen_Closed()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        sessionProvider.Update(new DateTime(2000, 1, 1, 0, 0, 0));
+        sessionProvider.Update(new DateTime(2000, 1, 1, 1, 0, 0));
+        sessionProvider.Update(new DateTime(2000, 1, 1, 1, 10, 0));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 22, 10, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.AreEqual(now, statuses[0].Time);
+    }
+
+    [Test]
+    public void Update_SkipToAfterPreOpen_ClosedPreOpen()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 1, 0, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert
+        Assert.AreEqual(2, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.AreEqual(now, statuses[0].Time);
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+        Assert.AreEqual(now, statuses[0].Time);
+    }
+
+    [Test]
+    public void Update_SkipToAfterOpen_ClosedPreOpenOpen()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 1, 10, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert
+        Assert.AreEqual(3, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.AreEqual(now, statuses[0].Time);
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+        Assert.AreEqual(now.Date.Add(preOpen), statuses[1].Time);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
+        Assert.AreEqual(now.Date.Add(open), statuses[2].Time);
+    }
+
+    [Test]
+    public void Update_Closed_SkipToAfterClosed_Closed()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 22, 10, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+    }
+
+    [Test]
+    public void Update_PreOpen_SkipToAfterClosed_OpenClosed()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        var now1 = new DateTime(2000, 1, 1, 1, 0, 0);
+        sessionProvider.Update(now1);
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now2 = new DateTime(2000, 1, 1, 22, 11, 0);
+
+        // act
+        sessionProvider.Update(now2);
+
+        // assert
+        Assert.AreEqual(2, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[0].Status);
+        Assert.AreEqual(now1.Date.Add(open), statuses[0].Time);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[1].Status);
+        Assert.AreEqual(now2.Date.Add(close), statuses[1].Time);
+    }
+
+    [Test]
+    public void Update_OpenNextDay_ClosedOpen()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        var now1 = new DateTime(2000, 1, 1, 1, 10, 0);
+        sessionProvider.Update(now1);
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now2 = new DateTime(2000, 1, 2, 1, 10, 0);
+
+        // act
+        sessionProvider.Update(now2);
+
+        // assert
+        Assert.AreEqual(3, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.AreEqual(now1.Date.Add(close), statuses[0].Time);
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+        Assert.AreEqual(now2.Date.Add(preOpen), statuses[1].Time);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
+        Assert.AreEqual(now2.Date.Add(open), statuses[2].Time);
+    }
+
+    // A day with a morning and an afternoon session, closing for a break in between.
+    private static readonly TradingSession Morning =
+        new(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(11, 0, 0));
+
+    private static readonly TradingSession Afternoon =
+        new(new TimeSpan(13, 0, 0), new TimeSpan(13, 30, 0), new TimeSpan(16, 0, 0));
+
+    private static SessionProvider TwoSessionProvider() =>
+        new(new[] {Morning, Afternoon});
+
+    [Test]
+    public void Constructor_NoSessions_ArgumentException()
+    {
+        // assert
+        Assert.Catch<ArgumentException>(
+            () => new SessionProvider(Array.Empty<TradingSession>())
+        );
+    }
+
+    [Test]
+    public void Constructor_OverlappingSessions_ArgumentException()
+    {
+        // arrange - the afternoon pre-opens before the morning has closed
+        var overlapping = new TradingSession(new TimeSpan(10, 0, 0), new TimeSpan(13, 30, 0),
+            new TimeSpan(16, 0, 0));
+
+        // assert
+        Assert.Catch<ArgumentException>(
+            () => new SessionProvider(new[] {Morning, overlapping})
+        );
+    }
+
+    [Test]
+    public void Constructor_UnorderedSessions_ArgumentException()
+    {
+        // assert
+        Assert.Catch<ArgumentException>(
+            () => new SessionProvider(new[] {Afternoon, Morning})
+        );
+    }
+
+    [Test]
+    public void Constructor_TouchingSessions_Success()
+    {
+        // arrange - a session may begin the moment the previous one closes
+        var touching = new TradingSession(new TimeSpan(11, 0, 0), new TimeSpan(11, 30, 0),
+            new TimeSpan(16, 0, 0));
+
+        // assert
+        new SessionProvider(new[] {Morning, touching});
+    }
+
+    [Test]
+    public void Update_TwoSessions_FullDayCycle()
+    {
+        // arrange
+        var sessionProvider = TwoSessionProvider();
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var day = new DateTime(2000, 1, 1);
+
+        // act - walk the whole day past the last close
+        sessionProvider.Update(day.Add(new TimeSpan(7, 0, 0)));
+        sessionProvider.Update(day.Add(new TimeSpan(8, 30, 0)));
+        sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
+        sessionProvider.Update(day.Add(new TimeSpan(13, 30, 0)));
+        sessionProvider.Update(day.Add(new TimeSpan(16, 0, 0)));
+
+        // assert
+        Assert.AreEqual(7, statuses.Count);
+
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+        Assert.AreEqual(day.Add(Morning.PreOpen), statuses[1].Time);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
+        Assert.AreEqual(day.Add(Morning.Open), statuses[2].Time);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[3].Status);
+        Assert.AreEqual(day.Add(Morning.Close), statuses[3].Time);
+
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[4].Status);
+        Assert.AreEqual(day.Add(Afternoon.PreOpen), statuses[4].Time);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[5].Status);
+        Assert.AreEqual(day.Add(Afternoon.Open), statuses[5].Time);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[6].Status);
+        Assert.AreEqual(day.Add(Afternoon.Close), statuses[6].Time);
+    }
+
+    [Test]
+    public void Update_IntradayClose_DoesNotEndTradingDay()
+    {
+        // arrange
+        var sessionProvider = TwoSessionProvider();
+        var day = new DateTime(2000, 1, 1);
+        sessionProvider.Update(day.Add(new TimeSpan(8, 30, 0)));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        // act
+        sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
+
+        // assert - the afternoon is still to come, so day orders must survive this close
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.IsFalse(statuses[0].EndsTradingDay);
+    }
+
+    [Test]
+    public void Update_FinalClose_EndsTradingDay()
+    {
+        // arrange
+        var sessionProvider = TwoSessionProvider();
+        var day = new DateTime(2000, 1, 1);
+        sessionProvider.Update(day.Add(new TimeSpan(13, 30, 0)));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        // act
+        sessionProvider.Update(day.Add(new TimeSpan(16, 0, 0)));
+
+        // assert
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.IsTrue(statuses[0].EndsTradingDay);
+    }
+
+    [Test]
+    public void Update_SingleSession_CloseEndsTradingDay()
+    {
+        // arrange - a lone session is also the day's last
+        var sessionProvider = new SessionProvider(new TimeSpan(1, 0, 0), new TimeSpan(1, 10, 0),
+            new TimeSpan(22, 10, 0));
+        sessionProvider.Update(new DateTime(2000, 1, 1, 1, 10, 0));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        // act
+        sessionProvider.Update(new DateTime(2000, 1, 1, 22, 10, 0));
+
+        // assert
+        Assert.AreEqual(1, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.IsTrue(statuses[0].EndsTradingDay);
+    }
+
+    [Test]
+    public void Update_BetweenSessions_StaysClosed()
+    {
+        // arrange
+        var sessionProvider = TwoSessionProvider();
+        var day = new DateTime(2000, 1, 1);
+        sessionProvider.Update(day.Add(new TimeSpan(11, 0, 0)));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        // act - the middle of the break
+        sessionProvider.Update(day.Add(new TimeSpan(12, 0, 0)));
+
+        // assert - nothing happens until the afternoon pre-opens
+        Assert.AreEqual(0, statuses.Count);
+    }
+
+    [Test]
+    public void Update_CatchUpIntoSecondSession_SkipsStraightToOpen()
+    {
+        // arrange - the first Update lands mid-afternoon, having missed the whole morning
+        var sessionProvider = TwoSessionProvider();
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now = new DateTime(2000, 1, 1, 14, 0, 0);
+
+        // act
+        sessionProvider.Update(now);
+
+        // assert - the session in progress wins; the morning is not replayed
+        Assert.AreEqual(3, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+        Assert.AreEqual(now.Date.Add(Afternoon.PreOpen), statuses[1].Time);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
+        Assert.AreEqual(now.Date.Add(Afternoon.Open), statuses[2].Time);
+    }
+
+    [Test]
+    public void Update_TwoSessions_NextDay_WrapsToFirstSession()
+    {
+        // arrange - closed after the afternoon of day 1
+        var sessionProvider = TwoSessionProvider();
+        var day1 = new DateTime(2000, 1, 1);
+        sessionProvider.Update(day1.Add(new TimeSpan(16, 0, 0)));
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var day2 = new DateTime(2000, 1, 2);
+
+        // act
+        sessionProvider.Update(day2.Add(new TimeSpan(8, 30, 0)));
+
+        // assert - day 2 begins with the morning session again
+        Assert.AreEqual(2, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[0].Status);
+        Assert.AreEqual(day2.Add(Morning.PreOpen), statuses[0].Time);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[1].Status);
+        Assert.AreEqual(day2.Add(Morning.Open), statuses[1].Time);
+    }
+
+    [Test]
+    public void Update_OpenTwoDaysLater_SkipsEmptyDay()
+    {
+        // arrange
+        var preOpen = new TimeSpan(1, 0, 0);
+        var open = new TimeSpan(1, 10, 0);
+        var close = new TimeSpan(22, 10, 0);
+        var sessionProvider = new SessionProvider(preOpen, open, close);
+        var now1 = new DateTime(2000, 1, 1, 1, 10, 0);
+        sessionProvider.Update(now1);
+
+        var statuses = new List<SessionStatusChangedArgs>();
+        sessionProvider.Changed += (_, status) => statuses.Add(status);
+
+        var now2 = new DateTime(2000, 1, 3, 1, 10, 0);
+
+        // act
+        sessionProvider.Update(now2);
+
+        // assert
+        Assert.AreEqual(3, statuses.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, statuses[0].Status);
+        Assert.AreEqual(now1.Date.Add(close), statuses[0].Time);
+        Assert.AreEqual(OrderBookStatus.PreOpen, statuses[1].Status);
+        Assert.AreEqual(now2.Date.Add(preOpen), statuses[1].Time);
+        Assert.AreEqual(OrderBookStatus.Open, statuses[2].Status);
+        Assert.AreEqual(now2.Date.Add(open), statuses[2].Time);
     }
 }

--- a/Circus/DataProducers/FullBookDataProducer.cs
+++ b/Circus/DataProducers/FullBookDataProducer.cs
@@ -1,115 +1,112 @@
-using System;
-using System.Collections.Generic;
 using Circus.OrderBook;
 
-namespace Circus.DataProducers
+namespace Circus.DataProducers;
+
+public enum OrderBookDeltaAction
 {
-    public enum OrderBookDeltaAction
-    {
-        Added,
-        Modified,
-        Removed,
-        Filled
-    }
+    Added,
+    Modified,
+    Removed,
+    Filled
+}
 
-    // ExchangeOrderId only - never CompanyId/ClientOrderId, which identify the originating
-    // client and must not be broadcast on a public depth feed.
-    public record OrderBookDeltaEvent(DateTime Time, Side Side, string ExchangeOrderId, decimal Price, int Quantity,
-        OrderBookDeltaAction Action);
+// ExchangeOrderId only - never CompanyId/ClientOrderId, which identify the originating
+// client and must not be broadcast on a public depth feed.
+public record OrderBookDeltaEvent(DateTime Time, Side Side, string ExchangeOrderId, decimal Price, int Quantity,
+    OrderBookDeltaAction Action);
 
-    // Full order-by-order (L3) view of the working book, derived purely from the
-    // OrderConfirmedEvent stream - no IOrderBook access, no snapshotting. A consumer replays the
-    // returned deltas in order onto its own mirrored book, same as a real incremental feed.
-    //
-    // Stop orders (still Hidden) are excluded entirely, same as a real market's undisplayed
-    // contingent orders - a stop activating into a working limit order is reported as Added, not
-    // Modified, since it has no prior presence in the working book to "move" from.
-    //
-    // Quantity is always DisplayedQuantity, never RemainingQuantity - an iceberg's hidden reserve
-    // must never appear on a public depth feed.
-    //
-    // An update that lost time priority (a reprice, a quantity increase, or an iceberg peak
-    // refilling from its hidden reserve - see UpdateOrderConfirmed.PreviousExchangeOrderId) is
-    // reported as Removed(old id) + Added(new id), not Modified - a real order-by-order feed
-    // shows this as the old id leaving the book and a new one arriving at the back of the queue,
-    // since a consumer reconstructing time priority needs to see that, not just a quantity/price
-    // change against an id that kept its place.
-    public class FullBookDataProducer : IDataProducer<OrderBookDeltaEvent>
+// Full order-by-order (L3) view of the working book, derived purely from the
+// OrderConfirmedEvent stream - no IOrderBook access, no snapshotting. A consumer replays the
+// returned deltas in order onto its own mirrored book, same as a real incremental feed.
+//
+// Stop orders (still Hidden) are excluded entirely, same as a real market's undisplayed
+// contingent orders - a stop activating into a working limit order is reported as Added, not
+// Modified, since it has no prior presence in the working book to "move" from.
+//
+// Quantity is always DisplayedQuantity, never RemainingQuantity - an iceberg's hidden reserve
+// must never appear on a public depth feed.
+//
+// An update that lost time priority (a reprice, a quantity increase, or an iceberg peak
+// refilling from its hidden reserve - see UpdateOrderConfirmed.PreviousExchangeOrderId) is
+// reported as Removed(old id) + Added(new id), not Modified - a real order-by-order feed
+// shows this as the old id leaving the book and a new one arriving at the back of the queue,
+// since a consumer reconstructing time priority needs to see that, not just a quantity/price
+// change against an id that kept its place.
+public class FullBookDataProducer : IDataProducer<OrderBookDeltaEvent>
+{
+    public IList<OrderBookDeltaEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
     {
-        public IList<OrderBookDeltaEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+        List<OrderBookDeltaEvent>? output = null;
+
+        foreach (var ev in events)
         {
-            List<OrderBookDeltaEvent>? output = null;
-
-            foreach (var ev in events)
+            // FillOrderConfirmed is only ever nested inside OrdersMatched.Fills, never a
+            // top-level event in its own right.
+            if (ev is OrdersMatched matched)
             {
-                // FillOrderConfirmed is only ever nested inside OrdersMatched.Fills, never a
-                // top-level event in its own right.
-                if (ev is OrdersMatched matched)
+                foreach (var fill in matched.Fills)
                 {
-                    foreach (var fill in matched.Fills)
-                    {
-                        Add(ref output, new OrderBookDeltaEvent(fill.Time, fill.Order.Side, fill.Order.ExchangeOrderId,
-                            fill.Order.Price!.Value, fill.Quantity, OrderBookDeltaAction.Filled));
-                    }
-
-                    continue;
+                    Add(ref output, new OrderBookDeltaEvent(fill.Time, fill.Order.Side, fill.Order.ExchangeOrderId,
+                        fill.Order.Price!.Value, fill.Quantity, OrderBookDeltaAction.Filled));
                 }
 
-                if (ev is UpdateOrderConfirmed {PreviousPrice: {} movedFromPrice} moved)
-                {
-                    if (moved.PreviousExchangeOrderId != moved.Order.ExchangeOrderId)
-                    {
-                        Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
-                            moved.PreviousExchangeOrderId, movedFromPrice, moved.PreviousQuantity,
-                            OrderBookDeltaAction.Removed));
-                        Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
-                            moved.Order.ExchangeOrderId, moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
-                            OrderBookDeltaAction.Added));
-                    }
-                    else
-                    {
-                        Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
-                            moved.Order.ExchangeOrderId, moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
-                            OrderBookDeltaAction.Modified));
-                    }
-
-                    continue;
-                }
-
-                OrderBookDeltaEvent? delta = ev switch
-                {
-                    CreateOrderConfirmed {Order.Status: not OrderStatus.Hidden} create =>
-                        new OrderBookDeltaEvent(create.Time, create.Order.Side, create.Order.ExchangeOrderId,
-                            create.Order.Price!.Value, create.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
-
-                    UpdateOrderConfirmed {PreviousPrice: null, Order.Status: OrderStatus.Hidden} => null,
-
-                    UpdateOrderConfirmed {PreviousPrice: null} update =>
-                        new OrderBookDeltaEvent(update.Time, update.Order.Side, update.Order.ExchangeOrderId,
-                            update.Order.Price!.Value, update.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
-
-                    CancelOrderConfirmed {PreviousPrice: {} previousPrice} cancel =>
-                        new OrderBookDeltaEvent(cancel.Time, cancel.Order.Side, cancel.Order.ExchangeOrderId,
-                            previousPrice, cancel.PreviousQuantity, OrderBookDeltaAction.Removed),
-
-                    ExpireOrderConfirmed {PreviousPrice: {} previousPrice} expire =>
-                        new OrderBookDeltaEvent(expire.Time, expire.Order.Side, expire.Order.ExchangeOrderId,
-                            previousPrice, expire.PreviousQuantity, OrderBookDeltaAction.Removed),
-
-                    _ => null
-                };
-
-                if (delta != null)
-                    Add(ref output, delta);
+                continue;
             }
 
-            return output ?? (IList<OrderBookDeltaEvent>) Array.Empty<OrderBookDeltaEvent>();
+            if (ev is UpdateOrderConfirmed {PreviousPrice: {} movedFromPrice} moved)
+            {
+                if (moved.PreviousExchangeOrderId != moved.Order.ExchangeOrderId)
+                {
+                    Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
+                        moved.PreviousExchangeOrderId, movedFromPrice, moved.PreviousQuantity,
+                        OrderBookDeltaAction.Removed));
+                    Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
+                        moved.Order.ExchangeOrderId, moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
+                        OrderBookDeltaAction.Added));
+                }
+                else
+                {
+                    Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
+                        moved.Order.ExchangeOrderId, moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
+                        OrderBookDeltaAction.Modified));
+                }
+
+                continue;
+            }
+
+            OrderBookDeltaEvent? delta = ev switch
+            {
+                CreateOrderConfirmed {Order.Status: not OrderStatus.Hidden} create =>
+                    new OrderBookDeltaEvent(create.Time, create.Order.Side, create.Order.ExchangeOrderId,
+                        create.Order.Price!.Value, create.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
+
+                UpdateOrderConfirmed {PreviousPrice: null, Order.Status: OrderStatus.Hidden} => null,
+
+                UpdateOrderConfirmed {PreviousPrice: null} update =>
+                    new OrderBookDeltaEvent(update.Time, update.Order.Side, update.Order.ExchangeOrderId,
+                        update.Order.Price!.Value, update.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
+
+                CancelOrderConfirmed {PreviousPrice: {} previousPrice} cancel =>
+                    new OrderBookDeltaEvent(cancel.Time, cancel.Order.Side, cancel.Order.ExchangeOrderId,
+                        previousPrice, cancel.PreviousQuantity, OrderBookDeltaAction.Removed),
+
+                ExpireOrderConfirmed {PreviousPrice: {} previousPrice} expire =>
+                    new OrderBookDeltaEvent(expire.Time, expire.Order.Side, expire.Order.ExchangeOrderId,
+                        previousPrice, expire.PreviousQuantity, OrderBookDeltaAction.Removed),
+
+                _ => null
+            };
+
+            if (delta != null)
+                Add(ref output, delta);
         }
 
-        private static void Add(ref List<OrderBookDeltaEvent>? output, OrderBookDeltaEvent delta)
-        {
-            output ??= new List<OrderBookDeltaEvent>();
-            output.Add(delta);
-        }
+        return output ?? (IList<OrderBookDeltaEvent>) Array.Empty<OrderBookDeltaEvent>();
+    }
+
+    private static void Add(ref List<OrderBookDeltaEvent>? output, OrderBookDeltaEvent delta)
+    {
+        output ??= new List<OrderBookDeltaEvent>();
+        output.Add(delta);
     }
 }

--- a/Circus/DataProducers/IDataProducer.cs
+++ b/Circus/DataProducers/IDataProducer.cs
@@ -1,10 +1,8 @@
-using System.Collections.Generic;
 using Circus.OrderBook;
 
-namespace Circus.DataProducers
+namespace Circus.DataProducers;
+
+public interface IDataProducer<T>
 {
-    public interface IDataProducer<T>
-    {
-        IList<T> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events);
-    }
+    IList<T> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events);
 }

--- a/Circus/DataProducers/IndicativePriceDataProducer.cs
+++ b/Circus/DataProducers/IndicativePriceDataProducer.cs
@@ -1,34 +1,31 @@
-using System;
-using System.Collections.Generic;
 using Circus.OrderBook;
 
-namespace Circus.DataProducers
+namespace Circus.DataProducers;
+
+// Publishes the auction quote a book is running - CME's indicative opening price, Eurex's
+// indicative auction price. Unlike the level producers this holds no state of its own: the
+// book already emits IndicativePriceChanged only when the quote moves, so there is nothing
+// here to deduplicate against.
+//
+// A null Price withdraws the quote (the book stopped crossing, or the auction ended), which a
+// subscriber must publish as such rather than leaving the last price standing.
+public class IndicativePriceDataProducer : IDataProducer<IndicativePriceDataEvent>
 {
-    // Publishes the auction quote a book is running - CME's indicative opening price, Eurex's
-    // indicative auction price. Unlike the level producers this holds no state of its own: the
-    // book already emits IndicativePriceChanged only when the quote moves, so there is nothing
-    // here to deduplicate against.
-    //
-    // A null Price withdraws the quote (the book stopped crossing, or the auction ended), which a
-    // subscriber must publish as such rather than leaving the last price standing.
-    public class IndicativePriceDataProducer : IDataProducer<IndicativePriceDataEvent>
+    public IList<IndicativePriceDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
     {
-        public IList<IndicativePriceDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+        List<IndicativePriceDataEvent>? output = null;
+
+        foreach (var ev in events)
         {
-            List<IndicativePriceDataEvent>? output = null;
-
-            foreach (var ev in events)
+            if (ev is IndicativePriceChanged changed)
             {
-                if (ev is IndicativePriceChanged changed)
-                {
-                    output ??= new List<IndicativePriceDataEvent>();
-                    output.Add(new IndicativePriceDataEvent(changed.Time, changed.Price, changed.Quantity));
-                }
+                output ??= new List<IndicativePriceDataEvent>();
+                output.Add(new IndicativePriceDataEvent(changed.Time, changed.Price, changed.Quantity));
             }
-
-            return output ?? (IList<IndicativePriceDataEvent>) Array.Empty<IndicativePriceDataEvent>();
         }
-    }
 
-    public record IndicativePriceDataEvent(DateTime Time, decimal? Price, int Quantity);
+        return output ?? (IList<IndicativePriceDataEvent>) Array.Empty<IndicativePriceDataEvent>();
+    }
 }
+
+public record IndicativePriceDataEvent(DateTime Time, decimal? Price, int Quantity);

--- a/Circus/DataProducers/LevelDataProducer.cs
+++ b/Circus/DataProducers/LevelDataProducer.cs
@@ -1,135 +1,131 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Circus.OrderBook;
 
-namespace Circus.DataProducers
+namespace Circus.DataProducers;
+
+// Maintains its own view of working-book price levels purely from the OrderConfirmedEvent
+// stream - so one instance is required per IOrderBook, created before that book processes its
+// first action, and it can never resync after a missed event (there's no snapshot fallback).
+//
+// Every quantity here is DisplayedQuantity, never RemainingQuantity - an iceberg's hidden
+// reserve must not appear in market data - which is why a fill moves a level by the change in
+// the filled order's displayed size rather than by the quantity that traded. The two differ
+// for an iceberg: a peak exhausted in continuous trading arrives as its own requeue event
+// (Removed at 0, then Added showing a fresh peak), and an auction print can trade straight
+// through the peak into the reserve, leaving the order still showing one.
+public class LevelDataProducer : IDataProducer<LevelsDataEvent>
 {
-    // Maintains its own view of working-book price levels purely from the OrderConfirmedEvent
-    // stream - so one instance is required per IOrderBook, created before that book processes its
-    // first action, and it can never resync after a missed event (there's no snapshot fallback).
-    //
-    // Every quantity here is DisplayedQuantity, never RemainingQuantity - an iceberg's hidden
-    // reserve must not appear in market data - which is why a fill moves a level by the change in
-    // the filled order's displayed size rather than by the quantity that traded. The two differ
-    // for an iceberg: a peak exhausted in continuous trading arrives as its own requeue event
-    // (Removed at 0, then Added showing a fresh peak), and an auction print can trade straight
-    // through the peak into the reserve, leaving the order still showing one.
-    public class LevelDataProducer : IDataProducer<LevelsDataEvent>
+    private class LevelState
     {
-        private class LevelState
-        {
-            public int Quantity;
-            public int Count;
-        }
+        public int Quantity;
+        public int Count;
+    }
 
-        private readonly int _maxLevels;
-        private readonly Dictionary<Side, SortedDictionary<decimal, LevelState>> _levels = new()
-        {
-            {Side.Buy, new SortedDictionary<decimal, LevelState>(Comparer<decimal>.Create((a, b) => b.CompareTo(a)))},
-            {Side.Sell, new SortedDictionary<decimal, LevelState>()}
-        };
+    private readonly int _maxLevels;
+    private readonly Dictionary<Side, SortedDictionary<decimal, LevelState>> _levels = new()
+    {
+        {Side.Buy, new SortedDictionary<decimal, LevelState>(Comparer<decimal>.Create((a, b) => b.CompareTo(a)))},
+        {Side.Sell, new SortedDictionary<decimal, LevelState>()}
+    };
 
-        public LevelDataProducer(int maxLevels)
-        {
-            _maxLevels = maxLevels;
-        }
+    public LevelDataProducer(int maxLevels)
+    {
+        _maxLevels = maxLevels;
+    }
 
-        public IList<LevelsDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
-        {
-            if (events.Count == 0)
-                return Array.Empty<LevelsDataEvent>();
+    public IList<LevelsDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+    {
+        if (events.Count == 0)
+            return Array.Empty<LevelsDataEvent>();
 
-            foreach (var ev in events)
+        foreach (var ev in events)
+        {
+            switch (ev)
             {
-                switch (ev)
-                {
-                    case CreateOrderConfirmed create:
-                        if (create.Order.Status != OrderStatus.Hidden)
-                            Add(create.Order.Side, create.Order.Price!.Value, create.Order.DisplayedQuantity);
-                        break;
+                case CreateOrderConfirmed create:
+                    if (create.Order.Status != OrderStatus.Hidden)
+                        Add(create.Order.Side, create.Order.Price!.Value, create.Order.DisplayedQuantity);
+                    break;
 
-                    case UpdateOrderConfirmed update:
-                        if (update.PreviousPrice.HasValue)
-                            Remove(update.Order.Side, update.PreviousPrice.Value, update.PreviousQuantity);
-                        if (update.Order.Status != OrderStatus.Hidden)
-                            Add(update.Order.Side, update.Order.Price!.Value, update.Order.DisplayedQuantity);
-                        break;
+                case UpdateOrderConfirmed update:
+                    if (update.PreviousPrice.HasValue)
+                        Remove(update.Order.Side, update.PreviousPrice.Value, update.PreviousQuantity);
+                    if (update.Order.Status != OrderStatus.Hidden)
+                        Add(update.Order.Side, update.Order.Price!.Value, update.Order.DisplayedQuantity);
+                    break;
 
-                    case CancelOrderConfirmed cancel:
-                        if (cancel.PreviousPrice.HasValue)
-                            Remove(cancel.Order.Side, cancel.PreviousPrice.Value, cancel.PreviousQuantity);
-                        break;
+                case CancelOrderConfirmed cancel:
+                    if (cancel.PreviousPrice.HasValue)
+                        Remove(cancel.Order.Side, cancel.PreviousPrice.Value, cancel.PreviousQuantity);
+                    break;
 
-                    case ExpireOrderConfirmed expire:
-                        if (expire.PreviousPrice.HasValue)
-                            Remove(expire.Order.Side, expire.PreviousPrice.Value, expire.PreviousQuantity);
-                        break;
+                case ExpireOrderConfirmed expire:
+                    if (expire.PreviousPrice.HasValue)
+                        Remove(expire.Order.Side, expire.PreviousPrice.Value, expire.PreviousQuantity);
+                    break;
 
-                    // FillOrderConfirmed is only ever nested inside OrdersMatched.Fills, never a
-                    // top-level event in its own right.
-                    case OrdersMatched matched:
-                        foreach (var fill in matched.Fills)
-                        {
-                            ReduceQuantity(fill.Order.Side, fill.Order.Price!.Value,
-                                fill.PreviousDisplayedQuantity - fill.Order.DisplayedQuantity,
-                                fullyFilled: fill.Order.RemainingQuantity == 0);
-                        }
+                // FillOrderConfirmed is only ever nested inside OrdersMatched.Fills, never a
+                // top-level event in its own right.
+                case OrdersMatched matched:
+                    foreach (var fill in matched.Fills)
+                    {
+                        ReduceQuantity(fill.Order.Side, fill.Order.Price!.Value,
+                            fill.PreviousDisplayedQuantity - fill.Order.DisplayedQuantity,
+                            fullyFilled: fill.Order.RemainingQuantity == 0);
+                    }
 
-                        break;
-                }
-            }
-
-            var bids = Snapshot(Side.Buy);
-            var offers = Snapshot(Side.Sell);
-            return new[] {new LevelsDataEvent(events[0].Time, bids, offers)};
-        }
-
-        private void Add(Side side, decimal price, int quantity)
-        {
-            var levels = _levels[side];
-            if (levels.TryGetValue(price, out var level))
-            {
-                level.Quantity += quantity;
-                level.Count++;
-            }
-            else
-            {
-                levels[price] = new LevelState {Quantity = quantity, Count = 1};
+                    break;
             }
         }
 
-        private void Remove(Side side, decimal price, int quantity)
+        var bids = Snapshot(Side.Buy);
+        var offers = Snapshot(Side.Sell);
+        return new[] {new LevelsDataEvent(events[0].Time, bids, offers)};
+    }
+
+    private void Add(Side side, decimal price, int quantity)
+    {
+        var levels = _levels[side];
+        if (levels.TryGetValue(price, out var level))
         {
-            var levels = _levels[side];
-            var level = levels[price];
-            level.Quantity -= quantity;
+            level.Quantity += quantity;
+            level.Count++;
+        }
+        else
+        {
+            levels[price] = new LevelState {Quantity = quantity, Count = 1};
+        }
+    }
+
+    private void Remove(Side side, decimal price, int quantity)
+    {
+        var levels = _levels[side];
+        var level = levels[price];
+        level.Quantity -= quantity;
+        level.Count--;
+        if (level.Count == 0)
+            levels.Remove(price);
+    }
+
+    private void ReduceQuantity(Side side, decimal price, int quantity, bool fullyFilled)
+    {
+        var levels = _levels[side];
+        var level = levels[price];
+        level.Quantity -= quantity;
+        if (fullyFilled)
+        {
             level.Count--;
             if (level.Count == 0)
                 levels.Remove(price);
         }
-
-        private void ReduceQuantity(Side side, decimal price, int quantity, bool fullyFilled)
-        {
-            var levels = _levels[side];
-            var level = levels[price];
-            level.Quantity -= quantity;
-            if (fullyFilled)
-            {
-                level.Count--;
-                if (level.Count == 0)
-                    levels.Remove(price);
-            }
-        }
-
-        private IReadOnlyList<Level> Snapshot(Side side) =>
-            _levels[side].Take(_maxLevels)
-                .Select(kv => new Level(kv.Key, kv.Value.Quantity, kv.Value.Count))
-                .ToList();
     }
 
-    public record LevelsDataEvent(DateTime Time, IReadOnlyList<Level> Bids, IReadOnlyList<Level> Offers);
-
-    // Aggregated market data, not a book structure: one publishable line per price.
-    public record Level(decimal Price, int Quantity, int Count);
+    private IReadOnlyList<Level> Snapshot(Side side) =>
+        _levels[side].Take(_maxLevels)
+            .Select(kv => new Level(kv.Key, kv.Value.Quantity, kv.Value.Count))
+            .ToList();
 }
+
+public record LevelsDataEvent(DateTime Time, IReadOnlyList<Level> Bids, IReadOnlyList<Level> Offers);
+
+// Aggregated market data, not a book structure: one publishable line per price.
+public record Level(decimal Price, int Quantity, int Count);

--- a/Circus/DataProducers/SecurityStatusDataProducer.cs
+++ b/Circus/DataProducers/SecurityStatusDataProducer.cs
@@ -1,66 +1,63 @@
-using System;
-using System.Collections.Generic;
 using Circus.OrderBook;
 
-namespace Circus.DataProducers
+namespace Circus.DataProducers;
+
+// What state an instrument is in, as one thing - CME's Security Status message, Eurex's
+// instrument state. The book publishes the parts separately because they are separate: a status
+// change and a limit lock are different events, and a limit-locked market is open. A subscriber
+// wanting to render "what is happening to this instrument" wants them together, and assembling
+// them is this producer's whole job.
+//
+// Stateful, like the level producers and unlike the trade and indicative ones: each incoming
+// event carries only its own part, so the rest has to be remembered. That means one instance per
+// IOrderBook, created before that book processes its first action, with no way to resync after a
+// missed event.
+//
+// Starts where a book starts - closed, nothing pending, no limit - so the first status change
+// is a change from something true rather than from a guess.
+public class SecurityStatusDataProducer : IDataProducer<SecurityStatusDataEvent>
 {
-    // What state an instrument is in, as one thing - CME's Security Status message, Eurex's
-    // instrument state. The book publishes the parts separately because they are separate: a status
-    // change and a limit lock are different events, and a limit-locked market is open. A subscriber
-    // wanting to render "what is happening to this instrument" wants them together, and assembling
-    // them is this producer's whole job.
-    //
-    // Stateful, like the level producers and unlike the trade and indicative ones: each incoming
-    // event carries only its own part, so the rest has to be remembered. That means one instance per
-    // IOrderBook, created before that book processes its first action, with no way to resync after a
-    // missed event.
-    //
-    // Starts where a book starts - closed, nothing pending, no limit - so the first status change
-    // is a change from something true rather than from a guess.
-    public class SecurityStatusDataProducer : IDataProducer<SecurityStatusDataEvent>
+    private OrderBookStatus _status = OrderBookStatus.Closed;
+    private StatusChangeReason _reason = StatusChangeReason.Requested;
+    private DateTime? _resumesAt;
+    private Side? _limitState;
+
+    public IList<SecurityStatusDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
     {
-        private OrderBookStatus _status = OrderBookStatus.Closed;
-        private StatusChangeReason _reason = StatusChangeReason.Requested;
-        private DateTime? _resumesAt;
-        private Side? _limitState;
+        List<SecurityStatusDataEvent>? output = null;
 
-        public IList<SecurityStatusDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+        foreach (var ev in events)
         {
-            List<SecurityStatusDataEvent>? output = null;
-
-            foreach (var ev in events)
+            switch (ev)
             {
-                switch (ev)
-                {
-                    case StatusChanged status:
-                        _status = status.Status;
-                        _reason = status.Reason;
-                        _resumesAt = status.ResumesAt;
-                        break;
+                case StatusChanged status:
+                    _status = status.Status;
+                    _reason = status.Reason;
+                    _resumesAt = status.ResumesAt;
+                    break;
 
-                    // A limit says nothing about the status, and must not disturb it: the market is
-                    // open, and stuck.
-                    case LimitStateChanged limit:
-                        _limitState = limit.Side;
-                        break;
+                // A limit says nothing about the status, and must not disturb it: the market is
+                // open, and stuck.
+                case LimitStateChanged limit:
+                    _limitState = limit.Side;
+                    break;
 
-                    default:
-                        continue;
-                }
-
-                // One per contributing event, carrying that event's own time rather than a time
-                // chosen for a batch. Each is a complete picture, so a consumer never needs two.
-                output ??= new List<SecurityStatusDataEvent>();
-                output.Add(new SecurityStatusDataEvent(ev.Time, _status, _reason, _resumesAt, _limitState));
+                default:
+                    continue;
             }
 
-            return output ?? (IList<SecurityStatusDataEvent>) Array.Empty<SecurityStatusDataEvent>();
+            // One per contributing event, carrying that event's own time rather than a time
+            // chosen for a batch. Each is a complete picture, so a consumer never needs two.
+            output ??= new List<SecurityStatusDataEvent>();
+            output.Add(new SecurityStatusDataEvent(ev.Time, _status, _reason, _resumesAt, _limitState));
         }
-    }
 
-    // ResumesAt is when a timed interruption is due back, null when nothing is pending. LimitState
-    // is which way a daily limit has the market stuck - Buy for limit up, where buyers cannot push
-    // higher - and null when it is free to trade.
-    public record SecurityStatusDataEvent(DateTime Time, OrderBookStatus Status, StatusChangeReason Reason,
-        DateTime? ResumesAt, Side? LimitState);
+        return output ?? (IList<SecurityStatusDataEvent>) Array.Empty<SecurityStatusDataEvent>();
+    }
 }
+
+// ResumesAt is when a timed interruption is due back, null when nothing is pending. LimitState
+// is which way a daily limit has the market stuck - Buy for limit up, where buyers cannot push
+// higher - and null when it is free to trade.
+public record SecurityStatusDataEvent(DateTime Time, OrderBookStatus Status, StatusChangeReason Reason,
+    DateTime? ResumesAt, Side? LimitState);

--- a/Circus/DataProducers/TradeDataProducer.cs
+++ b/Circus/DataProducers/TradeDataProducer.cs
@@ -1,27 +1,24 @@
-using System;
-using System.Collections.Generic;
 using Circus.OrderBook;
 
-namespace Circus.DataProducers
+namespace Circus.DataProducers;
+
+public class TradeDataProducer : IDataProducer<TradedDataEvent>
 {
-    public class TradeDataProducer : IDataProducer<TradedDataEvent>
+    public IList<TradedDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
     {
-        public IList<TradedDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+        List<TradedDataEvent>? output = null;
+
+        foreach (var ev in events)
         {
-            List<TradedDataEvent>? output = null;
-
-            foreach (var ev in events)
+            if (ev is OrdersMatched matched)
             {
-                if (ev is OrdersMatched matched)
-                {
-                    output ??= new List<TradedDataEvent>();
-                    output.Add(new TradedDataEvent(matched.Time, matched.Price, matched.Quantity));
-                }
+                output ??= new List<TradedDataEvent>();
+                output.Add(new TradedDataEvent(matched.Time, matched.Price, matched.Quantity));
             }
-
-            return output ?? (IList<TradedDataEvent>) Array.Empty<TradedDataEvent>();
         }
-    }
 
-    public record TradedDataEvent(DateTime Time, decimal Price, int Quantity);
+        return output ?? (IList<TradedDataEvent>) Array.Empty<TradedDataEvent>();
+    }
 }
+
+public record TradedDataEvent(DateTime Time, decimal Price, int Quantity);

--- a/Circus/Order.cs
+++ b/Circus/Order.cs
@@ -1,27 +1,24 @@
-using System;
+namespace Circus;
 
-namespace Circus
-{
-    public record Order(
-        string CompanyId,
-        string ExchangeOrderId,
-        string ClientOrderId,
-        Security Security,
-        DateTime CreatedTime,
-        DateTime ModifiedTime,
-        DateTime? CompletedTime,
-        OrderStatus Status,
-        OrderType Type,
-        OrderValidity OrderValidity,
-        Side Side,
-        int Quantity,
-        int FilledQuantity,
-        int RemainingQuantity,
-        int DisplayedQuantity,
-        decimal? Price,
-        decimal? TriggerPrice,
-        string? SelfMatchPreventionId = null,
-        SelfMatchPreventionInstruction? SelfMatchPreventionInstruction = null,
-        int? MaxVisibleQuantity = null
-    );
-}
+public record Order(
+    string CompanyId,
+    string ExchangeOrderId,
+    string ClientOrderId,
+    Security Security,
+    DateTime CreatedTime,
+    DateTime ModifiedTime,
+    DateTime? CompletedTime,
+    OrderStatus Status,
+    OrderType Type,
+    OrderValidity OrderValidity,
+    Side Side,
+    int Quantity,
+    int FilledQuantity,
+    int RemainingQuantity,
+    int DisplayedQuantity,
+    decimal? Price,
+    decimal? TriggerPrice,
+    string? SelfMatchPreventionId = null,
+    SelfMatchPreventionInstruction? SelfMatchPreventionInstruction = null,
+    int? MaxVisibleQuantity = null
+);

--- a/Circus/OrderBook/Auction.cs
+++ b/Circus/OrderBook/Auction.cs
@@ -1,114 +1,109 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// A call-auction print: every trade clears at one price, sized off each side's full remaining
+// quantity. The print is a single atomic allocation, not a sequence of continuous touches an
+// iceberg would have to ration its displayed size across.
+internal sealed class Auction : IMatchingAlgorithm
 {
-    // A call-auction print: every trade clears at one price, sized off each side's full remaining
-    // quantity. The print is a single atomic allocation, not a sequence of continuous touches an
-    // iceberg would have to ration its displayed size across.
-    internal sealed class Auction : IMatchingAlgorithm
+    // Feeds the tie-break below and nothing else. Seeded from an explicit reference price
+    // (CME's settlement price, pre-open) and thereafter tracks the last trade.
+    private long? _referencePriceTicks;
+
+    // Held for the duration of one print, so trades are allocated against the book as it stood
+    // when the price was struck rather than one they are themselves consuming.
+    private long _clearingPriceTicks;
+
+    public void OnTrade(long priceTicks) => _referencePriceTicks = priceTicks;
+
+    public void OnSessionChange(long? referencePriceTicks) => _referencePriceTicks = referencePriceTicks;
+
+    // Commits to the price already being quoted, so an uncrossing pass over an uncrossed book
+    // declines here rather than needing the caller to check first.
+    public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) =>
+        TryQuoteIndicative(working, out _clearingPriceTicks, out _);
+
+    // Time priority, at the clearing price rather than each order's own.
+    public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
+        new Allocation(restingHead,
+            Math.Min(restingHead.RemainingQuantity, aggressor.RemainingQuantity),
+            _clearingPriceTicks);
+
+    public bool UsesFullRemainingQuantity => true;
+
+    // The print resolves a crossed book; a volatility pause must not interrupt it partway.
+    public bool ChecksTradeRestrictions => false;
+
+    // The price maximizing executable volume: min(cumulative bids at/above p, cumulative asks
+    // at/below p). Ties break by minimum surplus (CME's rule), then proximity to the reference
+    // price (no venue documents a case this granular), then CME's final rule - highest price
+    // if the surplus is on the buy side, lowest if on the sell side.
+    //
+    // Stops are deliberately excluded, unlike CME's iterative stop-election loop; Matcher.Run
+    // picks them up afterwards like any other trade.
+    public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+        out long priceTicks, out int quantity)
     {
-        // Feeds the tie-break below and nothing else. Seeded from an explicit reference price
-        // (CME's settlement price, pre-open) and thereafter tracks the last trade.
-        private long? _referencePriceTicks;
+        priceTicks = 0;
+        quantity = 0;
 
-        // Held for the duration of one print, so trades are allocated against the book as it stood
-        // when the price was struck rather than one they are themselves consuming.
-        private long _clearingPriceTicks;
+        var buyLevels = working[Side.Buy].EnumerateFromBest()
+            .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
+        var sellLevels = working[Side.Sell].EnumerateFromBest()
+            .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
 
-        public void OnTrade(long priceTicks) => _referencePriceTicks = priceTicks;
+        if (buyLevels.Count == 0 || sellLevels.Count == 0 || buyLevels[0].Tick < sellLevels[0].Tick)
+            return false;
 
-        public void OnSessionChange(long? referencePriceTicks) => _referencePriceTicks = referencePriceTicks;
+        var candidates = buyLevels.Select(l => l.Tick).Concat(sellLevels.Select(l => l.Tick)).Distinct();
 
-        // Commits to the price already being quoted, so an uncrossing pass over an uncrossed book
-        // declines here rather than needing the caller to check first.
-        public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) =>
-            TryQuoteIndicative(working, out _clearingPriceTicks, out _);
-
-        // Time priority, at the clearing price rather than each order's own.
-        public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
-            new Allocation(restingHead,
-                Math.Min(restingHead.RemainingQuantity, aggressor.RemainingQuantity),
-                _clearingPriceTicks);
-
-        public bool UsesFullRemainingQuantity => true;
-
-        // The print resolves a crossed book; a volatility pause must not interrupt it partway.
-        public bool ChecksTradeRestrictions => false;
-
-        // The price maximizing executable volume: min(cumulative bids at/above p, cumulative asks
-        // at/below p). Ties break by minimum surplus (CME's rule), then proximity to the reference
-        // price (no venue documents a case this granular), then CME's final rule - highest price
-        // if the surplus is on the buy side, lowest if on the sell side.
-        //
-        // Stops are deliberately excluded, unlike CME's iterative stop-election loop; Matcher.Run
-        // picks them up afterwards like any other trade.
-        public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
-            out long priceTicks, out int quantity)
+        (long Price, int Executable, long Surplus)? best = null;
+        foreach (var p in candidates)
         {
-            priceTicks = 0;
-            quantity = 0;
+            var cumBid = buyLevels.Where(l => l.Tick >= p).Sum(l => l.Qty);
+            var cumAsk = sellLevels.Where(l => l.Tick <= p).Sum(l => l.Qty);
+            var executable = Math.Min(cumBid, cumAsk);
+            var surplus = cumBid - cumAsk;
 
-            var buyLevels = working[Side.Buy].EnumerateFromBest()
-                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
-            var sellLevels = working[Side.Sell].EnumerateFromBest()
-                .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
-
-            if (buyLevels.Count == 0 || sellLevels.Count == 0 || buyLevels[0].Tick < sellLevels[0].Tick)
-                return false;
-
-            var candidates = buyLevels.Select(l => l.Tick).Concat(sellLevels.Select(l => l.Tick)).Distinct();
-
-            (long Price, int Executable, long Surplus)? best = null;
-            foreach (var p in candidates)
+            if (best == null || executable > best.Value.Executable ||
+                (executable == best.Value.Executable &&
+                 IsBetterTieBreak(p, surplus, best.Value.Price, best.Value.Surplus)))
             {
-                var cumBid = buyLevels.Where(l => l.Tick >= p).Sum(l => l.Qty);
-                var cumAsk = sellLevels.Where(l => l.Tick <= p).Sum(l => l.Qty);
-                var executable = Math.Min(cumBid, cumAsk);
-                var surplus = cumBid - cumAsk;
-
-                if (best == null || executable > best.Value.Executable ||
-                    (executable == best.Value.Executable &&
-                     IsBetterTieBreak(p, surplus, best.Value.Price, best.Value.Surplus)))
-                {
-                    best = (p, executable, surplus);
-                }
+                best = (p, executable, surplus);
             }
-
-            priceTicks = best!.Value.Price;
-            quantity = best.Value.Executable;
-            return quantity > 0;
         }
 
-        private bool IsBetterTieBreak(long candidatePrice, long candidateSurplus, long currentPrice,
-            long currentSurplus)
+        priceTicks = best!.Value.Price;
+        quantity = best.Value.Executable;
+        return quantity > 0;
+    }
+
+    private bool IsBetterTieBreak(long candidatePrice, long candidateSurplus, long currentPrice,
+        long currentSurplus)
+    {
+        var candidateAbsSurplus = Math.Abs(candidateSurplus);
+        var currentAbsSurplus = Math.Abs(currentSurplus);
+        if (candidateAbsSurplus != currentAbsSurplus)
+            return candidateAbsSurplus < currentAbsSurplus;
+
+        if (_referencePriceTicks.HasValue)
         {
-            var candidateAbsSurplus = Math.Abs(candidateSurplus);
-            var currentAbsSurplus = Math.Abs(currentSurplus);
-            if (candidateAbsSurplus != currentAbsSurplus)
-                return candidateAbsSurplus < currentAbsSurplus;
-
-            if (_referencePriceTicks.HasValue)
-            {
-                var candidateDistance = Math.Abs(candidatePrice - _referencePriceTicks.Value);
-                var currentDistance = Math.Abs(currentPrice - _referencePriceTicks.Value);
-                if (candidateDistance != currentDistance)
-                    return candidateDistance < currentDistance;
-            }
-
-            // surplus on the buy side (positive) -> prefer the higher price; sell side -> lower
-            return candidateSurplus > 0 ? candidatePrice > currentPrice : candidatePrice < currentPrice;
+            var candidateDistance = Math.Abs(candidatePrice - _referencePriceTicks.Value);
+            var currentDistance = Math.Abs(currentPrice - _referencePriceTicks.Value);
+            if (candidateDistance != currentDistance)
+                return candidateDistance < currentDistance;
         }
 
-        // Counts an iceberg's hidden reserve: price discovery is on true size, unlike the
-        // displayed-only aggregates published as market data.
-        private static int SumRemaining(InternalOrder? first)
-        {
-            var total = 0;
-            for (var order = first; order != null; order = order.LevelNext)
-                total += order.RemainingQuantity;
-            return total;
-        }
+        // surplus on the buy side (positive) -> prefer the higher price; sell side -> lower
+        return candidateSurplus > 0 ? candidatePrice > currentPrice : candidatePrice < currentPrice;
+    }
+
+    // Counts an iceberg's hidden reserve: price discovery is on true size, unlike the
+    // displayed-only aggregates published as market data.
+    private static int SumRemaining(InternalOrder? first)
+    {
+        var total = 0;
+        for (var order = first; order != null; order = order.LevelNext)
+            total += order.RemainingQuantity;
+        return total;
     }
 }

--- a/Circus/OrderBook/CircuitBreakerRestriction.cs
+++ b/Circus/OrderBook/CircuitBreakerRestriction.cs
@@ -1,52 +1,49 @@
-using System;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// A threshold that stops trading rather than capping it. Set against a settlement price like a
+// daily limit, and unlike one it halts: no matching, no quote, nothing published until it
+// resumes or someone intervenes.
+//
+// Several are ordinarily configured together, and a price through the widest is through all of
+// them. The book serves the severest breach, ranking a longer halt above a shorter one and one
+// that never resumes above both - so the level that ends a trading day wins over the levels it
+// passed through on the way.
+internal sealed class CircuitBreakerRestriction : IPriceRestriction
 {
-    // A threshold that stops trading rather than capping it. Set against a settlement price like a
-    // daily limit, and unlike one it halts: no matching, no quote, nothing published until it
-    // resumes or someone intervenes.
-    //
-    // Several are ordinarily configured together, and a price through the widest is through all of
-    // them. The book serves the severest breach, ranking a longer halt above a shorter one and one
-    // that never resumes above both - so the level that ends a trading day wins over the levels it
-    // passed through on the way.
-    internal sealed class CircuitBreakerRestriction : IPriceRestriction
+    private readonly SessionLimitAnchor _anchor;
+    private readonly TimeSpan? _haltFor;
+
+    internal CircuitBreakerRestriction(PriceLimitWidth width, TimeSpan? haltFor = null)
     {
-        private readonly SessionLimitAnchor _anchor;
-        private readonly TimeSpan? _haltFor;
-
-        internal CircuitBreakerRestriction(PriceLimitWidth width, TimeSpan? haltFor = null)
-        {
-            _anchor = new SessionLimitAnchor(width);
-            _haltFor = haltFor;
-        }
-
-        public RestrictionScope Scope => RestrictionScope.Trade;
-
-        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Halt;
-
-        // Trade-scoped only, so this is never asked.
-        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.BeyondDailyPriceLimit;
-
-        // Null never resumes on its own, which is what the level that ends a trading day wants.
-        public TimeSpan? ResumeAfter => _haltFor;
-
-        public bool Allows(long priceTicks, DateTime time) => _anchor.Allows(priceTicks);
-
-        public bool AllowsStopSpread(long spreadTicks) => true;
-
-        // A halt is ended by its own clock or by whoever drives the book, not by where the auction
-        // would print - so this never holds one open.
-        public bool AllowsResumption(long priceTicks, DateTime time) => true;
-
-        public void OnTrade(long priceTicks, DateTime time)
-        {
-        }
-
-        public void OnIndicativePrice(long? priceTicks)
-        {
-        }
-
-        public void OnSessionChange(long? referencePriceTicks) => _anchor.OnSessionChange(referencePriceTicks);
+        _anchor = new SessionLimitAnchor(width);
+        _haltFor = haltFor;
     }
+
+    public RestrictionScope Scope => RestrictionScope.Trade;
+
+    public RestrictionBreachAction OnBreach => RestrictionBreachAction.Halt;
+
+    // Trade-scoped only, so this is never asked.
+    public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.BeyondDailyPriceLimit;
+
+    // Null never resumes on its own, which is what the level that ends a trading day wants.
+    public TimeSpan? ResumeAfter => _haltFor;
+
+    public bool Allows(long priceTicks, DateTime time) => _anchor.Allows(priceTicks);
+
+    public bool AllowsStopSpread(long spreadTicks) => true;
+
+    // A halt is ended by its own clock or by whoever drives the book, not by where the auction
+    // would print - so this never holds one open.
+    public bool AllowsResumption(long priceTicks, DateTime time) => true;
+
+    public void OnTrade(long priceTicks, DateTime time)
+    {
+    }
+
+    public void OnIndicativePrice(long? priceTicks)
+    {
+    }
+
+    public void OnSessionChange(long? referencePriceTicks) => _anchor.OnSessionChange(referencePriceTicks);
 }

--- a/Circus/OrderBook/DailyPriceLimitRestriction.cs
+++ b/Circus/OrderBook/DailyPriceLimitRestriction.cs
@@ -1,50 +1,47 @@
-using System;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// A session-long ceiling and floor set against a settlement price. The only restriction that
+// neither rejects nor interrupts: trading continues, at the limit price, and simply cannot go
+// through it. CME's limit-lock, which is why a limit-up market is still open and still quoting
+// rather than halted - it can trade back inside at any moment.
+//
+// Both scopes, so one anchor answers both questions: an order priced beyond the limit is turned
+// away at entry, and a prospective trade beyond it does not print. Those have to agree, and the
+// surest way to make them agree is for them to be the same object.
+internal sealed class DailyPriceLimitRestriction : IPriceRestriction
 {
-    // A session-long ceiling and floor set against a settlement price. The only restriction that
-    // neither rejects nor interrupts: trading continues, at the limit price, and simply cannot go
-    // through it. CME's limit-lock, which is why a limit-up market is still open and still quoting
-    // rather than halted - it can trade back inside at any moment.
-    //
-    // Both scopes, so one anchor answers both questions: an order priced beyond the limit is turned
-    // away at entry, and a prospective trade beyond it does not print. Those have to agree, and the
-    // surest way to make them agree is for them to be the same object.
-    internal sealed class DailyPriceLimitRestriction : IPriceRestriction
+    private readonly SessionLimitAnchor _anchor;
+
+    internal DailyPriceLimitRestriction(PriceLimitWidth width)
     {
-        private readonly SessionLimitAnchor _anchor;
-
-        internal DailyPriceLimitRestriction(PriceLimitWidth width)
-        {
-            _anchor = new SessionLimitAnchor(width);
-        }
-
-        public RestrictionScope Scope => RestrictionScope.OrderEntry | RestrictionScope.Trade;
-
-        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Block;
-
-        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.BeyondDailyPriceLimit;
-
-        // A limit interrupts nothing, so there is nothing to resume from. It ends when the session
-        // does, or when a new reference price replaces it.
-        public TimeSpan? ResumeAfter => null;
-
-        public bool Allows(long priceTicks, DateTime time) => _anchor.Allows(priceTicks);
-
-        // Not a band: it has no view on how a stop is priced beyond the limit check itself, which
-        // the trigger and limit prices each face on their own.
-        public bool AllowsStopSpread(long spreadTicks) => true;
-
-        public bool AllowsResumption(long priceTicks, DateTime time) => true;
-
-        public void OnTrade(long priceTicks, DateTime time)
-        {
-        }
-
-        public void OnIndicativePrice(long? priceTicks)
-        {
-        }
-
-        public void OnSessionChange(long? referencePriceTicks) => _anchor.OnSessionChange(referencePriceTicks);
+        _anchor = new SessionLimitAnchor(width);
     }
+
+    public RestrictionScope Scope => RestrictionScope.OrderEntry | RestrictionScope.Trade;
+
+    public RestrictionBreachAction OnBreach => RestrictionBreachAction.Block;
+
+    public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.BeyondDailyPriceLimit;
+
+    // A limit interrupts nothing, so there is nothing to resume from. It ends when the session
+    // does, or when a new reference price replaces it.
+    public TimeSpan? ResumeAfter => null;
+
+    public bool Allows(long priceTicks, DateTime time) => _anchor.Allows(priceTicks);
+
+    // Not a band: it has no view on how a stop is priced beyond the limit check itself, which
+    // the trigger and limit prices each face on their own.
+    public bool AllowsStopSpread(long spreadTicks) => true;
+
+    public bool AllowsResumption(long priceTicks, DateTime time) => true;
+
+    public void OnTrade(long priceTicks, DateTime time)
+    {
+    }
+
+    public void OnIndicativePrice(long? priceTicks)
+    {
+    }
+
+    public void OnSessionChange(long? referencePriceTicks) => _anchor.OnSessionChange(referencePriceTicks);
 }

--- a/Circus/OrderBook/IMatchingAlgorithm.cs
+++ b/Circus/OrderBook/IMatchingAlgorithm.cs
@@ -1,45 +1,42 @@
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+internal readonly record struct Allocation(InternalOrder Resting, int Quantity, long PriceTicks);
+
+// How a trade is allocated and priced. Matcher owns the loop around this - the crossing
+// condition, self-match detection, stop-triggering - and runs it identically whichever
+// algorithm is active; only the decisions below vary. Instances rather than singletons, so a
+// security can eventually carry its own set.
+internal interface IMatchingAlgorithm
 {
-    internal readonly record struct Allocation(InternalOrder Resting, int Quantity, long PriceTicks);
+    // What this algorithm would print right now without committing to it, which is what
+    // pre-open publishes as an indicative quote. Continuous trading has no single such price
+    // and declines. Side-effect-free, unlike TryBegin.
+    bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+        out long priceTicks, out int quantity);
 
-    // How a trade is allocated and priced. Matcher owns the loop around this - the crossing
-    // condition, self-match detection, stop-triggering - and runs it identically whichever
-    // algorithm is active; only the decisions below vary. Instances rather than singletons, so a
-    // security can eventually carry its own set.
-    internal interface IMatchingAlgorithm
-    {
-        // What this algorithm would print right now without committing to it, which is what
-        // pre-open publishes as an indicative quote. Continuous trading has no single such price
-        // and declines. Side-effect-free, unlike TryBegin.
-        bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
-            out long priceTicks, out int quantity);
+    // Derives whatever run-scoped state the algorithm needs - an auction strikes its clearing
+    // price here. False means there is nothing to match and the run yields nothing.
+    bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working);
 
-        // Derives whatever run-scoped state the algorithm needs - an auction strikes its clearing
-        // price here. False means there is nothing to match and the run yields nothing.
-        bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working);
+    // The counterparty for the next trade, which is the decision separating one algorithm from
+    // another. restingHead is the FIFO-earliest order at the resting side's best level; walk
+    // LevelNext for the rest. The order returned must come from that level but need not be the
+    // head - PriceLadder unlinks from any position, so pro-rata and friends are expressible.
+    // Null ends the run; a crossed book normally must not decline.
+    //
+    // An algorithm caching per-level state should key it on the price tick and recompute when
+    // the level changes: a selection can be dropped before it trades if self-match prevention
+    // cancels the pair.
+    Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor);
 
-        // The counterparty for the next trade, which is the decision separating one algorithm from
-        // another. restingHead is the FIFO-earliest order at the resting side's best level; walk
-        // LevelNext for the rest. The order returned must come from that level but need not be the
-        // head - PriceLadder unlinks from any position, so pro-rata and friends are expressible.
-        // Null ends the run; a crossed book normally must not decline.
-        //
-        // An algorithm caching per-level state should key it on the price tick and recompute when
-        // the level changes: a selection can be dropped before it trades if self-match prevention
-        // cancels the pair.
-        Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor);
+    // Whether fills take an order's full remaining quantity rather than its displayed peak.
+    bool UsesFullRemainingQuantity { get; }
 
-        // Whether fills take an order's full remaining quantity rather than its displayed peak.
-        bool UsesFullRemainingQuantity { get; }
+    bool ChecksTradeRestrictions { get; }
 
-        bool ChecksTradeRestrictions { get; }
+    // Reference-price upkeep, mirroring IPriceRestriction. The book fans these across every
+    // phase's algorithm, so one with no anchor ignores them.
+    void OnTrade(long priceTicks);
 
-        // Reference-price upkeep, mirroring IPriceRestriction. The book fans these across every
-        // phase's algorithm, so one with no anchor ignores them.
-        void OnTrade(long priceTicks);
-
-        void OnSessionChange(long? referencePriceTicks);
-    }
+    void OnSessionChange(long? referencePriceTicks);
 }

--- a/Circus/OrderBook/IOrderBook.cs
+++ b/Circus/OrderBook/IOrderBook.cs
@@ -1,16 +1,13 @@
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// Actions in, events out. Everything a consumer knows about the book - price levels, trades,
+// an auction's indicative quote - is derived from the event stream rather than queried back
+// out of the book, so a market data feed and a downstream mirror see the same thing.
+public interface IOrderBook
 {
-    // Actions in, events out. Everything a consumer knows about the book - price levels, trades,
-    // an auction's indicative quote - is derived from the event stream rather than queried back
-    // out of the book, so a market data feed and a downstream mirror see the same thing.
-    public interface IOrderBook
-    {
-        Security Security { get; }
+    Security Security { get; }
 
-        OrderBookStatus Status { get; }
+    OrderBookStatus Status { get; }
 
-        IReadOnlyList<OrderBookEvent> Process(OrderBookAction action);
-    }
+    IReadOnlyList<OrderBookEvent> Process(OrderBookAction action);
 }

--- a/Circus/OrderBook/IPriceRestriction.cs
+++ b/Circus/OrderBook/IPriceRestriction.cs
@@ -1,68 +1,65 @@
-using System;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// Flags, because a daily price limit is both: it refuses an order priced beyond the limit and
+// refuses to print through it. Everything else governs one or the other.
+[Flags]
+internal enum RestrictionScope
 {
-    // Flags, because a daily price limit is both: it refuses an order priced beyond the limit and
-    // refuses to print through it. Everything else governs one or the other.
-    [Flags]
-    internal enum RestrictionScope
-    {
-        OrderEntry = 1,
-        Trade = 2
-    }
+    OrderEntry = 1,
+    Trade = 2
+}
 
-    internal enum RestrictionBreachAction
-    {
-        Reject,
-        Block,
-        Pause,
-        Halt
-    }
+internal enum RestrictionBreachAction
+{
+    Reject,
+    Block,
+    Pause,
+    Halt
+}
 
-    // A breached Trade-scoped restriction: what it costs the book, and how long for. ResumeAfter
-    // null leaves the interruption open-ended, waiting for someone to end it explicitly - and for
-    // Block means nothing at all, since a limit does not interrupt anything to be resumed from.
-    internal readonly record struct RestrictionBreach(RestrictionBreachAction Action, TimeSpan? ResumeAfter);
+// A breached Trade-scoped restriction: what it costs the book, and how long for. ResumeAfter
+// null leaves the interruption open-ended, waiting for someone to end it explicitly - and for
+// Block means nothing at all, since a limit does not interrupt anything to be resumed from.
+internal readonly record struct RestrictionBreach(RestrictionBreachAction Action, TimeSpan? ResumeAfter);
 
-    // A price-restriction adapter. Each owns its own reference price - there is no shared anchor -
-    // updating it from OnTrade (ranges that follow the market), OnIndicativePrice (the entry band
-    // during an auction) and/or OnSessionChange (limits fixed against a settlement price).
-    internal interface IPriceRestriction
-    {
-        RestrictionScope Scope { get; }
+// A price-restriction adapter. Each owns its own reference price - there is no shared anchor -
+// updating it from OnTrade (ranges that follow the market), OnIndicativePrice (the entry band
+// during an auction) and/or OnSessionChange (limits fixed against a settlement price).
+internal interface IPriceRestriction
+{
+    RestrictionScope Scope { get; }
 
-        // Only consulted for Scope carrying Trade - an OrderEntry breach always rejects the order.
-        RestrictionBreachAction OnBreach { get; }
+    // Only consulted for Scope carrying Trade - an OrderEntry breach always rejects the order.
+    RestrictionBreachAction OnBreach { get; }
 
-        // Which rejection an order refused by this restriction earns. Only consulted for Scope
-        // carrying OrderEntry: an order turned away by a band and one turned away by a daily limit
-        // are not the same thing to whoever sent it.
-        OrderRejectedReason EntryRejectionReason { get; }
+    // Which rejection an order refused by this restriction earns. Only consulted for Scope
+    // carrying OrderEntry: an order turned away by a band and one turned away by a daily limit
+    // are not the same thing to whoever sent it.
+    OrderRejectedReason EntryRejectionReason { get; }
 
-        // How long the interruption this restriction causes lasts before the book returns by
-        // itself. Null means it does not end on its own. Only consulted for Scope == Trade.
-        TimeSpan? ResumeAfter { get; }
+    // How long the interruption this restriction causes lasts before the book returns by
+    // itself. Null means it does not end on its own. Only consulted for Scope == Trade.
+    TimeSpan? ResumeAfter { get; }
 
-        // The time is the moment being judged, not just bookkeeping: a restriction measuring
-        // movement over a rolling window has to know how much of its history is still in scope.
-        bool Allows(long priceTicks, DateTime time);
+    // The time is the moment being judged, not just bookkeeping: a restriction measuring
+    // movement over a rolling window has to know how much of its history is still in scope.
+    bool Allows(long priceTicks, DateTime time);
 
-        // How far apart a stop order's trigger and limit prices may be. Separate from Allows
-        // because it measures a width rather than a distance from a reference, and CME governs it
-        // with the same band that governs entry prices. Only consulted for Scope == OrderEntry.
-        bool AllowsStopSpread(long spreadTicks);
+    // How far apart a stop order's trigger and limit prices may be. Separate from Allows
+    // because it measures a width rather than a distance from a reference, and CME governs it
+    // with the same band that governs entry prices. Only consulted for Scope == OrderEntry.
+    bool AllowsStopSpread(long spreadTicks);
 
-        // Whether an interruption may end with a print at this price. Eurex holds the closing price
-        // of a volatility interruption to a wider range than the one that caused it, and extends
-        // the interruption rather than resolving it outside that range. A restriction with no such
-        // range says yes and lets the interruption end. Only consulted for Scope == Trade.
-        bool AllowsResumption(long priceTicks, DateTime time);
+    // Whether an interruption may end with a print at this price. Eurex holds the closing price
+    // of a volatility interruption to a wider range than the one that caused it, and extends
+    // the interruption rather than resolving it outside that range. A restriction with no such
+    // range says yes and lets the interruption end. Only consulted for Scope == Trade.
+    bool AllowsResumption(long priceTicks, DateTime time);
 
-        // Maintain this restriction's own anchor. OnTrade fires on every print; OnSessionChange
-        // fires when an explicit reference price (settlement-style) is supplied at a status change;
-        // OnIndicativePrice fires when the auction quote moves, with null when it is withdrawn.
-        void OnTrade(long priceTicks, DateTime time);
-        void OnSessionChange(long? referencePriceTicks);
-        void OnIndicativePrice(long? priceTicks);
-    }
+    // Maintain this restriction's own anchor. OnTrade fires on every print; OnSessionChange
+    // fires when an explicit reference price (settlement-style) is supplied at a status change;
+    // OnIndicativePrice fires when the auction quote moves, with null when it is withdrawn.
+    void OnTrade(long priceTicks, DateTime time);
+    void OnSessionChange(long? referencePriceTicks);
+    void OnIndicativePrice(long? priceTicks);
 }

--- a/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/Circus/OrderBook/InMemoryOrderBook.cs
@@ -1,539 +1,461 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Circus.TimeProviders;
 
-namespace Circus.OrderBook
+namespace Circus.OrderBook;
+
+public class InMemoryOrderBook : IOrderBook
 {
-    public class InMemoryOrderBook : IOrderBook
+    private readonly Security _security;
+    private readonly ITimeProvider _timeProvider;
+
+    private OrderBookStatus _status = OrderBookStatus.Closed;
+    private long _nextSequenceNumber;
+    private long? _lastTradedPrice;
+
+    // A timed interruption's deadline and where it returns to. Null whenever the book is not
+    // serving one, which includes an interruption configured to last until told otherwise.
+    private DateTime? _resumeAt;
+    private OrderBookStatus _resumeTo;
+
+    // Which way a daily limit currently has the market stuck, so the state is published on the
+    // change rather than on every sweep it turns away. Null is a market free to trade.
+    private Side? _limitState;
+
+    // The indicative quote as last published, so only moves in it are emitted.
+    private (long PriceTicks, int Quantity)? _indicativeQuote;
+
+    // Order-entry and trade-time price bands, each maintaining its own reference anchor.
+    // A future velocity limit or circuit breaker is a new entry here, not a redesign.
+    private readonly IReadOnlyList<IPriceRestriction> _priceRestrictions;
+
+    // Owns the working/stop ladders and the pure decision helpers (liquidity checks,
+    // self-match verdicts) that read them.
+    private readonly Matcher _matcher = new();
+
+    // Nothing outside this table names a status - the rest of the book reads the current phase
+    // and acts on what it says. Pre-open's auction instance is also what prints on the way out
+    // of it, so the opening print is the quote it had been publishing.
+    private readonly IReadOnlyDictionary<OrderBookStatus, TradingPhase> _phases =
+        new Dictionary<OrderBookStatus, TradingPhase>
+        {
+            {
+                OrderBookStatus.PreOpen,
+                new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                    MatchesContinuously: false, StartsSession: true, ExpiresDayOrders: false)
+            },
+            {
+                OrderBookStatus.Open,
+                new TradingPhase(new PriceTime(), AcceptsOrderActions: true, AcceptsMarketOrders: true,
+                    MatchesContinuously: true, StartsSession: false, ExpiresDayOrders: false)
+            },
+            {
+                OrderBookStatus.Closed,
+                new TradingPhase(null, AcceptsOrderActions: false, AcceptsMarketOrders: false,
+                    MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: true)
+            },
+            {
+                // Quotes and prints on the way out exactly as pre-open does, so a pause
+                // resolves into a single uncrossing price rather than resuming mid-sweep. It is
+                // an interruption within a session and not the start of one, though, so unlike
+                // pre-open it neither reseeds sequence numbers nor retires anything.
+                OrderBookStatus.Paused,
+                new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                    MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: false)
+            },
+            {
+                // No algorithm, so nothing matches and no indicative quote is published -
+                // withholding price discovery is what makes this a halt rather than a pause.
+                // Order actions stay open so resting positions can still be managed, and the
+                // day's orders survive: a halt is not a close. Nothing prints on the way out
+                // either, so a caller wanting a reopening auction goes through PreOpen or
+                // Paused rather than straight back to Open.
+                OrderBookStatus.Halted,
+                new TradingPhase(null, AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                    MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: false)
+            }
+        };
+
+    private TradingPhase CurrentPhase => _phases[_status];
+
+    // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
+    private readonly Dictionary<long, InternalOrder> _orders = new();
+    private readonly Dictionary<long, InternalOrder> _completedOrders = new();
+
+    // every (companyId, clientOrderId) pair ever assigned by a client, permanently reserved -
+    // used for per-client uniqueness checks, ownership enforcement, and Update/Cancel lookups
+    private readonly Dictionary<(string CompanyId, string ClientOrderId), InternalOrder> _clientOrderIndex = new();
+
+    private const int MaxClientOrderIdLength = 20;
+
+    public InMemoryOrderBook(Security security, ITimeProvider timeProvider)
+        : this(security, timeProvider, Adapt(security.PriceRestrictions))
     {
-        private readonly Security _security;
-        private readonly ITimeProvider _timeProvider;
+    }
 
-        private OrderBookStatus _status = OrderBookStatus.Closed;
-        private long _nextSequenceNumber;
-        private long? _lastTradedPrice;
-
-        // A timed interruption's deadline and where it returns to. Null whenever the book is not
-        // serving one, which includes an interruption configured to last until told otherwise.
-        private DateTime? _resumeAt;
-        private OrderBookStatus _resumeTo;
-
-        // Which way a daily limit currently has the market stuck, so the state is published on the
-        // change rather than on every sweep it turns away. Null is a market free to trade.
-        private Side? _limitState;
-
-        // The indicative quote as last published, so only moves in it are emitted.
-        private (long PriceTicks, int Quantity)? _indicativeQuote;
-
-        // Order-entry and trade-time price bands, each maintaining its own reference anchor.
-        // A future velocity limit or circuit breaker is a new entry here, not a redesign.
-        private readonly IReadOnlyList<IPriceRestriction> _priceRestrictions;
-
-        // Owns the working/stop ladders and the pure decision helpers (liquidity checks,
-        // self-match verdicts) that read them.
-        private readonly Matcher _matcher = new();
-
-        // Nothing outside this table names a status - the rest of the book reads the current phase
-        // and acts on what it says. Pre-open's auction instance is also what prints on the way out
-        // of it, so the opening print is the quote it had been publishing.
-        private readonly IReadOnlyDictionary<OrderBookStatus, TradingPhase> _phases =
-            new Dictionary<OrderBookStatus, TradingPhase>
+    // Config in, enforcement out. The security describes what it trades under; this is the only
+    // place that knows which adapter each description means, so a new restriction is a new arm
+    // rather than a change to how books are constructed.
+    private static IReadOnlyList<IPriceRestriction> Adapt(IReadOnlyList<PriceRestrictionConfig>? configs) =>
+        configs == null
+            ? Array.Empty<IPriceRestriction>()
+            : configs.Select<PriceRestrictionConfig, IPriceRestriction>(config => config switch
             {
-                {
-                    OrderBookStatus.PreOpen,
-                    new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
-                        MatchesContinuously: false, StartsSession: true, ExpiresDayOrders: false)
-                },
-                {
-                    OrderBookStatus.Open,
-                    new TradingPhase(new PriceTime(), AcceptsOrderActions: true, AcceptsMarketOrders: true,
-                        MatchesContinuously: true, StartsSession: false, ExpiresDayOrders: false)
-                },
-                {
-                    OrderBookStatus.Closed,
-                    new TradingPhase(null, AcceptsOrderActions: false, AcceptsMarketOrders: false,
-                        MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: true)
-                },
-                {
-                    // Quotes and prints on the way out exactly as pre-open does, so a pause
-                    // resolves into a single uncrossing price rather than resuming mid-sweep. It is
-                    // an interruption within a session and not the start of one, though, so unlike
-                    // pre-open it neither reseeds sequence numbers nor retires anything.
-                    OrderBookStatus.Paused,
-                    new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
-                        MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: false)
-                },
-                {
-                    // No algorithm, so nothing matches and no indicative quote is published -
-                    // withholding price discovery is what makes this a halt rather than a pause.
-                    // Order actions stay open so resting positions can still be managed, and the
-                    // day's orders survive: a halt is not a close. Nothing prints on the way out
-                    // either, so a caller wanting a reopening auction goes through PreOpen or
-                    // Paused rather than straight back to Open.
-                    OrderBookStatus.Halted,
-                    new TradingPhase(null, AcceptsOrderActions: true, AcceptsMarketOrders: false,
-                        MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: false)
-                }
-            };
+                OrderPriceBand band => new OrderPriceRestriction(band.BandTicks),
+                VolatilityBand band => new VolatilityBandRestriction(band.RangeTicks, band.PauseFor,
+                    band.Window, band.ExtendedRangeTicks),
+                StaticPriceRange range => new StaticPriceRangeRestriction(range.RangeTicks, range.PauseFor),
 
-        private TradingPhase CurrentPhase => _phases[_status];
+                // Same adapter as VolatilityBand: a velocity limit is that range at a short
+                // window, and the two configs exist to say which is meant, not to behave apart.
+                VelocityLimit limit => new VolatilityBandRestriction(limit.RangeTicks, limit.PauseFor,
+                    limit.Window),
+                DailyPriceLimit limit => new DailyPriceLimitRestriction(limit.Width),
+                CircuitBreaker breaker => new CircuitBreakerRestriction(breaker.Width, breaker.HaltFor),
+                _ => throw new ArgumentException($"Unknown price restriction {config.GetType().Name}")
+            }).ToList();
 
-        // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
-        private readonly Dictionary<long, InternalOrder> _orders = new();
-        private readonly Dictionary<long, InternalOrder> _completedOrders = new();
+    // Restrictions supplied outright rather than derived from the security. Internal because it
+    // is a seam, not an API: it exists so combinations a Security cannot yet describe - two
+    // trade-scoped restrictions disagreeing about severity, say - can still be exercised.
+    internal InMemoryOrderBook(Security security, ITimeProvider timeProvider,
+        IReadOnlyList<IPriceRestriction> priceRestrictions)
+    {
+        _security = security;
+        _timeProvider = timeProvider;
+        _priceRestrictions = priceRestrictions;
+    }
 
-        // every (companyId, clientOrderId) pair ever assigned by a client, permanently reserved -
-        // used for per-client uniqueness checks, ownership enforcement, and Update/Cancel lookups
-        private readonly Dictionary<(string CompanyId, string ClientOrderId), InternalOrder> _clientOrderIndex = new();
+    private DateTime Now() => _timeProvider.GetCurrentTime();
 
-        private const int MaxClientOrderIdLength = 20;
+    public Security Security => _security;
+    public OrderBookStatus Status => _status;
 
-        public InMemoryOrderBook(Security security, ITimeProvider timeProvider)
-            : this(security, timeProvider, Adapt(security.PriceRestrictions))
+    public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
+    {
+        // Before the action rather than after: an order arriving once the interruption has
+        // elapsed should meet a resumed book, not the paused one it would otherwise land in.
+        // Doing it here rather than only on AdvanceTime means a book being fed order flow
+        // resumes on its own, without needing anything to poke it.
+        var events = ResumeIfDue();
+        events.AddRange(Handle(action));
+
+        // Last, so it reports where the action left the book rather than any state it passed
+        // through - a pre-open cancel that uncrosses the book withdraws the quote, and the
+        // opening print withdraws it after the trades it produced.
+        var quoteChange = TakeIndicativeQuoteChange();
+        if (quoteChange != null)
+            events.Add(quoteChange);
+
+        return events;
+    }
+
+    private List<OrderBookEvent> Handle(OrderBookAction action)
+    {
+        return action switch
         {
-        }
+            CreateLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
+                OrderType.Limit, o.Price, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+            CreateMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
+                OrderType.Market, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+            CreateMarketLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
+                o.Quantity, OrderType.MarketLimit, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+            CreateStopLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
+                o.Quantity, OrderType.StopLimit, o.Price, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+            CreateStopMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
+                o.Quantity, OrderType.StopMarket, null, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+            UpdateOrder update => UpdateOrder(update.CompanyId, update.ClientOrderId,
+                update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice),
+            CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId),
+            PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice),
+            OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice),
+            CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay),
+            PauseTrading => UpdateStatus(OrderBookStatus.Paused),
+            HaltTrading => UpdateStatus(OrderBookStatus.Halted),
 
-        // Config in, enforcement out. The security describes what it trades under; this is the only
-        // place that knows which adapter each description means, so a new restriction is a new arm
-        // rather than a change to how books are constructed.
-        private static IReadOnlyList<IPriceRestriction> Adapt(IReadOnlyList<PriceRestrictionConfig>? configs) =>
-            configs == null
-                ? Array.Empty<IPriceRestriction>()
-                : configs.Select<PriceRestrictionConfig, IPriceRestriction>(config => config switch
-                {
-                    OrderPriceBand band => new OrderPriceRestriction(band.BandTicks),
-                    VolatilityBand band => new VolatilityBandRestriction(band.RangeTicks, band.PauseFor,
-                        band.Window, band.ExtendedRangeTicks),
-                    StaticPriceRange range => new StaticPriceRangeRestriction(range.RangeTicks, range.PauseFor),
+            // Carries nothing and does nothing: the work is the due-interruption check every
+            // Process already runs, and this is how a caller with no order flow reaches it.
+            AdvanceTime => new List<OrderBookEvent>(),
+            _ => throw new ArgumentException("Unknown order book action")
+        };
+    }
 
-                    // Same adapter as VolatilityBand: a velocity limit is that range at a short
-                    // window, and the two configs exist to say which is meant, not to behave apart.
-                    VelocityLimit limit => new VolatilityBandRestriction(limit.RangeTicks, limit.PauseFor,
-                        limit.Window),
-                    DailyPriceLimit limit => new DailyPriceLimitRestriction(limit.Width),
-                    CircuitBreaker breaker => new CircuitBreakerRestriction(breaker.Width, breaker.HaltFor),
-                    _ => throw new ArgumentException($"Unknown price restriction {config.GetType().Name}")
-                }).ToList();
+    // A timed interruption returns the book to whatever it interrupted. Cleared by any explicit
+    // status change, so a session closing over a pause ends it rather than being undone by it.
+    private List<OrderBookEvent> ResumeIfDue()
+    {
+        if (_resumeAt == null || Now() < _resumeAt.Value)
+            return new List<OrderBookEvent>();
 
-        // Restrictions supplied outright rather than derived from the security. Internal because it
-        // is a seam, not an API: it exists so combinations a Security cannot yet describe - two
-        // trade-scoped restrictions disagreeing about severity, say - can still be exercised.
-        internal InMemoryOrderBook(Security security, ITimeProvider timeProvider,
-            IReadOnlyList<IPriceRestriction> priceRestrictions)
-        {
-            _security = security;
-            _timeProvider = timeProvider;
-            _priceRestrictions = priceRestrictions;
-        }
+        _resumeAt = null;
+        return UpdateStatus(_resumeTo, reason: StatusChangeReason.InterruptionElapsed);
+    }
 
-        private DateTime Now() => _timeProvider.GetCurrentTime();
+    // Asked of the phase's own algorithm, so a quote exists exactly when there is an auction
+    // to report one for - the start-of-day session or a volatility pause. Continuous trading
+    // declines (price-time prints at as many prices as a sweep touches, not one), as does an
+    // uncrossed book and a phase with no algorithm at all.
+    private OrderBookEvent? TakeIndicativeQuoteChange()
+    {
+        var algorithm = CurrentPhase.Algorithm;
 
-        public Security Security => _security;
-        public OrderBookStatus Status => _status;
+        (long PriceTicks, int Quantity)? quote = null;
+        if (algorithm != null &&
+            algorithm.TryQuoteIndicative(_matcher.Working, out var priceTicks, out var quantity))
+            quote = (priceTicks, quantity);
 
-        public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
-        {
-            // Before the action rather than after: an order arriving once the interruption has
-            // elapsed should meet a resumed book, not the paused one it would otherwise land in.
-            // Doing it here rather than only on AdvanceTime means a book being fed order flow
-            // resumes on its own, without needing anything to poke it.
-            var events = ResumeIfDue();
-            events.AddRange(Handle(action));
-
-            // Last, so it reports where the action left the book rather than any state it passed
-            // through - a pre-open cancel that uncrosses the book withdraws the quote, and the
-            // opening print withdraws it after the trades it produced.
-            var quoteChange = TakeIndicativeQuoteChange();
-            if (quoteChange != null)
-                events.Add(quoteChange);
-
-            return events;
-        }
-
-        private List<OrderBookEvent> Handle(OrderBookAction action)
-        {
-            return action switch
-            {
-                CreateLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
-                    OrderType.Limit, o.Price, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
-                CreateMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
-                    OrderType.Market, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
-                CreateMarketLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                    o.Quantity, OrderType.MarketLimit, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
-                CreateStopLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                    o.Quantity, OrderType.StopLimit, o.Price, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
-                CreateStopMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                    o.Quantity, OrderType.StopMarket, null, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
-                UpdateOrder update => UpdateOrder(update.CompanyId, update.ClientOrderId,
-                    update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice),
-                CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId),
-                PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice),
-                OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice),
-                CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay),
-                PauseTrading => UpdateStatus(OrderBookStatus.Paused),
-                HaltTrading => UpdateStatus(OrderBookStatus.Halted),
-
-                // Carries nothing and does nothing: the work is the due-interruption check every
-                // Process already runs, and this is how a caller with no order flow reaches it.
-                AdvanceTime => new List<OrderBookEvent>(),
-                _ => throw new ArgumentException("Unknown order book action")
-            };
-        }
-
-        // A timed interruption returns the book to whatever it interrupted. Cleared by any explicit
-        // status change, so a session closing over a pause ends it rather than being undone by it.
-        private List<OrderBookEvent> ResumeIfDue()
-        {
-            if (_resumeAt == null || Now() < _resumeAt.Value)
-                return new List<OrderBookEvent>();
-
-            _resumeAt = null;
-            return UpdateStatus(_resumeTo, reason: StatusChangeReason.InterruptionElapsed);
-        }
-
-        // Asked of the phase's own algorithm, so a quote exists exactly when there is an auction
-        // to report one for - the start-of-day session or a volatility pause. Continuous trading
-        // declines (price-time prints at as many prices as a sweep touches, not one), as does an
-        // uncrossed book and a phase with no algorithm at all.
-        private OrderBookEvent? TakeIndicativeQuoteChange()
-        {
-            var algorithm = CurrentPhase.Algorithm;
-
-            (long PriceTicks, int Quantity)? quote = null;
-            if (algorithm != null &&
-                algorithm.TryQuoteIndicative(_matcher.Working, out var priceTicks, out var quantity))
-                quote = (priceTicks, quantity);
-
-            if (Nullable.Equals(quote, _indicativeQuote))
-                return null;
-
-            _indicativeQuote = quote;
-
-            // An anchor for anything banding against the auction price, withdrawn along with the
-            // quote. Reaching restrictions here rather than at order entry means an order is judged
-            // against the quote as it stood before that order - which is the only thing it could be
-            // judged against, since the quote cannot account for an order that has not arrived.
-            foreach (var restriction in _priceRestrictions)
-                restriction.OnIndicativePrice(quote?.PriceTicks);
-
-            return new IndicativePriceChanged(_security, Now(),
-                quote.HasValue ? (decimal?) ToDecimal(quote.Value.PriceTicks) : null, quote?.Quantity ?? 0);
-        }
-
-        private List<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity,
-            Side side, int quantity, OrderType type, decimal? price = null, decimal? triggerPrice = null,
-            SelfMatchPrevention? selfMatchPrevention = null, int? maxVisibleQuantity = null)
-        {
-            var selfMatchPreventionId = selfMatchPrevention?.Id;
-            var selfMatchPreventionInstruction = selfMatchPrevention?.Instruction;
-            var status = triggerPrice.HasValue ? OrderStatus.Hidden : OrderStatus.Working;
-
-            if (!CurrentPhase.AcceptsOrderActions)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketClosed);
-            if (type == OrderType.Market && !CurrentPhase.AcceptsMarketOrders)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketOrdersNotAccepted);
-            if (string.IsNullOrEmpty(clientOrderId))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdRequired);
-            if (clientOrderId.Length > MaxClientOrderIdLength)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
-            if (string.IsNullOrEmpty(companyId))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdRequired);
-            if (companyId.Length > MaxClientOrderIdLength)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdTooLong);
-            if (selfMatchPreventionId != null && selfMatchPreventionId.Length > MaxClientOrderIdLength)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.SelfMatchPreventionIdTooLong);
-            if (quantity < 1)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidQuantity);
-            if (!TryConvertToTicks(price, out var priceTicks))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (triggerTicks != null && priceTicks != null && side == Side.Buy && priceTicks < triggerTicks)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanPrice);
-            if (triggerTicks != null && priceTicks != null && side == Side.Sell && priceTicks > triggerTicks)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice);
-            if (triggerTicks != null && priceTicks != null &&
-                !AllowsStopSpread(triggerTicks.Value, priceTicks.Value))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceTooFarFromPrice);
-            if (triggerTicks != null && !_lastTradedPrice.HasValue)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoLastTradedPrice);
-            if (triggerTicks != null && side == Side.Buy && triggerTicks <= _lastTradedPrice)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice);
-            if (triggerTicks != null && side == Side.Sell && triggerTicks >= _lastTradedPrice)
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
-            if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
-                return RejectCreate(companyId, clientOrderId, entryRefusal);
-            if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int minQty } && (minQty < 1 || minQty > quantity))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MinQuantityOutOfRange);
-            if (maxVisibleQuantity.HasValue && (maxVisibleQuantity < 1 || maxVisibleQuantity > quantity))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MaxVisibleQuantityOutOfRange);
-            if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var existingOrder))
-            {
-                return existingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
-                    ? RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderInBook)
-                    : RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderIdAlreadyUsed);
-            }
-
-            if (type == OrderType.Market || type == OrderType.MarketLimit)
-            {
-                var protectionTicks = type == OrderType.MarketLimit ? 0 : _security.MarketOrderProtectionTicks;
-                if(!TryGetLimitPrice(side, protectionTicks, out priceTicks))
-                    return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoOrdersToMatchMarketOrder);
-            }
-
-            if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int gateMinQty } && !triggerTicks.HasValue &&
-                !_matcher.HasSufficientLiquidity(side, priceTicks!.Value, gateMinQty, selfMatchPreventionId,
-                    selfMatchPreventionInstruction))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InsufficientLiquidityForMinQuantity);
-            if (validity is OrderValidity.GoodTilDate { Date: var goodTilDate } && goodTilDate < DateOnly.FromDateTime(Now()))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidExpireDate);
-
-            _nextSequenceNumber++;
-            var order = new InternalOrder(_nextSequenceNumber, companyId, clientOrderId, _security, Now(), status,
-                type, validity, side, quantity, priceTicks, triggerTicks, selfMatchPreventionId,
-                selfMatchPreventionInstruction, maxVisibleQuantity);
-
-            _orders.Add(order.InternalId, order);
-            _clientOrderIndex.Add((companyId, clientOrderId), order);
-            _matcher.Rest(order);
-
-            List<OrderBookEvent> events = new();
-            events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
-            Match(events);
-
-            if (order.Validity is OrderValidity.ImmediateOrCancel && order.Status == OrderStatus.Working)
-                events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
-
-            return events;
-        }
-
-        private bool TryConvertToTicks(decimal? price, out long? ticks)
-        {
-            if (!price.HasValue)
-            {
-                ticks = null;
-                return true;
-            }
-
-            var rawTicks = price.Value / _security.TickSize;
-            var truncatedTicks = Math.Truncate(rawTicks);
-            if (rawTicks != truncatedTicks)
-            {
-                ticks = null;
-                return false;
-            }
-
-            ticks = (long) truncatedTicks;
-            return true;
-        }
-
-        private decimal ToDecimal(long ticks) => ticks * _security.TickSize;
-
-        private bool TryGetLimitPrice(Side side, int protectionTicks, out long? priceTicks)
-        {
-            priceTicks = null;
-            var opposing = _matcher.Working[side == Side.Buy ? Side.Sell : Side.Buy];
-            if (!opposing.TryGetBest(out var bestTick, out _))
-                return false;
-
-            // set price as best offer + protection ticks for buy orders, best bid - protection ticks for sell orders
-            // TODO: option to use best bid + protection tickets for buy orders, etc (eurex)
-            priceTicks = bestTick + ((side == Side.Buy ? 1 : -1) * protectionTicks);
-            return true;
-        }
-
-        // Client-supplied resting limit prices only. Trigger prices are governed by the
-        // TriggerPriceMustBe... checks above, and Market/MarketLimit prices by
-        // MarketOrderProtectionTicks.
-        // Null when every entry-scoped restriction allows the price, otherwise the rejection the
-        // first refusing one asks for - a band and a daily limit turn an order away for reasons
-        // that read differently to whoever sent it.
-        private OrderRejectedReason? FindOrderEntryRefusal(long priceTicks)
-        {
-            var time = Now();
-            foreach (var restriction in _priceRestrictions)
-            {
-                if (restriction.Scope.HasFlag(RestrictionScope.OrderEntry) &&
-                    !restriction.Allows(priceTicks, time))
-                    return restriction.EntryRejectionReason;
-            }
-
+        if (Nullable.Equals(quote, _indicativeQuote))
             return null;
+
+        _indicativeQuote = quote;
+
+        // An anchor for anything banding against the auction price, withdrawn along with the
+        // quote. Reaching restrictions here rather than at order entry means an order is judged
+        // against the quote as it stood before that order - which is the only thing it could be
+        // judged against, since the quote cannot account for an order that has not arrived.
+        foreach (var restriction in _priceRestrictions)
+            restriction.OnIndicativePrice(quote?.PriceTicks);
+
+        return new IndicativePriceChanged(_security, Now(),
+            quote.HasValue ? (decimal?) ToDecimal(quote.Value.PriceTicks) : null, quote?.Quantity ?? 0);
+    }
+
+    private List<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity,
+        Side side, int quantity, OrderType type, decimal? price = null, decimal? triggerPrice = null,
+        SelfMatchPrevention? selfMatchPrevention = null, int? maxVisibleQuantity = null)
+    {
+        var selfMatchPreventionId = selfMatchPrevention?.Id;
+        var selfMatchPreventionInstruction = selfMatchPrevention?.Instruction;
+        var status = triggerPrice.HasValue ? OrderStatus.Hidden : OrderStatus.Working;
+
+        if (!CurrentPhase.AcceptsOrderActions)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketClosed);
+        if (type == OrderType.Market && !CurrentPhase.AcceptsMarketOrders)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketOrdersNotAccepted);
+        if (string.IsNullOrEmpty(clientOrderId))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdRequired);
+        if (clientOrderId.Length > MaxClientOrderIdLength)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
+        if (string.IsNullOrEmpty(companyId))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdRequired);
+        if (companyId.Length > MaxClientOrderIdLength)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdTooLong);
+        if (selfMatchPreventionId != null && selfMatchPreventionId.Length > MaxClientOrderIdLength)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.SelfMatchPreventionIdTooLong);
+        if (quantity < 1)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidQuantity);
+        if (!TryConvertToTicks(price, out var priceTicks))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement);
+        if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement);
+        if (triggerTicks != null && priceTicks != null && side == Side.Buy && priceTicks < triggerTicks)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanPrice);
+        if (triggerTicks != null && priceTicks != null && side == Side.Sell && priceTicks > triggerTicks)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice);
+        if (triggerTicks != null && priceTicks != null &&
+            !AllowsStopSpread(triggerTicks.Value, priceTicks.Value))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceTooFarFromPrice);
+        if (triggerTicks != null && !_lastTradedPrice.HasValue)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoLastTradedPrice);
+        if (triggerTicks != null && side == Side.Buy && triggerTicks <= _lastTradedPrice)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice);
+        if (triggerTicks != null && side == Side.Sell && triggerTicks >= _lastTradedPrice)
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
+        if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
+            return RejectCreate(companyId, clientOrderId, entryRefusal);
+        if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int minQty } && (minQty < 1 || minQty > quantity))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MinQuantityOutOfRange);
+        if (maxVisibleQuantity.HasValue && (maxVisibleQuantity < 1 || maxVisibleQuantity > quantity))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MaxVisibleQuantityOutOfRange);
+        if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var existingOrder))
+        {
+            return existingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
+                ? RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderInBook)
+                : RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderIdAlreadyUsed);
         }
 
-        // A stop elected far from its trigger would rest at a price the band would never have
-        // accepted directly, so CME bounds the gap by the same band. Checked on the pair rather
-        // than on either price, and only where a band exists to bound it.
-        private bool AllowsStopSpread(long triggerTicks, long priceTicks) =>
-            _priceRestrictions.Where(r => r.Scope.HasFlag(RestrictionScope.OrderEntry))
-                .All(r => r.AllowsStopSpread(Math.Abs(priceTicks - triggerTicks)));
-
-        // Only ever called on an order currently resting in the working book (a FAK remainder or
-        // a self-match-prevention cancel during Match()) - never a still-Hidden stop order.
-        private OrderBookEvent CancelRemainder(InternalOrder order, OrderCancelledReason reason)
+        if (type == OrderType.Market || type == OrderType.MarketLimit)
         {
-            var previousClientOrderId = order.ClientOrderId;
-            var previousPrice = ToDecimal(order.Price!.Value);
-            var previousQuantity = order.DisplayedQuantity;
-            order.Cancel(Now());
-            CompleteOrder(order);
-            return new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
-                reason, previousPrice, previousQuantity);
+            var protectionTicks = type == OrderType.MarketLimit ? 0 : _security.MarketOrderProtectionTicks;
+            if(!TryGetLimitPrice(side, protectionTicks, out priceTicks))
+                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoOrdersToMatchMarketOrder);
         }
 
-        private List<OrderBookEvent> UpdateOrder(string companyId, string clientOrderId, string previousClientOrderId,
-            int? newTotalQuantity = null, decimal? price = null, decimal? triggerPrice = null)
+        if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int gateMinQty } && !triggerTicks.HasValue &&
+            !_matcher.HasSufficientLiquidity(side, priceTicks!.Value, gateMinQty, selfMatchPreventionId,
+                selfMatchPreventionInstruction))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InsufficientLiquidityForMinQuantity);
+        if (validity is OrderValidity.GoodTilDate { Date: var goodTilDate } && goodTilDate < DateOnly.FromDateTime(Now()))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidExpireDate);
+
+        _nextSequenceNumber++;
+        var order = new InternalOrder(_nextSequenceNumber, companyId, clientOrderId, _security, Now(), status,
+            type, validity, side, quantity, priceTicks, triggerTicks, selfMatchPreventionId,
+            selfMatchPreventionInstruction, maxVisibleQuantity);
+
+        _orders.Add(order.InternalId, order);
+        _clientOrderIndex.Add((companyId, clientOrderId), order);
+        _matcher.Rest(order);
+
+        List<OrderBookEvent> events = new();
+        events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
+        Match(events);
+
+        if (order.Validity is OrderValidity.ImmediateOrCancel && order.Status == OrderStatus.Working)
+            events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
+
+        return events;
+    }
+
+    private bool TryConvertToTicks(decimal? price, out long? ticks)
+    {
+        if (!price.HasValue)
         {
-            if (!CurrentPhase.AcceptsOrderActions)
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
-            if (string.IsNullOrEmpty(clientOrderId))
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
-            if (clientOrderId.Length > MaxClientOrderIdLength)
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
-            if (string.IsNullOrEmpty(companyId))
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired);
-            if (companyId.Length > MaxClientOrderIdLength)
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong);
-            if (newTotalQuantity == null && price == null && triggerPrice == null)
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.NoChange);
-            if (newTotalQuantity != null && newTotalQuantity < 1)
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidQuantity);
-            if (!TryConvertToTicks(price, out var priceTicks))
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
-            if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, entryRefusal);
-            if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
-                order.ClientOrderId != previousClientOrderId)
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
-            if (order.Status is not (OrderStatus.Working or OrderStatus.Hidden))
-                return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.TooLateToCancel,
+            ticks = null;
+            return true;
+        }
+
+        var rawTicks = price.Value / _security.TickSize;
+        var truncatedTicks = Math.Truncate(rawTicks);
+        if (rawTicks != truncatedTicks)
+        {
+            ticks = null;
+            return false;
+        }
+
+        ticks = (long) truncatedTicks;
+        return true;
+    }
+
+    private decimal ToDecimal(long ticks) => ticks * _security.TickSize;
+
+    private bool TryGetLimitPrice(Side side, int protectionTicks, out long? priceTicks)
+    {
+        priceTicks = null;
+        var opposing = _matcher.Working[side == Side.Buy ? Side.Sell : Side.Buy];
+        if (!opposing.TryGetBest(out var bestTick, out _))
+            return false;
+
+        // set price as best offer + protection ticks for buy orders, best bid - protection ticks for sell orders
+        // TODO: option to use best bid + protection tickets for buy orders, etc (eurex)
+        priceTicks = bestTick + ((side == Side.Buy ? 1 : -1) * protectionTicks);
+        return true;
+    }
+
+    // Client-supplied resting limit prices only. Trigger prices are governed by the
+    // TriggerPriceMustBe... checks above, and Market/MarketLimit prices by
+    // MarketOrderProtectionTicks.
+    // Null when every entry-scoped restriction allows the price, otherwise the rejection the
+    // first refusing one asks for - a band and a daily limit turn an order away for reasons
+    // that read differently to whoever sent it.
+    private OrderRejectedReason? FindOrderEntryRefusal(long priceTicks)
+    {
+        var time = Now();
+        foreach (var restriction in _priceRestrictions)
+        {
+            if (restriction.Scope.HasFlag(RestrictionScope.OrderEntry) &&
+                !restriction.Allows(priceTicks, time))
+                return restriction.EntryRejectionReason;
+        }
+
+        return null;
+    }
+
+    // A stop elected far from its trigger would rest at a price the band would never have
+    // accepted directly, so CME bounds the gap by the same band. Checked on the pair rather
+    // than on either price, and only where a band exists to bound it.
+    private bool AllowsStopSpread(long triggerTicks, long priceTicks) =>
+        _priceRestrictions.Where(r => r.Scope.HasFlag(RestrictionScope.OrderEntry))
+            .All(r => r.AllowsStopSpread(Math.Abs(priceTicks - triggerTicks)));
+
+    // Only ever called on an order currently resting in the working book (a FAK remainder or
+    // a self-match-prevention cancel during Match()) - never a still-Hidden stop order.
+    private OrderBookEvent CancelRemainder(InternalOrder order, OrderCancelledReason reason)
+    {
+        var previousClientOrderId = order.ClientOrderId;
+        var previousPrice = ToDecimal(order.Price!.Value);
+        var previousQuantity = order.DisplayedQuantity;
+        order.Cancel(Now());
+        CompleteOrder(order);
+        return new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
+            reason, previousPrice, previousQuantity);
+    }
+
+    private List<OrderBookEvent> UpdateOrder(string companyId, string clientOrderId, string previousClientOrderId,
+        int? newTotalQuantity = null, decimal? price = null, decimal? triggerPrice = null)
+    {
+        if (!CurrentPhase.AcceptsOrderActions)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
+        if (string.IsNullOrEmpty(clientOrderId))
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
+        if (clientOrderId.Length > MaxClientOrderIdLength)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
+        if (string.IsNullOrEmpty(companyId))
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired);
+        if (companyId.Length > MaxClientOrderIdLength)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong);
+        if (newTotalQuantity == null && price == null && triggerPrice == null)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.NoChange);
+        if (newTotalQuantity != null && newTotalQuantity < 1)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidQuantity);
+        if (!TryConvertToTicks(price, out var priceTicks))
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
+        if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
+        if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, entryRefusal);
+        if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
+            order.ClientOrderId != previousClientOrderId)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
+        if (order.Status is not (OrderStatus.Working or OrderStatus.Hidden))
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.TooLateToCancel,
+                order.ExchangeOrderId);
+        if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var conflictingOrder))
+        {
+            return conflictingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
+                ? RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderInBook,
+                    order.ExchangeOrderId)
+                : RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderIdAlreadyUsed,
                     order.ExchangeOrderId);
-            if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var conflictingOrder))
-            {
-                return conflictingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
-                    ? RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderInBook,
-                        order.ExchangeOrderId)
-                    : RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderIdAlreadyUsed,
-                        order.ExchangeOrderId);
-            }
-
-            if (order.Status == OrderStatus.Hidden)
-            {
-                var newTriggerTicks = triggerTicks ?? order.TriggerPrice;
-                var newPriceTicks = priceTicks ?? order.Price;
-
-                if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Buy && newPriceTicks < newTriggerTicks)
-                    return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                        OrderRejectedReason.TriggerPriceMustBeLessThanPrice, order.ExchangeOrderId);
-                if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Sell && newPriceTicks > newTriggerTicks)
-                    return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                        OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, order.ExchangeOrderId);
-                if (newTriggerTicks != null && newPriceTicks != null &&
-                    !AllowsStopSpread(newTriggerTicks.Value, newPriceTicks.Value))
-                    return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                        OrderRejectedReason.TriggerPriceTooFarFromPrice, order.ExchangeOrderId);
-
-                if (triggerTicks != null && order.Side == Side.Buy && triggerTicks <= _lastTradedPrice)
-                    return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                        OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, order.ExchangeOrderId);
-                if (triggerTicks != null && order.Side == Side.Sell && triggerTicks >= _lastTradedPrice)
-                    return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                        OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, order.ExchangeOrderId);
-            }
-            else
-            {
-                // ignore trigger price if already triggered
-                triggerTicks = null;
-            }
-
-            // TODO: can't update price on stop market order?
-
-            // Captured before any mutation below. previousPrice is null when the order isn't
-            // currently resting in the working book (still Hidden) - the working-book level
-            // aggregate treats that case as an arrival, not a move.
-            var previousQuantity = order.DisplayedQuantity;
-            var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
-
-            if (newTotalQuantity <= order.FilledQuantity)
-            {
-                order.Cancel(Now(), clientOrderId);
-                _clientOrderIndex[(companyId, clientOrderId)] = order;
-                CompleteOrder(order);
-
-                return new List<OrderBookEvent>
-                {
-                    new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
-                        OrderCancelledReason.UpdatedQuantityLowerThanFilledQuantity, previousPrice, previousQuantity)
-                };
-            }
-
-            var sequenceNumber = order.SequenceNumber;
-            var isPriceChange = (triggerTicks != null && order.Status == OrderStatus.Hidden && triggerTicks != order.TriggerPrice) ||
-                                (priceTicks != null && order.Status != OrderStatus.Hidden && priceTicks != order.Price);
-            // For an iceberg order, MaxVisibleQuantity (the peak) is immutable, so any quantity
-            // increase here can only be growing the hidden reserve - CME/Eurex don't lose
-            // priority for that, only for a peak increase, which isn't possible in this scope.
-            var isQuantityIncrease = order.MaxVisibleQuantity == null &&
-                (newTotalQuantity != null && newTotalQuantity > order.Quantity);
-
-            if (isPriceChange || isQuantityIncrease)
-            {
-                _nextSequenceNumber++;
-                sequenceNumber = _nextSequenceNumber;
-                var updatedPriceTicks =
-                    (order.Status == OrderStatus.Hidden ? triggerTicks ?? order.TriggerPrice : priceTicks ?? order.Price) ??
-                    throw new InvalidOperationException("missing price");
-
-                // Called before order.Update() below, so the order still carries the price it
-                // currently rests at - which is what Reprice moves it off.
-                _matcher.Reprice(order, updatedPriceTicks);
-            }
-
-            // captured before Update() below, which - since sequenceNumber may have just been
-            // bumped above - is where ExchangeOrderId (derived from SequenceNumber) actually changes.
-            var previousExchangeOrderId = order.ExchangeOrderId;
-            order.Update(sequenceNumber, Now(), newTotalQuantity, triggerTicks, priceTicks, clientOrderId);
-            _clientOrderIndex[(companyId, clientOrderId)] = order;
-
-            List<OrderBookEvent> events = new();
-            events.Add(new UpdateOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
-                previousExchangeOrderId, previousPrice, previousQuantity));
-            Match(events);
-            return events;
         }
 
-        private List<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId)
+        if (order.Status == OrderStatus.Hidden)
         {
-            if (!CurrentPhase.AcceptsOrderActions)
-                return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
-            if (string.IsNullOrEmpty(clientOrderId))
-                return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
-            if (clientOrderId.Length > MaxClientOrderIdLength)
-                return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
-            if (string.IsNullOrEmpty(companyId))
-                return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired);
-            if (companyId.Length > MaxClientOrderIdLength)
-                return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong);
-            if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
-                order.ClientOrderId != previousClientOrderId)
-                return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
-            if (order.Status is not (OrderStatus.Working or OrderStatus.Hidden))
-                return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.TooLateToCancel,
-                    order.ExchangeOrderId);
-            if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var conflictingOrder))
-            {
-                return conflictingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
-                    ? RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderInBook,
-                        order.ExchangeOrderId)
-                    : RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderIdAlreadyUsed,
-                        order.ExchangeOrderId);
-            }
+            var newTriggerTicks = triggerTicks ?? order.TriggerPrice;
+            var newPriceTicks = priceTicks ?? order.Price;
 
-            var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
-            var previousQuantity = order.DisplayedQuantity;
+            if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Buy && newPriceTicks < newTriggerTicks)
+                return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
+                    OrderRejectedReason.TriggerPriceMustBeLessThanPrice, order.ExchangeOrderId);
+            if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Sell && newPriceTicks > newTriggerTicks)
+                return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
+                    OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, order.ExchangeOrderId);
+            if (newTriggerTicks != null && newPriceTicks != null &&
+                !AllowsStopSpread(newTriggerTicks.Value, newPriceTicks.Value))
+                return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
+                    OrderRejectedReason.TriggerPriceTooFarFromPrice, order.ExchangeOrderId);
+
+            if (triggerTicks != null && order.Side == Side.Buy && triggerTicks <= _lastTradedPrice)
+                return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
+                    OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, order.ExchangeOrderId);
+            if (triggerTicks != null && order.Side == Side.Sell && triggerTicks >= _lastTradedPrice)
+                return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
+                    OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, order.ExchangeOrderId);
+        }
+        else
+        {
+            // ignore trigger price if already triggered
+            triggerTicks = null;
+        }
+
+        // TODO: can't update price on stop market order?
+
+        // Captured before any mutation below. previousPrice is null when the order isn't
+        // currently resting in the working book (still Hidden) - the working-book level
+        // aggregate treats that case as an arrival, not a move.
+        var previousQuantity = order.DisplayedQuantity;
+        var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
+
+        if (newTotalQuantity <= order.FilledQuantity)
+        {
             order.Cancel(Now(), clientOrderId);
             _clientOrderIndex[(companyId, clientOrderId)] = order;
             CompleteOrder(order);
@@ -541,451 +463,525 @@ namespace Circus.OrderBook
             return new List<OrderBookEvent>
             {
                 new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
-                    OrderCancelledReason.Cancelled, previousPrice, previousQuantity)
+                    OrderCancelledReason.UpdatedQuantityLowerThanFilledQuantity, previousPrice, previousQuantity)
             };
         }
 
-        private List<OrderBookEvent> RejectCreate(string companyId, string clientOrderId, OrderRejectedReason reason) =>
-            new() {new CreateOrderRejected(_security, Now(), companyId, clientOrderId, reason)};
+        var sequenceNumber = order.SequenceNumber;
+        var isPriceChange = (triggerTicks != null && order.Status == OrderStatus.Hidden && triggerTicks != order.TriggerPrice) ||
+                            (priceTicks != null && order.Status != OrderStatus.Hidden && priceTicks != order.Price);
+        // For an iceberg order, MaxVisibleQuantity (the peak) is immutable, so any quantity
+        // increase here can only be growing the hidden reserve - CME/Eurex don't lose
+        // priority for that, only for a peak increase, which isn't possible in this scope.
+        var isQuantityIncrease = order.MaxVisibleQuantity == null &&
+            (newTotalQuantity != null && newTotalQuantity > order.Quantity);
 
-        private List<OrderBookEvent> RejectUpdate(string companyId, string clientOrderId, string previousClientOrderId,
-                OrderRejectedReason reason, string? exchangeOrderId = null) =>
-            new()
-            {
-                new UpdateOrderRejected(_security, Now(), companyId, clientOrderId, previousClientOrderId,
-                    exchangeOrderId, reason)
-            };
-
-        private List<OrderBookEvent> RejectCancel(string companyId, string clientOrderId, string previousClientOrderId,
-                OrderRejectedReason reason, string? exchangeOrderId = null) =>
-            new()
-            {
-                new CancelOrderRejected(_security, Now(), companyId, clientOrderId, previousClientOrderId,
-                    exchangeOrderId, reason)
-            };
-
-        private OrderBookEvent ExpireOrder(InternalOrder order)
+        if (isPriceChange || isQuantityIncrease)
         {
-            var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
-            var previousQuantity = order.DisplayedQuantity;
-            order.Expire(Now());
-            CompleteOrder(order);
+            _nextSequenceNumber++;
+            sequenceNumber = _nextSequenceNumber;
+            var updatedPriceTicks =
+                (order.Status == OrderStatus.Hidden ? triggerTicks ?? order.TriggerPrice : priceTicks ?? order.Price) ??
+                throw new InvalidOperationException("missing price");
 
-            return new ExpireOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousPrice,
-                previousQuantity);
+            // Called before order.Update() below, so the order still carries the price it
+            // currently rests at - which is what Reprice moves it off.
+            _matcher.Reprice(order, updatedPriceTicks);
         }
 
-        private void CompleteOrder(InternalOrder order)
+        // captured before Update() below, which - since sequenceNumber may have just been
+        // bumped above - is where ExchangeOrderId (derived from SequenceNumber) actually changes.
+        var previousExchangeOrderId = order.ExchangeOrderId;
+        order.Update(sequenceNumber, Now(), newTotalQuantity, triggerTicks, priceTicks, clientOrderId);
+        _clientOrderIndex[(companyId, clientOrderId)] = order;
+
+        List<OrderBookEvent> events = new();
+        events.Add(new UpdateOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
+            previousExchangeOrderId, previousPrice, previousQuantity));
+        Match(events);
+        return events;
+    }
+
+    private List<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId)
+    {
+        if (!CurrentPhase.AcceptsOrderActions)
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
+        if (string.IsNullOrEmpty(clientOrderId))
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
+        if (clientOrderId.Length > MaxClientOrderIdLength)
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
+        if (string.IsNullOrEmpty(companyId))
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired);
+        if (companyId.Length > MaxClientOrderIdLength)
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong);
+        if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
+            order.ClientOrderId != previousClientOrderId)
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
+        if (order.Status is not (OrderStatus.Working or OrderStatus.Hidden))
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.TooLateToCancel,
+                order.ExchangeOrderId);
+        if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var conflictingOrder))
         {
-            _matcher.Unrest(order);
-            FinishOrder(order);
+            return conflictingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
+                ? RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderInBook,
+                    order.ExchangeOrderId)
+                : RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderIdAlreadyUsed,
+                    order.ExchangeOrderId);
         }
 
-        private void FinishOrder(InternalOrder order)
+        var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
+        var previousQuantity = order.DisplayedQuantity;
+        order.Cancel(Now(), clientOrderId);
+        _clientOrderIndex[(companyId, clientOrderId)] = order;
+        CompleteOrder(order);
+
+        return new List<OrderBookEvent>
         {
-            _orders.Remove(order.InternalId);
-            _completedOrders.Add(order.InternalId, order);
-        }
+            new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
+                OrderCancelledReason.Cancelled, previousPrice, previousQuantity)
+        };
+    }
 
-        // Called immediately after order.Fill(...). Snapshot the order for FillOrderConfirmed
-        // before calling: a replenish changes ExchangeOrderId, and the fill was against the old one.
-        private OrderBookEvent? FinishFill(InternalOrder order, DateTime time)
+    private List<OrderBookEvent> RejectCreate(string companyId, string clientOrderId, OrderRejectedReason reason) =>
+        new() {new CreateOrderRejected(_security, Now(), companyId, clientOrderId, reason)};
+
+    private List<OrderBookEvent> RejectUpdate(string companyId, string clientOrderId, string previousClientOrderId,
+            OrderRejectedReason reason, string? exchangeOrderId = null) =>
+        new()
         {
-            if (order.Status == OrderStatus.Filled)
-            {
-                CompleteOrder(order);
-                return null;
-            }
-
-            if (order.DisplayedQuantity == 0 && order.MaxVisibleQuantity.HasValue)
-            {
-                // Peak exhausted with reserve remaining. Requeues to the back of the level with a
-                // fresh ExchangeOrderId, as CME and Eurex both do - so a full-book feed sees the
-                // old id leave and a new one arrive rather than an in-place modify.
-                var previousExchangeOrderId = order.ExchangeOrderId;
-                var priceTicks = order.Price ?? throw new InvalidOperationException("limit order missing price");
-                _matcher.Unrest(order);
-                _nextSequenceNumber++;
-                order.Replenish(_nextSequenceNumber, time);
-                _matcher.Rest(order);
-
-                return new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
-                    order.ClientOrderId, previousExchangeOrderId, ToDecimal(priceTicks), 0);
-            }
-
-            return null;
-        }
-
-        // The single gate on whether trading may happen right now, which is why an exiting
-        // auction's print goes through it too: a phase left for one that does not trade abandons
-        // the orders it accumulated rather than crossing them.
-        private void Match(List<OrderBookEvent> events, IMatchingAlgorithm? algorithm = null)
-        {
-            var phase = CurrentPhase;
-            if (!phase.MatchesContinuously)
-            {
-                return;
-            }
-
-            var continuous = phase.Algorithm ??
-                throw new InvalidOperationException("a phase that matches continuously needs an algorithm");
-            var time = Now();
-            var pendingImmediateOrCancelStops = new List<InternalOrder>();
-
-            foreach (var outcome in _matcher.Run(algorithm ?? continuous, continuous, CheckTradeRestrictionBreach))
-                Apply(outcome, events, time, pendingImmediateOrCancelStops);
-
-            // Deferred until the sweep is done: the loop only exits once nothing crosses anywhere,
-            // so "did it fill" cannot be answered any earlier.
-            foreach (var order in pendingImmediateOrCancelStops)
-            {
-                if (order.RemainingQuantity > 0)
-                    events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
-            }
-        }
-
-        // The severest consequence among the Trade-scoped restrictions that disallow priceTicks; a
-        // pure query, consulted by Matcher.Run only outside an auction uncrossing pass. Severest
-        // rather than first, so the order these are declared in cannot decide whether a breach that
-        // halts is served or shadowed by one that merely pauses.
-        private RestrictionBreach? CheckTradeRestrictionBreach(long priceTicks)
-        {
-            var time = Now();
-            RestrictionBreach? worst = null;
-
-            foreach (var restriction in _priceRestrictions)
-            {
-                if (!restriction.Scope.HasFlag(RestrictionScope.Trade) || restriction.Allows(priceTicks, time))
-                    continue;
-
-                var breach = new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
-                if (worst == null || IsMoreSevere(breach, worst.Value))
-                    worst = breach;
-            }
-
-            return worst;
-        }
-
-        // Consequence first, then how long it lasts - a price through a circuit breaker's widest
-        // level is through its narrower ones too, and the market should be halted for as long as
-        // the level it actually reached says rather than the one it passed on the way. Never
-        // resuming outranks any duration, which is what the level that ends a trading day is.
-        private static bool IsMoreSevere(RestrictionBreach candidate, RestrictionBreach current)
-        {
-            if (Severity(candidate.Action) != Severity(current.Action))
-                return Severity(candidate.Action) > Severity(current.Action);
-
-            if (!candidate.ResumeAfter.HasValue || !current.ResumeAfter.HasValue)
-                return !candidate.ResumeAfter.HasValue && current.ResumeAfter.HasValue;
-
-            return candidate.ResumeAfter.Value > current.ResumeAfter.Value;
-        }
-
-        // Whether a restriction refuses to let the interruption the book is in end at the price it
-        // would end at. Eurex extends a volatility interruption rather than resolving it at a price
-        // still too far out; without a restriction configured for that, this always declines to
-        // interfere and every transition goes ahead.
-        //
-        // Only where a print is what would end it: a phase leaving for one that does not trade
-        // abandons its orders rather than crossing them, so there is no price to hold to anything -
-        // and a close must never be blocked by a price range.
-        private RestrictionBreach? CheckResumptionRefusal(OrderBookStatus arrivingStatus)
-        {
-            var departing = CurrentPhase;
-            if (!departing.PrintsOnExit || !_phases[arrivingStatus].MatchesContinuously)
-                return null;
-
-            if (!departing.Algorithm!.TryQuoteIndicative(_matcher.Working, out var priceTicks, out _))
-                return null;
-
-            var time = Now();
-            foreach (var restriction in _priceRestrictions)
-            {
-                // First refusal rather than the severest: every restriction refusing here is asking
-                // for the same thing, so there is nothing to rank.
-                if (restriction.Scope.HasFlag(RestrictionScope.Trade) &&
-                    !restriction.AllowsResumption(priceTicks, time))
-                    return new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
-            }
-
-            return null;
-        }
-
-        // Ranked explicitly rather than leaning on the enum's declaration order, which is free to
-        // change. Reject never reaches here - it is an order-entry consequence.
-        private static int Severity(RestrictionBreachAction action) => action switch
-        {
-            RestrictionBreachAction.Halt => 3,
-            RestrictionBreachAction.Pause => 2,
-
-            // Below both: a limit-locked market is still open and still trading, at the limit. It
-            // is the mildest thing that can stop a sweep, not a form of interruption.
-            RestrictionBreachAction.Block => 1,
-            _ => 0
+            new UpdateOrderRejected(_security, Now(), companyId, clientOrderId, previousClientOrderId,
+                exchangeOrderId, reason)
         };
 
-        private void Apply(MatchOutcome outcome, List<OrderBookEvent> events, DateTime time,
-            List<InternalOrder> pendingImmediateOrCancelStops)
+    private List<OrderBookEvent> RejectCancel(string companyId, string clientOrderId, string previousClientOrderId,
+            OrderRejectedReason reason, string? exchangeOrderId = null) =>
+        new()
         {
-            switch (outcome)
-            {
-                case SelfMatchDetected(var resting, var aggressor, var instruction):
-                    if (instruction != SelfMatchPreventionInstruction.CancelAggressor)
-                        events.Add(CancelRemainder(resting, OrderCancelledReason.SelfMatchPrevention));
-                    if (instruction != SelfMatchPreventionInstruction.CancelResting)
-                        events.Add(CancelRemainder(aggressor, OrderCancelledReason.SelfMatchPrevention));
-                    break;
+            new CancelOrderRejected(_security, Now(), companyId, clientOrderId, previousClientOrderId,
+                exchangeOrderId, reason)
+        };
 
-                case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity, var usesFullRemainingQuantity):
-                    ApplyTrade(resting, aggressor, priceTicks, quantity, usesFullRemainingQuantity, events, time);
-                    break;
+    private OrderBookEvent ExpireOrder(InternalOrder order)
+    {
+        var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
+        var previousQuantity = order.DisplayedQuantity;
+        order.Expire(Now());
+        CompleteOrder(order);
 
-                // A limit stops the sweep and nothing else: the market is open, quoting, and can
-                // trade at the limit and back inside it. Only the status is spared - the run has
-                // already ended, since Matcher.Run stops on any breach.
-                case TradeRestrictionBreached(var blockedTicks, {Action: RestrictionBreachAction.Block}):
-                    TakeLimitStateChange(blockedTicks, events);
-                    break;
+        return new ExpireOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousPrice,
+            previousQuantity);
+    }
 
-                // Assigned directly rather than routed through UpdateStatus: this runs inside the
-                // Run/Apply loop, and UpdateStatus matches, which would re-enter the matcher
-                // mid-enumeration. The phases these land on are deliberately ones with nothing to
-                // do on arrival anyway - neither starts a session nor expires orders.
-                case TradeRestrictionBreached(_, var breach):
-                    // Captured before the overwrite: an interruption returns to whatever it
-                    // interrupted, which is the only phase that could have been matching.
-                    _resumeTo = _status;
-                    _status = breach.Action == RestrictionBreachAction.Halt
-                        ? OrderBookStatus.Halted
-                        : OrderBookStatus.Paused;
-                    _resumeAt = breach.ResumeAfter.HasValue ? Now() + breach.ResumeAfter.Value : null;
-                    events.Add(new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction,
-                        _resumeAt));
-                    break;
+    private void CompleteOrder(InternalOrder order)
+    {
+        _matcher.Unrest(order);
+        FinishOrder(order);
+    }
 
-                case StopsTriggered(var orders):
-                    TriggerStops(orders, time, events, pendingImmediateOrCancelStops);
-                    break;
-            }
+    private void FinishOrder(InternalOrder order)
+    {
+        _orders.Remove(order.InternalId);
+        _completedOrders.Add(order.InternalId, order);
+    }
+
+    // Called immediately after order.Fill(...). Snapshot the order for FillOrderConfirmed
+    // before calling: a replenish changes ExchangeOrderId, and the fill was against the old one.
+    private OrderBookEvent? FinishFill(InternalOrder order, DateTime time)
+    {
+        if (order.Status == OrderStatus.Filled)
+        {
+            CompleteOrder(order);
+            return null;
         }
 
-        // Which way the market is stuck, and only when that changes - a limit-locked book refuses
-        // every sweep that follows, and saying so once is enough. Direction comes from where the
-        // blocked price sits against the last one that traded; with nothing traded yet there is
-        // nothing to compare it to, and the price alone says where the limit is.
-        private void TakeLimitStateChange(long blockedTicks, List<OrderBookEvent> events)
+        if (order.DisplayedQuantity == 0 && order.MaxVisibleQuantity.HasValue)
         {
-            var side = _lastTradedPrice switch
-            {
-                null => (Side?) null,
-                var last when blockedTicks > last => Side.Buy,
-                var last when blockedTicks < last => Side.Sell,
-                _ => _limitState
-            };
+            // Peak exhausted with reserve remaining. Requeues to the back of the level with a
+            // fresh ExchangeOrderId, as CME and Eurex both do - so a full-book feed sees the
+            // old id leave and a new one arrive rather than an in-place modify.
+            var previousExchangeOrderId = order.ExchangeOrderId;
+            var priceTicks = order.Price ?? throw new InvalidOperationException("limit order missing price");
+            _matcher.Unrest(order);
+            _nextSequenceNumber++;
+            order.Replenish(_nextSequenceNumber, time);
+            _matcher.Rest(order);
 
-            if (_limitState == side)
-                return;
-
-            _limitState = side;
-            events.Add(new LimitStateChanged(_security, Now(), side, ToDecimal(blockedTicks)));
+            return new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
+                order.ClientOrderId, previousExchangeOrderId, ToDecimal(priceTicks), 0);
         }
 
-        // A print means the market is trading again, wherever it is trading. Releasing on any trade
-        // rather than on one strictly inside the limits is deliberate: trading at the limit is the
-        // market working, not the market stuck.
-        private void ReleaseLimitState(List<OrderBookEvent> events)
-        {
-            if (_limitState == null)
-                return;
+        return null;
+    }
 
-            _limitState = null;
-            events.Add(new LimitStateChanged(_security, Now(), null, null));
+    // The single gate on whether trading may happen right now, which is why an exiting
+    // auction's print goes through it too: a phase left for one that does not trade abandons
+    // the orders it accumulated rather than crossing them.
+    private void Match(List<OrderBookEvent> events, IMatchingAlgorithm? algorithm = null)
+    {
+        var phase = CurrentPhase;
+        if (!phase.MatchesContinuously)
+        {
+            return;
         }
 
-        private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
-            bool usesFullRemainingQuantity, List<OrderBookEvent> events, DateTime time)
+        var continuous = phase.Algorithm ??
+            throw new InvalidOperationException("a phase that matches continuously needs an algorithm");
+        var time = Now();
+        var pendingImmediateOrCancelStops = new List<InternalOrder>();
+
+        foreach (var outcome in _matcher.Run(algorithm ?? continuous, continuous, CheckTradeRestrictionBreach))
+            Apply(outcome, events, time, pendingImmediateOrCancelStops);
+
+        // Deferred until the sweep is done: the loop only exits once nothing crosses anywhere,
+        // so "did it fill" cannot be answered any earlier.
+        foreach (var order in pendingImmediateOrCancelStops)
         {
-            var price = ToDecimal(priceTicks);
+            if (order.RemainingQuantity > 0)
+                events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
+        }
+    }
 
-            void FillOrder(InternalOrder order)
-            {
-                if (usesFullRemainingQuantity)
-                    order.FillFullSize(time, quantity);
-                else
-                    order.Fill(time, quantity);
-            }
+    // The severest consequence among the Trade-scoped restrictions that disallow priceTicks; a
+    // pure query, consulted by Matcher.Run only outside an auction uncrossing pass. Severest
+    // rather than first, so the order these are declared in cannot decide whether a breach that
+    // halts is served or shadowed by one that merely pauses.
+    private RestrictionBreach? CheckTradeRestrictionBreach(long priceTicks)
+    {
+        var time = Now();
+        RestrictionBreach? worst = null;
 
-            var restingDisplayed = resting.DisplayedQuantity;
-            FillOrder(resting);
-            var restingSnapshot = resting.ToOrder();
-            var restingReplenish = FinishFill(resting, time);
+        foreach (var restriction in _priceRestrictions)
+        {
+            if (!restriction.Scope.HasFlag(RestrictionScope.Trade) || restriction.Allows(priceTicks, time))
+                continue;
 
-            var aggressorDisplayed = aggressor.DisplayedQuantity;
-            FillOrder(aggressor);
-            var aggressorSnapshot = aggressor.ToOrder();
-            var aggressorReplenish = FinishFill(aggressor, time);
-
-            events.Add(new OrdersMatched(_security, time, price, quantity,
-                new[]
-                {
-                    new FillOrderConfirmed(_security, time, resting.CompanyId, restingSnapshot, price, quantity,
-                        restingDisplayed, true),
-                    new FillOrderConfirmed(_security, time, aggressor.CompanyId, aggressorSnapshot, price,
-                        quantity, aggressorDisplayed, false)
-                }
-            ));
-
-            if (restingReplenish != null)
-                events.Add(restingReplenish);
-            if (aggressorReplenish != null)
-                events.Add(aggressorReplenish);
-
-            ReleaseLimitState(events);
-
-            if (_lastTradedPrice != priceTicks)
-            {
-                _lastTradedPrice = priceTicks;
-                foreach (var phase in _phases.Values)
-                    phase.Algorithm?.OnTrade(priceTicks);
-                foreach (var restriction in _priceRestrictions)
-                    restriction.OnTrade(priceTicks, time);
-            }
+            var breach = new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
+            if (worst == null || IsMoreSevere(breach, worst.Value))
+                worst = breach;
         }
 
-        private void TriggerStops(IReadOnlyList<InternalOrder> orders, DateTime time, List<OrderBookEvent> events,
-            List<InternalOrder> pendingImmediateOrCancelStops)
+        return worst;
+    }
+
+    // Consequence first, then how long it lasts - a price through a circuit breaker's widest
+    // level is through its narrower ones too, and the market should be halted for as long as
+    // the level it actually reached says rather than the one it passed on the way. Never
+    // resuming outranks any duration, which is what the level that ends a trading day is.
+    private static bool IsMoreSevere(RestrictionBreach candidate, RestrictionBreach current)
+    {
+        if (Severity(candidate.Action) != Severity(current.Action))
+            return Severity(candidate.Action) > Severity(current.Action);
+
+        if (!candidate.ResumeAfter.HasValue || !current.ResumeAfter.HasValue)
+            return !candidate.ResumeAfter.HasValue && current.ResumeAfter.HasValue;
+
+        return candidate.ResumeAfter.Value > current.ResumeAfter.Value;
+    }
+
+    // Whether a restriction refuses to let the interruption the book is in end at the price it
+    // would end at. Eurex extends a volatility interruption rather than resolving it at a price
+    // still too far out; without a restriction configured for that, this always declines to
+    // interfere and every transition goes ahead.
+    //
+    // Only where a print is what would end it: a phase leaving for one that does not trade
+    // abandons its orders rather than crossing them, so there is no price to hold to anything -
+    // and a close must never be blocked by a price range.
+    private RestrictionBreach? CheckResumptionRefusal(OrderBookStatus arrivingStatus)
+    {
+        var departing = CurrentPhase;
+        if (!departing.PrintsOnExit || !_phases[arrivingStatus].MatchesContinuously)
+            return null;
+
+        if (!departing.Algorithm!.TryQuoteIndicative(_matcher.Working, out var priceTicks, out _))
+            return null;
+
+        var time = Now();
+        foreach (var restriction in _priceRestrictions)
         {
-            foreach (var order in orders)
-            {
-                // Lifted out while still typed as a stop; converted or cancelled below.
-                _matcher.Unrest(order);
-
-                if (order.Validity is OrderValidity.ImmediateOrCancel)
-                    pendingImmediateOrCancelStops.Add(order);
-
-                // calculate price for stop market orders
-                long? newPriceTicks = order.Price;
-                if (order.Type == OrderType.StopMarket &&
-                    !TryGetLimitPrice(order.Side, _security.MarketOrderProtectionTicks, out newPriceTicks))
-                {
-                    var previousClientOrderId = order.ClientOrderId;
-                    var previousQuantity = order.DisplayedQuantity;
-                    order.Cancel(Now());
-                    FinishOrder(order);
-
-                    // FinishOrder, not CompleteOrder: already unrested above and never reached the
-                    // working book, which is also why previousPrice is null.
-                    events.Add(new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(),
-                        previousClientOrderId, OrderCancelledReason.NoOrdersToMatchMarketOrder, null,
-                        previousQuantity));
-                    continue;
-                }
-
-                if (order.Validity is OrderValidity.ImmediateOrCancel { MinQuantity: int stopMinQty } &&
-                    !_matcher.HasSufficientLiquidity(order.Side, newPriceTicks!.Value, stopMinQty,
-                        order.SelfMatchPreventionId, order.SelfMatchPreventionInstruction))
-                {
-                    var previousClientOrderId = order.ClientOrderId;
-                    var previousQuantity = order.DisplayedQuantity;
-                    order.Cancel(Now());
-                    FinishOrder(order);
-
-                    events.Add(new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(),
-                        previousClientOrderId, OrderCancelledReason.ImmediateOrCancelNotFilled, null,
-                        previousQuantity));
-                    continue;
-                }
-
-                var previousExchangeOrderId = order.ExchangeOrderId;
-                _nextSequenceNumber++;
-                order.ConvertToLimit(time, _nextSequenceNumber, newPriceTicks);
-
-                // Retyped as a limit order, so this rests it in the working book.
-                _matcher.Rest(order);
-
-                // previousPrice null - an arrival, not a move between working-book levels.
-                events.Add(new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
-                    order.ClientOrderId, previousExchangeOrderId, null, order.DisplayedQuantity));
-            }
+            // First refusal rather than the severest: every restriction refusing here is asking
+            // for the same thing, so there is nothing to rank.
+            if (restriction.Scope.HasFlag(RestrictionScope.Trade) &&
+                !restriction.AllowsResumption(priceTicks, time))
+                return new RestrictionBreach(restriction.OnBreach, restriction.ResumeAfter);
         }
 
-        // endsTradingDay qualifies a close: several sessions can share one trading day, and only the
-        // last of them ends it. The phase table stays the authority on whether a phase expires day
-        // orders at all - this only says whether this particular close is that day's last.
-        private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null,
-            bool endsTradingDay = true, StatusChangeReason reason = StatusChangeReason.Requested)
+        return null;
+    }
+
+    // Ranked explicitly rather than leaning on the enum's declaration order, which is free to
+    // change. Reject never reaches here - it is an order-entry consequence.
+    private static int Severity(RestrictionBreachAction action) => action switch
+    {
+        RestrictionBreachAction.Halt => 3,
+        RestrictionBreachAction.Pause => 2,
+
+        // Below both: a limit-locked market is still open and still trading, at the limit. It
+        // is the mildest thing that can stop a sweep, not a form of interruption.
+        RestrictionBreachAction.Block => 1,
+        _ => 0
+    };
+
+    private void Apply(MatchOutcome outcome, List<OrderBookEvent> events, DateTime time,
+        List<InternalOrder> pendingImmediateOrCancelStops)
+    {
+        switch (outcome)
         {
-            if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
-            {
-                foreach (var phase in _phases.Values)
-                    phase.Algorithm?.OnSessionChange(referenceTicks);
-                foreach (var restriction in _priceRestrictions)
-                    restriction.OnSessionChange(referenceTicks);
-            }
+            case SelfMatchDetected(var resting, var aggressor, var instruction):
+                if (instruction != SelfMatchPreventionInstruction.CancelAggressor)
+                    events.Add(CancelRemainder(resting, OrderCancelledReason.SelfMatchPrevention));
+                if (instruction != SelfMatchPreventionInstruction.CancelResting)
+                    events.Add(CancelRemainder(aggressor, OrderCancelledReason.SelfMatchPrevention));
+                break;
 
-            if (!_phases.ContainsKey(status))
-                throw new ArgumentOutOfRangeException(nameof(status), status, "no phase configured for this status");
+            case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity, var usesFullRemainingQuantity):
+                ApplyTrade(resting, aggressor, priceTicks, quantity, usesFullRemainingQuantity, events, time);
+                break;
 
-            var extension = CheckResumptionRefusal(status);
-            if (extension != null)
-            {
-                // Nothing has moved yet, so refusing simply leaves the book where it was. The status
-                // is unchanged and re-reported: what a subscriber needs to know is that the
-                // interruption is still running and why, which is the same thing a fresh one says.
-                _resumeAt = extension.Value.ResumeAfter.HasValue ? Now() + extension.Value.ResumeAfter.Value : null;
-                return new List<OrderBookEvent>
-                    {new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction, _resumeAt)};
-            }
+            // A limit stops the sweep and nothing else: the market is open, quoting, and can
+            // trade at the limit and back inside it. Only the status is spared - the run has
+            // already ended, since Matcher.Run stops on any breach.
+            case TradeRestrictionBreached(var blockedTicks, {Action: RestrictionBreachAction.Block}):
+                TakeLimitStateChange(blockedTicks, events);
+                break;
 
-            // Any transition supersedes a pending one, so a session closing over a running pause
-            // ends it rather than being undone when that pause's deadline arrives.
-            _resumeAt = null;
+            // Assigned directly rather than routed through UpdateStatus: this runs inside the
+            // Run/Apply loop, and UpdateStatus matches, which would re-enter the matcher
+            // mid-enumeration. The phases these land on are deliberately ones with nothing to
+            // do on arrival anyway - neither starts a session nor expires orders.
+            case TradeRestrictionBreached(_, var breach):
+                // Captured before the overwrite: an interruption returns to whatever it
+                // interrupted, which is the only phase that could have been matching.
+                _resumeTo = _status;
+                _status = breach.Action == RestrictionBreachAction.Halt
+                    ? OrderBookStatus.Halted
+                    : OrderBookStatus.Paused;
+                _resumeAt = breach.ResumeAfter.HasValue ? Now() + breach.ResumeAfter.Value : null;
+                events.Add(new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction,
+                    _resumeAt));
+                break;
 
-            var departing = CurrentPhase;
-            _status = status;
-            var arriving = CurrentPhase;
+            case StopsTriggered(var orders):
+                TriggerStops(orders, time, events, pendingImmediateOrCancelStops);
+                break;
+        }
+    }
 
-            if (arriving.StartsSession)
-            {
-                // Seeded from the date so an id carries the day it was issued, but only ever
-                // forwards: a second session on the same date computes a seed the counter has
-                // already passed and so continues from where it was. Restarting it would re-issue
-                // ids that orders surviving the previous session (GTC, or GTD not yet due) still
-                // hold, and _orders/_completedOrders are keyed on exactly that. Math.Max is also
-                // what keeps a replay whose clock moves backwards from colliding - a run of ids
-                // that no longer encodes its date beats one that repeats itself.
-                var date = Now();
-                var seed = ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
-                _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
-            }
+    // Which way the market is stuck, and only when that changes - a limit-locked book refuses
+    // every sweep that follows, and saying so once is enough. Direction comes from where the
+    // blocked price sits against the last one that traded; with nothing traded yet there is
+    // nothing to compare it to, and the price alone says where the limit is.
+    private void TakeLimitStateChange(long blockedTicks, List<OrderBookEvent> events)
+    {
+        var side = _lastTradedPrice switch
+        {
+            null => (Side?) null,
+            var last when blockedTicks > last => Side.Buy,
+            var last when blockedTicks < last => Side.Sell,
+            _ => _limitState
+        };
 
-            // _resumeAt was cleared above, so this reports nothing pending - which is what an
-            // explicit transition means, having just superseded whatever was.
-            var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status, reason, _resumeAt)};
+        if (_limitState == side)
+            return;
 
-            // A quoting phase has been accumulating orders for a print, and leaving it is where
-            // that print happens - so a second auction phase would need nothing changed here.
-            // Match declines it if the phase just entered does not trade.
-            if (departing.PrintsOnExit)
-                Match(events, departing.Algorithm);
+        _limitState = side;
+        events.Add(new LimitStateChanged(_security, Now(), side, ToDecimal(blockedTicks)));
+    }
 
-            // Then trading continues under whatever governs the phase just entered.
-            Match(events);
+    // A print means the market is trading again, wherever it is trading. Releasing on any trade
+    // rather than on one strictly inside the limits is deliberate: trading at the limit is the
+    // market working, not the market stuck.
+    private void ReleaseLimitState(List<OrderBookEvent> events)
+    {
+        if (_limitState == null)
+            return;
 
-            if (arriving.ExpiresDayOrders && endsTradingDay)
-                events.AddRange(ExpireOrders());
+        _limitState = null;
+        events.Add(new LimitStateChanged(_security, Now(), null, null));
+    }
 
-            return events;
+    private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
+        bool usesFullRemainingQuantity, List<OrderBookEvent> events, DateTime time)
+    {
+        var price = ToDecimal(priceTicks);
+
+        void FillOrder(InternalOrder order)
+        {
+            if (usesFullRemainingQuantity)
+                order.FillFullSize(time, quantity);
+            else
+                order.Fill(time, quantity);
         }
 
-        private IEnumerable<OrderBookEvent> ExpireOrders()
-        {
-            var today = DateOnly.FromDateTime(Now());
-            var orders = _orders.Values.Where(o =>
-                o.Validity is OrderValidity.Day ||
-                (o.Validity is OrderValidity.GoodTilDate { Date: var date } && date <= today)).ToList();
+        var restingDisplayed = resting.DisplayedQuantity;
+        FillOrder(resting);
+        var restingSnapshot = resting.ToOrder();
+        var restingReplenish = FinishFill(resting, time);
 
-            return orders.Select(ExpireOrder).ToList();
+        var aggressorDisplayed = aggressor.DisplayedQuantity;
+        FillOrder(aggressor);
+        var aggressorSnapshot = aggressor.ToOrder();
+        var aggressorReplenish = FinishFill(aggressor, time);
+
+        events.Add(new OrdersMatched(_security, time, price, quantity,
+            new[]
+            {
+                new FillOrderConfirmed(_security, time, resting.CompanyId, restingSnapshot, price, quantity,
+                    restingDisplayed, true),
+                new FillOrderConfirmed(_security, time, aggressor.CompanyId, aggressorSnapshot, price,
+                    quantity, aggressorDisplayed, false)
+            }
+        ));
+
+        if (restingReplenish != null)
+            events.Add(restingReplenish);
+        if (aggressorReplenish != null)
+            events.Add(aggressorReplenish);
+
+        ReleaseLimitState(events);
+
+        if (_lastTradedPrice != priceTicks)
+        {
+            _lastTradedPrice = priceTicks;
+            foreach (var phase in _phases.Values)
+                phase.Algorithm?.OnTrade(priceTicks);
+            foreach (var restriction in _priceRestrictions)
+                restriction.OnTrade(priceTicks, time);
         }
+    }
+
+    private void TriggerStops(IReadOnlyList<InternalOrder> orders, DateTime time, List<OrderBookEvent> events,
+        List<InternalOrder> pendingImmediateOrCancelStops)
+    {
+        foreach (var order in orders)
+        {
+            // Lifted out while still typed as a stop; converted or cancelled below.
+            _matcher.Unrest(order);
+
+            if (order.Validity is OrderValidity.ImmediateOrCancel)
+                pendingImmediateOrCancelStops.Add(order);
+
+            // calculate price for stop market orders
+            long? newPriceTicks = order.Price;
+            if (order.Type == OrderType.StopMarket &&
+                !TryGetLimitPrice(order.Side, _security.MarketOrderProtectionTicks, out newPriceTicks))
+            {
+                var previousClientOrderId = order.ClientOrderId;
+                var previousQuantity = order.DisplayedQuantity;
+                order.Cancel(Now());
+                FinishOrder(order);
+
+                // FinishOrder, not CompleteOrder: already unrested above and never reached the
+                // working book, which is also why previousPrice is null.
+                events.Add(new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(),
+                    previousClientOrderId, OrderCancelledReason.NoOrdersToMatchMarketOrder, null,
+                    previousQuantity));
+                continue;
+            }
+
+            if (order.Validity is OrderValidity.ImmediateOrCancel { MinQuantity: int stopMinQty } &&
+                !_matcher.HasSufficientLiquidity(order.Side, newPriceTicks!.Value, stopMinQty,
+                    order.SelfMatchPreventionId, order.SelfMatchPreventionInstruction))
+            {
+                var previousClientOrderId = order.ClientOrderId;
+                var previousQuantity = order.DisplayedQuantity;
+                order.Cancel(Now());
+                FinishOrder(order);
+
+                events.Add(new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(),
+                    previousClientOrderId, OrderCancelledReason.ImmediateOrCancelNotFilled, null,
+                    previousQuantity));
+                continue;
+            }
+
+            var previousExchangeOrderId = order.ExchangeOrderId;
+            _nextSequenceNumber++;
+            order.ConvertToLimit(time, _nextSequenceNumber, newPriceTicks);
+
+            // Retyped as a limit order, so this rests it in the working book.
+            _matcher.Rest(order);
+
+            // previousPrice null - an arrival, not a move between working-book levels.
+            events.Add(new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
+                order.ClientOrderId, previousExchangeOrderId, null, order.DisplayedQuantity));
+        }
+    }
+
+    // endsTradingDay qualifies a close: several sessions can share one trading day, and only the
+    // last of them ends it. The phase table stays the authority on whether a phase expires day
+    // orders at all - this only says whether this particular close is that day's last.
+    private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null,
+        bool endsTradingDay = true, StatusChangeReason reason = StatusChangeReason.Requested)
+    {
+        if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
+        {
+            foreach (var phase in _phases.Values)
+                phase.Algorithm?.OnSessionChange(referenceTicks);
+            foreach (var restriction in _priceRestrictions)
+                restriction.OnSessionChange(referenceTicks);
+        }
+
+        if (!_phases.ContainsKey(status))
+            throw new ArgumentOutOfRangeException(nameof(status), status, "no phase configured for this status");
+
+        var extension = CheckResumptionRefusal(status);
+        if (extension != null)
+        {
+            // Nothing has moved yet, so refusing simply leaves the book where it was. The status
+            // is unchanged and re-reported: what a subscriber needs to know is that the
+            // interruption is still running and why, which is the same thing a fresh one says.
+            _resumeAt = extension.Value.ResumeAfter.HasValue ? Now() + extension.Value.ResumeAfter.Value : null;
+            return new List<OrderBookEvent>
+                {new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction, _resumeAt)};
+        }
+
+        // Any transition supersedes a pending one, so a session closing over a running pause
+        // ends it rather than being undone when that pause's deadline arrives.
+        _resumeAt = null;
+
+        var departing = CurrentPhase;
+        _status = status;
+        var arriving = CurrentPhase;
+
+        if (arriving.StartsSession)
+        {
+            // Seeded from the date so an id carries the day it was issued, but only ever
+            // forwards: a second session on the same date computes a seed the counter has
+            // already passed and so continues from where it was. Restarting it would re-issue
+            // ids that orders surviving the previous session (GTC, or GTD not yet due) still
+            // hold, and _orders/_completedOrders are keyed on exactly that. Math.Max is also
+            // what keeps a replay whose clock moves backwards from colliding - a run of ids
+            // that no longer encodes its date beats one that repeats itself.
+            var date = Now();
+            var seed = ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
+            _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
+        }
+
+        // _resumeAt was cleared above, so this reports nothing pending - which is what an
+        // explicit transition means, having just superseded whatever was.
+        var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status, reason, _resumeAt)};
+
+        // A quoting phase has been accumulating orders for a print, and leaving it is where
+        // that print happens - so a second auction phase would need nothing changed here.
+        // Match declines it if the phase just entered does not trade.
+        if (departing.PrintsOnExit)
+            Match(events, departing.Algorithm);
+
+        // Then trading continues under whatever governs the phase just entered.
+        Match(events);
+
+        if (arriving.ExpiresDayOrders && endsTradingDay)
+            events.AddRange(ExpireOrders());
+
+        return events;
+    }
+
+    private IEnumerable<OrderBookEvent> ExpireOrders()
+    {
+        var today = DateOnly.FromDateTime(Now());
+        var orders = _orders.Values.Where(o =>
+            o.Validity is OrderValidity.Day ||
+            (o.Validity is OrderValidity.GoodTilDate { Date: var date } && date <= today)).ToList();
+
+        return orders.Select(ExpireOrder).ToList();
     }
 }

--- a/Circus/OrderBook/InternalOrder.cs
+++ b/Circus/OrderBook/InternalOrder.cs
@@ -1,192 +1,189 @@
-using System;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// Price/TriggerPrice are tick counts (price / Security.TickSize), not decimal: decimal
+// comparison has no hardware path, so the hot paths stay on long and convert back only at the
+// public-API boundary.
+internal class InternalOrder
 {
-    // Price/TriggerPrice are tick counts (price / Security.TickSize), not decimal: decimal
-    // comparison has no hardware path, so the hot paths stay on long and convert back only at the
-    // public-API boundary.
-    internal class InternalOrder
+    public long SequenceNumber { get; private set; }
+
+    // Stable for the order's whole life and never exposed. ExchangeOrderId is the public
+    // identity, and unlike this one it deliberately does change.
+    public long InternalId { get; }
+
+    public string CompanyId { get; }
+
+    // Derived from SequenceNumber so it cannot drift: every priority-losing mutation bumps
+    // that and so changes this. Real exchanges do the same, since an order sent to the back of
+    // the queue is functionally a new entry.
+    public string ExchangeOrderId => SequenceNumber.ToString();
+
+    public string ClientOrderId { get; private set; }
+    public Security Security { get; }
+    public DateTime CreatedTime { get; }
+    public DateTime ModifiedTime { get; private set; }
+    public DateTime? CompletedTime { get; private set; }
+    public OrderStatus Status { get; private set; }
+    public OrderType Type { get; private set; }
+    public OrderValidity Validity { get; }
+    public Side Side { get; }
+    public int Quantity { get; private set; }
+    public int RemainingQuantity { get; private set; }
+    public int FilledQuantity { get; private set; }
+    public long? Price { get; private set; }
+    public long? TriggerPrice { get; private set; }
+    public string? SelfMatchPreventionId { get; }
+    public SelfMatchPreventionInstruction? SelfMatchPreventionInstruction { get; }
+    public int? MaxVisibleQuantity { get; }
+
+    // The shown portion of an iceberg, against RemainingQuantity's true total. Equal to it for
+    // a non-iceberg order, so nothing elsewhere special-cases that.
+    public int DisplayedQuantity { get; private set; }
+
+    // Intrusive list pointers for the level currently holding this order - an order rests in
+    // only one at a time. Avoids a node object per order.
+    internal InternalOrder? LevelNext { get; set; }
+    internal InternalOrder? LevelPrev { get; set; }
+
+    public InternalOrder(long sequenceNumber, string companyId, string clientOrderId, Security security, DateTime time,
+        OrderStatus status, OrderType type, OrderValidity validity, Side side, int quantity, long? price,
+        long? triggerPrice, string? selfMatchPreventionId = null,
+        SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null, int? maxVisibleQuantity = null)
     {
-        public long SequenceNumber { get; private set; }
+        SequenceNumber = sequenceNumber;
+        InternalId = sequenceNumber;
+        CompanyId = companyId;
+        ClientOrderId = clientOrderId;
+        Security = security;
+        CreatedTime = time;
+        ModifiedTime = time;
+        Status = status;
+        Type = type;
+        Validity = validity;
+        Side = side;
+        Quantity = quantity;
+        RemainingQuantity = Quantity;
+        FilledQuantity = 0;
+        Price = price;
+        TriggerPrice = triggerPrice;
+        SelfMatchPreventionId = selfMatchPreventionId;
+        SelfMatchPreventionInstruction = selfMatchPreventionInstruction;
+        MaxVisibleQuantity = maxVisibleQuantity;
+        DisplayedQuantity = Math.Min(maxVisibleQuantity ?? quantity, quantity);
+    }
 
-        // Stable for the order's whole life and never exposed. ExchangeOrderId is the public
-        // identity, and unlike this one it deliberately does change.
-        public long InternalId { get; }
+    public override string ToString() =>
+        $"[Order #{ExchangeOrderId} company={CompanyId} clientOrder={ClientOrderId} {Status} {ModifiedTime:HH:mm:ss} {Side} {Quantity}@{ToDecimal(Price)}]";
 
-        public string CompanyId { get; }
+    public Order ToOrder()
+    {
+        return new(CompanyId, ExchangeOrderId, ClientOrderId, Security, CreatedTime, ModifiedTime, CompletedTime,
+            Status, Type, Validity, Side, Quantity, FilledQuantity, RemainingQuantity, DisplayedQuantity,
+            ToDecimal(Price), ToDecimal(TriggerPrice), SelfMatchPreventionId, SelfMatchPreventionInstruction,
+            MaxVisibleQuantity);
+    }
 
-        // Derived from SequenceNumber so it cannot drift: every priority-losing mutation bumps
-        // that and so changes this. Real exchanges do the same, since an order sent to the back of
-        // the queue is functionally a new entry.
-        public string ExchangeOrderId => SequenceNumber.ToString();
+    private decimal? ToDecimal(long? ticks) => ticks.HasValue ? ticks.Value * Security.TickSize : null;
 
-        public string ClientOrderId { get; private set; }
-        public Security Security { get; }
-        public DateTime CreatedTime { get; }
-        public DateTime ModifiedTime { get; private set; }
-        public DateTime? CompletedTime { get; private set; }
-        public OrderStatus Status { get; private set; }
-        public OrderType Type { get; private set; }
-        public OrderValidity Validity { get; }
-        public Side Side { get; }
-        public int Quantity { get; private set; }
-        public int RemainingQuantity { get; private set; }
-        public int FilledQuantity { get; private set; }
-        public long? Price { get; private set; }
-        public long? TriggerPrice { get; private set; }
-        public string? SelfMatchPreventionId { get; }
-        public SelfMatchPreventionInstruction? SelfMatchPreventionInstruction { get; }
-        public int? MaxVisibleQuantity { get; }
-
-        // The shown portion of an iceberg, against RemainingQuantity's true total. Equal to it for
-        // a non-iceberg order, so nothing elsewhere special-cases that.
-        public int DisplayedQuantity { get; private set; }
-
-        // Intrusive list pointers for the level currently holding this order - an order rests in
-        // only one at a time. Avoids a node object per order.
-        internal InternalOrder? LevelNext { get; set; }
-        internal InternalOrder? LevelPrev { get; set; }
-
-        public InternalOrder(long sequenceNumber, string companyId, string clientOrderId, Security security, DateTime time,
-            OrderStatus status, OrderType type, OrderValidity validity, Side side, int quantity, long? price,
-            long? triggerPrice, string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null, int? maxVisibleQuantity = null)
+    public void Cancel(DateTime time, string? clientOrderId = null)
+    {
+        if (clientOrderId != null)
         {
-            SequenceNumber = sequenceNumber;
-            InternalId = sequenceNumber;
-            CompanyId = companyId;
             ClientOrderId = clientOrderId;
-            Security = security;
-            CreatedTime = time;
-            ModifiedTime = time;
-            Status = status;
-            Type = type;
-            Validity = validity;
-            Side = side;
-            Quantity = quantity;
-            RemainingQuantity = Quantity;
-            FilledQuantity = 0;
-            Price = price;
-            TriggerPrice = triggerPrice;
-            SelfMatchPreventionId = selfMatchPreventionId;
-            SelfMatchPreventionInstruction = selfMatchPreventionInstruction;
-            MaxVisibleQuantity = maxVisibleQuantity;
-            DisplayedQuantity = Math.Min(maxVisibleQuantity ?? quantity, quantity);
         }
 
-        public override string ToString() =>
-            $"[Order #{ExchangeOrderId} company={CompanyId} clientOrder={ClientOrderId} {Status} {ModifiedTime:HH:mm:ss} {Side} {Quantity}@{ToDecimal(Price)}]";
+        RemainingQuantity = 0;
+        CompletedTime = time;
+        Status = OrderStatus.Cancelled;
+    }
 
-        public Order ToOrder()
+    public void Expire(DateTime time)
+    {
+        RemainingQuantity = 0;
+        CompletedTime = time;
+        Status = OrderStatus.Expired;
+    }
+
+    public void Update(long sequenceNumber, DateTime time, int? quantity, long? triggerPrice, long? price,
+        string clientOrderId)
+    {
+        SequenceNumber = sequenceNumber;
+        ModifiedTime = time;
+        ClientOrderId = clientOrderId;
+        if (quantity.HasValue)
         {
-            return new(CompanyId, ExchangeOrderId, ClientOrderId, Security, CreatedTime, ModifiedTime, CompletedTime,
-                Status, Type, Validity, Side, Quantity, FilledQuantity, RemainingQuantity, DisplayedQuantity,
-                ToDecimal(Price), ToDecimal(TriggerPrice), SelfMatchPreventionId, SelfMatchPreventionInstruction,
-                MaxVisibleQuantity);
-        }
+            // quantity is the new total size, so remaining = new total - already filled
+            RemainingQuantity -= (Quantity - quantity.Value);
+            Quantity = quantity.Value;
 
-        private decimal? ToDecimal(long? ticks) => ticks.HasValue ? ticks.Value * Security.TickSize : null;
-
-        public void Cancel(DateTime time, string? clientOrderId = null)
-        {
-            if (clientOrderId != null)
-            {
-                ClientOrderId = clientOrderId;
-            }
-
-            RemainingQuantity = 0;
-            CompletedTime = time;
-            Status = OrderStatus.Cancelled;
-        }
-
-        public void Expire(DateTime time)
-        {
-            RemainingQuantity = 0;
-            CompletedTime = time;
-            Status = OrderStatus.Expired;
-        }
-
-        public void Update(long sequenceNumber, DateTime time, int? quantity, long? triggerPrice, long? price,
-            string clientOrderId)
-        {
-            SequenceNumber = sequenceNumber;
-            ModifiedTime = time;
-            ClientOrderId = clientOrderId;
-            if (quantity.HasValue)
-            {
-                // quantity is the new total size, so remaining = new total - already filled
-                RemainingQuantity -= (Quantity - quantity.Value);
-                Quantity = quantity.Value;
-
-                // keep displayed in sync - for a non-iceberg order this just mirrors
-                // RemainingQuantity (no peak to cap it below); for an iceberg it's re-derived the
-                // same way construction does, capped to whatever peak is still configured
-                DisplayedQuantity = Math.Min(MaxVisibleQuantity ?? RemainingQuantity, RemainingQuantity);
-            }
-
-            if (triggerPrice.HasValue)
-            {
-                TriggerPrice = triggerPrice;
-            }
-
-            if (price.HasValue)
-            {
-                Price = price;
-            }
-        }
-
-        public void Fill(DateTime time, int quantity)
-        {
-            // TODO: validate quantity
-
-            FilledQuantity += quantity;
-            RemainingQuantity -= quantity;
-            DisplayedQuantity -= quantity;
-
-            if (RemainingQuantity == 0)
-            {
-                Status = OrderStatus.Filled;
-                CompletedTime = time;
-            }
-        }
-
-        // An auction print allocates full remaining size in one shot rather than peeling from the
-        // displayed peak. DisplayedQuantity is re-derived from what's left rather than subtracted
-        // from, since quantity here isn't capped to the peak and could take it negative. Bumps
-        // neither SequenceNumber nor ModifiedTime: the order keeps its place in the queue.
-        public void FillFullSize(DateTime time, int quantity)
-        {
-            FilledQuantity += quantity;
-            RemainingQuantity -= quantity;
+            // keep displayed in sync - for a non-iceberg order this just mirrors
+            // RemainingQuantity (no peak to cap it below); for an iceberg it's re-derived the
+            // same way construction does, capped to whatever peak is still configured
             DisplayedQuantity = Math.Min(MaxVisibleQuantity ?? RemainingQuantity, RemainingQuantity);
-
-            if (RemainingQuantity == 0)
-            {
-                Status = OrderStatus.Filled;
-                CompletedTime = time;
-            }
         }
 
-        // Peak exhausted with reserve remaining. Bumps SequenceNumber/ModifiedTime because the
-        // caller requeues to the back of the level straight after, as CME and Eurex both do.
-        public void Replenish(long sequenceNumber, DateTime time)
+        if (triggerPrice.HasValue)
         {
-            DisplayedQuantity = Math.Min(MaxVisibleQuantity!.Value, RemainingQuantity);
-            SequenceNumber = sequenceNumber;
-            ModifiedTime = time;
+            TriggerPrice = triggerPrice;
         }
 
-        public void ConvertToLimit(DateTime time, long sequenceNumber, long? price = null)
+        if (price.HasValue)
         {
-            if (price.HasValue)
-            {
-                Price = price;
-            }
-
-            SequenceNumber = sequenceNumber;
-            ModifiedTime = time;
-            Type = OrderType.Limit;
-            Status = OrderStatus.Working;
+            Price = price;
         }
+    }
+
+    public void Fill(DateTime time, int quantity)
+    {
+        // TODO: validate quantity
+
+        FilledQuantity += quantity;
+        RemainingQuantity -= quantity;
+        DisplayedQuantity -= quantity;
+
+        if (RemainingQuantity == 0)
+        {
+            Status = OrderStatus.Filled;
+            CompletedTime = time;
+        }
+    }
+
+    // An auction print allocates full remaining size in one shot rather than peeling from the
+    // displayed peak. DisplayedQuantity is re-derived from what's left rather than subtracted
+    // from, since quantity here isn't capped to the peak and could take it negative. Bumps
+    // neither SequenceNumber nor ModifiedTime: the order keeps its place in the queue.
+    public void FillFullSize(DateTime time, int quantity)
+    {
+        FilledQuantity += quantity;
+        RemainingQuantity -= quantity;
+        DisplayedQuantity = Math.Min(MaxVisibleQuantity ?? RemainingQuantity, RemainingQuantity);
+
+        if (RemainingQuantity == 0)
+        {
+            Status = OrderStatus.Filled;
+            CompletedTime = time;
+        }
+    }
+
+    // Peak exhausted with reserve remaining. Bumps SequenceNumber/ModifiedTime because the
+    // caller requeues to the back of the level straight after, as CME and Eurex both do.
+    public void Replenish(long sequenceNumber, DateTime time)
+    {
+        DisplayedQuantity = Math.Min(MaxVisibleQuantity!.Value, RemainingQuantity);
+        SequenceNumber = sequenceNumber;
+        ModifiedTime = time;
+    }
+
+    public void ConvertToLimit(DateTime time, long sequenceNumber, long? price = null)
+    {
+        if (price.HasValue)
+        {
+            Price = price;
+        }
+
+        SequenceNumber = sequenceNumber;
+        ModifiedTime = time;
+        Type = OrderType.Limit;
+        Status = OrderStatus.Working;
     }
 }

--- a/Circus/OrderBook/MatchOutcome.cs
+++ b/Circus/OrderBook/MatchOutcome.cs
@@ -1,21 +1,18 @@
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
-{
-    // What Matcher.Run decided should happen next. Run mutates nothing and emits nothing;
-    // InMemoryOrderBook.Apply does both.
-    internal abstract record MatchOutcome;
+// What Matcher.Run decided should happen next. Run mutates nothing and emits nothing;
+// InMemoryOrderBook.Apply does both.
+internal abstract record MatchOutcome;
 
-    internal sealed record SelfMatchDetected(InternalOrder Resting, InternalOrder Aggressor,
-        SelfMatchPreventionInstruction Instruction) : MatchOutcome;
+internal sealed record SelfMatchDetected(InternalOrder Resting, InternalOrder Aggressor,
+    SelfMatchPreventionInstruction Instruction) : MatchOutcome;
 
-    internal sealed record TradeExecuted(InternalOrder Resting, InternalOrder Aggressor, long PriceTicks,
-        int Quantity, bool UsesFullRemainingQuantity) : MatchOutcome;
+internal sealed record TradeExecuted(InternalOrder Resting, InternalOrder Aggressor, long PriceTicks,
+    int Quantity, bool UsesFullRemainingQuantity) : MatchOutcome;
 
-    // Terminal: Run stops yielding after this.
-    internal sealed record TradeRestrictionBreached(long PriceTicks, RestrictionBreach Breach) : MatchOutcome;
+// Terminal: Run stops yielding after this.
+internal sealed record TradeRestrictionBreached(long PriceTicks, RestrictionBreach Breach) : MatchOutcome;
 
-    // Elected by the trade that just printed, in FIFO order across both sides, and still resting
-    // in the stop ladders until Apply removes them.
-    internal sealed record StopsTriggered(IReadOnlyList<InternalOrder> Orders) : MatchOutcome;
-}
+// Elected by the trade that just printed, in FIFO order across both sides, and still resting
+// in the stop ladders until Apply removes them.
+internal sealed record StopsTriggered(IReadOnlyList<InternalOrder> Orders) : MatchOutcome;

--- a/Circus/OrderBook/Matcher.cs
+++ b/Circus/OrderBook/Matcher.cs
@@ -1,250 +1,245 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// Owns the working and stop ladders outright: Rest, Unrest and Reprice are the only ways an
+// order enters, leaves or moves within them, and the ladders never leave this class in a form
+// anything else could write to.
+//
+// Run decides what should happen against that state but never mutates it or emits events;
+// InMemoryOrderBook.Apply does both, between calls into Run's enumerator.
+internal sealed class Matcher
 {
-    // Owns the working and stop ladders outright: Rest, Unrest and Reprice are the only ways an
-    // order enters, leaves or moves within them, and the ladders never leave this class in a form
-    // anything else could write to.
-    //
-    // Run decides what should happen against that state but never mutates it or emits events;
-    // InMemoryOrderBook.Apply does both, between calls into Run's enumerator.
-    internal sealed class Matcher
+    // Array-backed, indexed by tick count (price / Security.TickSize) rather than decimal —
+    // see InternalOrder and PriceLadder for why.
+    private readonly Dictionary<Side, PriceLadder> _working = new()
     {
-        // Array-backed, indexed by tick count (price / Security.TickSize) rather than decimal —
-        // see InternalOrder and PriceLadder for why.
-        private readonly Dictionary<Side, PriceLadder> _working = new()
+        {Side.Buy, new PriceLadder(descending: true)},
+        {Side.Sell, new PriceLadder(descending: false)}
+    };
+
+    private readonly Dictionary<Side, PriceLadder> _stops = new()
+    {
+        {Side.Buy, new PriceLadder(descending: false)},
+        {Side.Sell, new PriceLadder(descending: true)}
+    };
+
+    // Projected once so what leaves this class can be read but not written. The stop ladders
+    // are not projected at all - nothing outside needs to read them.
+    private readonly IReadOnlyDictionary<Side, IReadOnlyPriceLadder> _workingView;
+
+    public Matcher()
+    {
+        _workingView = _working.ToDictionary(x => x.Key, x => (IReadOnlyPriceLadder) x.Value);
+    }
+
+    public IReadOnlyDictionary<Side, IReadOnlyPriceLadder> Working => _workingView;
+
+    // An untriggered stop rests in the stops ladder at its trigger price, everything else in
+    // the working book at its limit price. Type rather than Status is the discriminator: these
+    // run after Cancel/Expire/Fill has already overwritten Status, and ConvertToLimit retypes
+    // an elected stop, so the two never disagree.
+    private static bool RestsInStops(InternalOrder order) =>
+        order.Type is OrderType.StopLimit or OrderType.StopMarket;
+
+    private PriceLadder LadderFor(InternalOrder order) =>
+        RestsInStops(order) ? _stops[order.Side] : _working[order.Side];
+
+    private static long RestingPriceOf(InternalOrder order) =>
+        (RestsInStops(order) ? order.TriggerPrice : order.Price) ??
+        throw new InvalidOperationException($"{order.Type} order missing the price it rests at");
+
+    public void Rest(InternalOrder order) => LadderFor(order).Add(RestingPriceOf(order), order);
+
+    public void Unrest(InternalOrder order) => LadderFor(order).Remove(RestingPriceOf(order), order);
+
+    // Lands at the back of the new level. Passing the price it already rests at requeues it in
+    // place, which is what a quantity increase needs - losing time priority is the point.
+    public void Reprice(InternalOrder order, long newPriceTicks)
+    {
+        var ladder = LadderFor(order);
+        ladder.Remove(RestingPriceOf(order), order);
+        ladder.Add(newPriceTicks, order);
+    }
+
+    private InternalOrder? BestOrder(Side side) =>
+        _working[side].TryGetBest(out _, out var order) ? order : null;
+
+    // One decision at a time: self-match cancellations, trades, restriction breaches and stop
+    // triggers. The algorithm supplies counterparty and price; everything else here is the same
+    // whichever one is active.
+    //
+    // The book is re-read every iteration, so the caller MUST apply each outcome - ladder
+    // mutation included - before asking for the next. Buffering the sequence instead of
+    // applying as you go never terminates. It is also what lets a converted stop landing in the
+    // working book be picked up by this same loop rather than a recursive pass.
+    //
+    // afterStopTrigger takes over once a stop fires, and is assumed already prepared.
+    // checkTradeRestrictionBreach reports the severest consequence among the Trade-scoped
+    // restrictions disallowing a prospective price, and is consulted only when the algorithm
+    // asks for it.
+    public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm, IMatchingAlgorithm afterStopTrigger,
+        Func<long, RestrictionBreach?> checkTradeRestrictionBreach)
+    {
+        if (!algorithm.TryBegin(_workingView))
+            yield break;
+
+        var buy = BestOrder(Side.Buy);
+        var sell = BestOrder(Side.Sell);
+
+        if (buy != null && !buy.Price.HasValue)
+            throw new InvalidOperationException("buy limit order requires price");
+        if (sell != null && !sell.Price.HasValue)
+            throw new InvalidOperationException("sell limit order requires price");
+
+        while (buy != null && sell != null && buy.Price >= sell.Price)
         {
-            {Side.Buy, new PriceLadder(descending: true)},
-            {Side.Sell, new PriceLadder(descending: false)}
-        };
+            // The older of the two orders at the touch is passive by definition, whatever the
+            // algorithm then does with its level.
+            var restingHead = buy.ModifiedTime < sell.ModifiedTime ? buy : sell;
+            var aggressor = buy == restingHead ? sell : buy;
 
-        private readonly Dictionary<Side, PriceLadder> _stops = new()
-        {
-            {Side.Buy, new PriceLadder(descending: false)},
-            {Side.Sell, new PriceLadder(descending: true)}
-        };
-
-        // Projected once so what leaves this class can be read but not written. The stop ladders
-        // are not projected at all - nothing outside needs to read them.
-        private readonly IReadOnlyDictionary<Side, IReadOnlyPriceLadder> _workingView;
-
-        public Matcher()
-        {
-            _workingView = _working.ToDictionary(x => x.Key, x => (IReadOnlyPriceLadder) x.Value);
-        }
-
-        public IReadOnlyDictionary<Side, IReadOnlyPriceLadder> Working => _workingView;
-
-        // An untriggered stop rests in the stops ladder at its trigger price, everything else in
-        // the working book at its limit price. Type rather than Status is the discriminator: these
-        // run after Cancel/Expire/Fill has already overwritten Status, and ConvertToLimit retypes
-        // an elected stop, so the two never disagree.
-        private static bool RestsInStops(InternalOrder order) =>
-            order.Type is OrderType.StopLimit or OrderType.StopMarket;
-
-        private PriceLadder LadderFor(InternalOrder order) =>
-            RestsInStops(order) ? _stops[order.Side] : _working[order.Side];
-
-        private static long RestingPriceOf(InternalOrder order) =>
-            (RestsInStops(order) ? order.TriggerPrice : order.Price) ??
-            throw new InvalidOperationException($"{order.Type} order missing the price it rests at");
-
-        public void Rest(InternalOrder order) => LadderFor(order).Add(RestingPriceOf(order), order);
-
-        public void Unrest(InternalOrder order) => LadderFor(order).Remove(RestingPriceOf(order), order);
-
-        // Lands at the back of the new level. Passing the price it already rests at requeues it in
-        // place, which is what a quantity increase needs - losing time priority is the point.
-        public void Reprice(InternalOrder order, long newPriceTicks)
-        {
-            var ladder = LadderFor(order);
-            ladder.Remove(RestingPriceOf(order), order);
-            ladder.Add(newPriceTicks, order);
-        }
-
-        private InternalOrder? BestOrder(Side side) =>
-            _working[side].TryGetBest(out _, out var order) ? order : null;
-
-        // One decision at a time: self-match cancellations, trades, restriction breaches and stop
-        // triggers. The algorithm supplies counterparty and price; everything else here is the same
-        // whichever one is active.
-        //
-        // The book is re-read every iteration, so the caller MUST apply each outcome - ladder
-        // mutation included - before asking for the next. Buffering the sequence instead of
-        // applying as you go never terminates. It is also what lets a converted stop landing in the
-        // working book be picked up by this same loop rather than a recursive pass.
-        //
-        // afterStopTrigger takes over once a stop fires, and is assumed already prepared.
-        // checkTradeRestrictionBreach reports the severest consequence among the Trade-scoped
-        // restrictions disallowing a prospective price, and is consulted only when the algorithm
-        // asks for it.
-        public IEnumerable<MatchOutcome> Run(IMatchingAlgorithm algorithm, IMatchingAlgorithm afterStopTrigger,
-            Func<long, RestrictionBreach?> checkTradeRestrictionBreach)
-        {
-            if (!algorithm.TryBegin(_workingView))
+            var selection = algorithm.SelectNext(restingHead, aggressor);
+            if (selection == null)
                 yield break;
 
-            var buy = BestOrder(Side.Buy);
-            var sell = BestOrder(Side.Sell);
+            var (resting, quantity, priceTicks) = selection.Value;
 
-            if (buy != null && !buy.Price.HasValue)
-                throw new InvalidOperationException("buy limit order requires price");
-            if (sell != null && !sell.Price.HasValue)
-                throw new InvalidOperationException("sell limit order requires price");
-
-            while (buy != null && sell != null && buy.Price >= sell.Price)
+            // Against the order the algorithm picked, which need not be the head it was offered.
+            if (IsSelfMatch(resting, aggressor, out var instruction))
             {
-                // The older of the two orders at the touch is passive by definition, whatever the
-                // algorithm then does with its level.
-                var restingHead = buy.ModifiedTime < sell.ModifiedTime ? buy : sell;
-                var aggressor = buy == restingHead ? sell : buy;
+                yield return new SelfMatchDetected(resting, aggressor, instruction);
+                buy = BestOrder(Side.Buy);
+                sell = BestOrder(Side.Sell);
+                continue;
+            }
 
-                var selection = algorithm.SelectNext(restingHead, aggressor);
-                if (selection == null)
-                    yield break;
-
-                var (resting, quantity, priceTicks) = selection.Value;
-
-                // Against the order the algorithm picked, which need not be the head it was offered.
-                if (IsSelfMatch(resting, aggressor, out var instruction))
+            if (algorithm.ChecksTradeRestrictions)
+            {
+                var breach = checkTradeRestrictionBreach(priceTicks);
+                if (breach.HasValue)
                 {
-                    yield return new SelfMatchDetected(resting, aggressor, instruction);
-                    buy = BestOrder(Side.Buy);
-                    sell = BestOrder(Side.Sell);
+                    yield return new TradeRestrictionBreached(priceTicks, breach.Value);
+                    yield break;
+                }
+            }
+
+            yield return new TradeExecuted(resting, aggressor, priceTicks, quantity,
+                algorithm.UsesFullRemainingQuantity);
+
+            var triggeredStops = GatherTriggeredStops(priceTicks);
+            if (triggeredStops != null)
+            {
+                yield return new StopsTriggered(triggeredStops);
+
+                // Once a stop fires mid-sweep, everything after it prices continuously - an
+                // auction print is the resolution mechanism for the book as it stood at open,
+                // not for orders that have just newly arrived because of it.
+                algorithm = afterStopTrigger;
+            }
+
+            buy = BestOrder(Side.Buy);
+            sell = BestOrder(Side.Sell);
+        }
+    }
+
+    // Identifies only; Apply does the removing, converting and cancelling. Safe to call after
+    // every trade, even repeatedly at one price, since an order an earlier StopsTriggered
+    // already removed is not found again. Buy stops fire as price rises to their level and
+    // sell stops as it falls, which is the direction each ladder is already ordered in.
+    private List<InternalOrder>? GatherTriggeredStops(long priceTicks)
+    {
+        SortedDictionary<long, InternalOrder>? triggered = null;
+
+        foreach (var (tick, first, _) in _stops[Side.Buy].EnumerateFromBest())
+        {
+            if (tick > priceTicks)
+                break;
+
+            triggered ??= new SortedDictionary<long, InternalOrder>();
+            for (var order = first; order != null; order = order.LevelNext)
+                triggered.Add(order.SequenceNumber, order);
+        }
+
+        foreach (var (tick, first, _) in _stops[Side.Sell].EnumerateFromBest())
+        {
+            if (tick < priceTicks)
+                break;
+
+            triggered ??= new SortedDictionary<long, InternalOrder>();
+            for (var order = first; order != null; order = order.LevelNext)
+                triggered.Add(order.SequenceNumber, order);
+        }
+
+        return triggered?.Values.ToList();
+    }
+
+    // Whether an incoming order would find at least `quantity` immediately fillable, for the
+    // IOC minimum-quantity gate. The self-match arguments are the incoming order's own: a
+    // resting match under CancelResting is skipped, but under CancelAggressor/CancelBoth the
+    // incoming order would itself be cancelled there, so the walk must stop dead rather than
+    // skip one order and keep summing.
+    //
+    // Walks head-first, which SelectNext no longer guarantees. A narrow assumption: total
+    // reachable quantity is independent of visit order, and only the point at which the
+    // self-match stop truncates the walk is not - so this stays exact for any algorithm
+    // without self-match interaction, and needs revisiting alongside one where it differs.
+    //
+    // Not delegated to SelectNext: the gate runs before the incoming order is constructed, so
+    // there is no aggressor to offer, and a stateful algorithm's per-level bookkeeping would
+    // be polluted by a walk that never trades.
+    public bool HasSufficientLiquidity(Side side, long priceTicks, int quantity, string? selfMatchPreventionId,
+        SelfMatchPreventionInstruction? selfMatchPreventionInstruction)
+    {
+        var opposing = _working[side == Side.Buy ? Side.Sell : Side.Buy];
+        var total = 0;
+        foreach (var (tick, first, _) in opposing.EnumerateFromBest())
+        {
+            var crosses = side == Side.Buy ? tick <= priceTicks : tick >= priceTicks;
+            if (!crosses)
+                break;
+
+            for (var restingOrder = first; restingOrder != null; restingOrder = restingOrder.LevelNext)
+            {
+                if (TryGetSelfMatchInstruction(restingOrder, selfMatchPreventionId,
+                        selfMatchPreventionInstruction, out var instruction))
+                {
+                    // total < quantity is guaranteed here - otherwise we'd have already
+                    // returned true below before reaching this order
+                    if (instruction != SelfMatchPreventionInstruction.CancelResting)
+                        return false;
+
                     continue;
                 }
 
-                if (algorithm.ChecksTradeRestrictions)
-                {
-                    var breach = checkTradeRestrictionBreach(priceTicks);
-                    if (breach.HasValue)
-                    {
-                        yield return new TradeRestrictionBreached(priceTicks, breach.Value);
-                        yield break;
-                    }
-                }
-
-                yield return new TradeExecuted(resting, aggressor, priceTicks, quantity,
-                    algorithm.UsesFullRemainingQuantity);
-
-                var triggeredStops = GatherTriggeredStops(priceTicks);
-                if (triggeredStops != null)
-                {
-                    yield return new StopsTriggered(triggeredStops);
-
-                    // Once a stop fires mid-sweep, everything after it prices continuously - an
-                    // auction print is the resolution mechanism for the book as it stood at open,
-                    // not for orders that have just newly arrived because of it.
-                    algorithm = afterStopTrigger;
-                }
-
-                buy = BestOrder(Side.Buy);
-                sell = BestOrder(Side.Sell);
+                total += restingOrder.RemainingQuantity;
+                if (total >= quantity)
+                    return true;
             }
         }
 
-        // Identifies only; Apply does the removing, converting and cancelling. Safe to call after
-        // every trade, even repeatedly at one price, since an order an earlier StopsTriggered
-        // already removed is not found again. Buy stops fire as price rises to their level and
-        // sell stops as it falls, which is the direction each ladder is already ordered in.
-        private List<InternalOrder>? GatherTriggeredStops(long priceTicks)
+        return total >= quantity;
+    }
+
+    // Two orders are a prevented self-match only if both carry the same non-null
+    // SelfMatchPreventionId - matches CME/Eurex, where this is a dedicated opt-in id
+    // distinct from the firm/company identifier (so unrelated desks under one company
+    // aren't blocked from trading each other).
+    private static bool IsSelfMatch(InternalOrder resting, InternalOrder aggressor,
+        out SelfMatchPreventionInstruction instruction) =>
+        TryGetSelfMatchInstruction(resting, aggressor.SelfMatchPreventionId,
+            aggressor.SelfMatchPreventionInstruction, out instruction);
+
+    private static bool TryGetSelfMatchInstruction(InternalOrder resting, string? incomingSelfMatchPreventionId,
+        SelfMatchPreventionInstruction? incomingInstruction, out SelfMatchPreventionInstruction instruction)
+    {
+        if (incomingSelfMatchPreventionId == null ||
+            resting.SelfMatchPreventionId != incomingSelfMatchPreventionId)
         {
-            SortedDictionary<long, InternalOrder>? triggered = null;
-
-            foreach (var (tick, first, _) in _stops[Side.Buy].EnumerateFromBest())
-            {
-                if (tick > priceTicks)
-                    break;
-
-                triggered ??= new SortedDictionary<long, InternalOrder>();
-                for (var order = first; order != null; order = order.LevelNext)
-                    triggered.Add(order.SequenceNumber, order);
-            }
-
-            foreach (var (tick, first, _) in _stops[Side.Sell].EnumerateFromBest())
-            {
-                if (tick < priceTicks)
-                    break;
-
-                triggered ??= new SortedDictionary<long, InternalOrder>();
-                for (var order = first; order != null; order = order.LevelNext)
-                    triggered.Add(order.SequenceNumber, order);
-            }
-
-            return triggered?.Values.ToList();
+            instruction = default;
+            return false;
         }
 
-        // Whether an incoming order would find at least `quantity` immediately fillable, for the
-        // IOC minimum-quantity gate. The self-match arguments are the incoming order's own: a
-        // resting match under CancelResting is skipped, but under CancelAggressor/CancelBoth the
-        // incoming order would itself be cancelled there, so the walk must stop dead rather than
-        // skip one order and keep summing.
-        //
-        // Walks head-first, which SelectNext no longer guarantees. A narrow assumption: total
-        // reachable quantity is independent of visit order, and only the point at which the
-        // self-match stop truncates the walk is not - so this stays exact for any algorithm
-        // without self-match interaction, and needs revisiting alongside one where it differs.
-        //
-        // Not delegated to SelectNext: the gate runs before the incoming order is constructed, so
-        // there is no aggressor to offer, and a stateful algorithm's per-level bookkeeping would
-        // be polluted by a walk that never trades.
-        public bool HasSufficientLiquidity(Side side, long priceTicks, int quantity, string? selfMatchPreventionId,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction)
-        {
-            var opposing = _working[side == Side.Buy ? Side.Sell : Side.Buy];
-            var total = 0;
-            foreach (var (tick, first, _) in opposing.EnumerateFromBest())
-            {
-                var crosses = side == Side.Buy ? tick <= priceTicks : tick >= priceTicks;
-                if (!crosses)
-                    break;
-
-                for (var restingOrder = first; restingOrder != null; restingOrder = restingOrder.LevelNext)
-                {
-                    if (TryGetSelfMatchInstruction(restingOrder, selfMatchPreventionId,
-                            selfMatchPreventionInstruction, out var instruction))
-                    {
-                        // total < quantity is guaranteed here - otherwise we'd have already
-                        // returned true below before reaching this order
-                        if (instruction != SelfMatchPreventionInstruction.CancelResting)
-                            return false;
-
-                        continue;
-                    }
-
-                    total += restingOrder.RemainingQuantity;
-                    if (total >= quantity)
-                        return true;
-                }
-            }
-
-            return total >= quantity;
-        }
-
-        // Two orders are a prevented self-match only if both carry the same non-null
-        // SelfMatchPreventionId - matches CME/Eurex, where this is a dedicated opt-in id
-        // distinct from the firm/company identifier (so unrelated desks under one company
-        // aren't blocked from trading each other).
-        private static bool IsSelfMatch(InternalOrder resting, InternalOrder aggressor,
-            out SelfMatchPreventionInstruction instruction) =>
-            TryGetSelfMatchInstruction(resting, aggressor.SelfMatchPreventionId,
-                aggressor.SelfMatchPreventionInstruction, out instruction);
-
-        private static bool TryGetSelfMatchInstruction(InternalOrder resting, string? incomingSelfMatchPreventionId,
-            SelfMatchPreventionInstruction? incomingInstruction, out SelfMatchPreventionInstruction instruction)
-        {
-            if (incomingSelfMatchPreventionId == null ||
-                resting.SelfMatchPreventionId != incomingSelfMatchPreventionId)
-            {
-                instruction = default;
-                return false;
-            }
-
-            instruction = incomingInstruction ?? resting.SelfMatchPreventionInstruction ??
-                SelfMatchPreventionInstruction.CancelResting;
-            return true;
-        }
+        instruction = incomingInstruction ?? resting.SelfMatchPreventionInstruction ??
+            SelfMatchPreventionInstruction.CancelResting;
+        return true;
     }
 }

--- a/Circus/OrderBook/OrderBookAction.cs
+++ b/Circus/OrderBook/OrderBookAction.cs
@@ -1,102 +1,101 @@
-namespace Circus.OrderBook
+namespace Circus.OrderBook;
+
+public abstract record OrderBookAction
 {
-    public abstract record OrderBookAction
-    {
-        public required Security Security { get; init; }
-    }
+    public required Security Security { get; init; }
+}
 
-    public sealed record PreOpenTrading : OrderBookAction
-    {
-        public decimal? ReferencePrice { get; init; }
-    }
+public sealed record PreOpenTrading : OrderBookAction
+{
+    public decimal? ReferencePrice { get; init; }
+}
 
-    public sealed record OpenTrading : OrderBookAction
-    {
-        public decimal? ReferencePrice { get; init; }
-    }
+public sealed record OpenTrading : OrderBookAction
+{
+    public decimal? ReferencePrice { get; init; }
+}
 
-    // A trading day can hold several sessions, and only the last close of the day retires that
-    // day's Day/GoodTilDate orders - an intra-day close (a lunch break, say) leaves them resting.
-    // Defaults to true so a single-session day needs to say nothing.
-    public sealed record CloseTrading : OrderBookAction
-    {
-        public bool EndsTradingDay { get; init; } = true;
-    }
+// A trading day can hold several sessions, and only the last close of the day retires that
+// day's Day/GoodTilDate orders - an intra-day close (a lunch break, say) leaves them resting.
+// Defaults to true so a single-session day needs to say nothing.
+public sealed record CloseTrading : OrderBookAction
+{
+    public bool EndsTradingDay { get; init; } = true;
+}
 
-    // Interrupt trading within a session, keeping a quote. The book raises this itself on a
-    // volatility band breach; as an action it is the operator-driven equivalent.
-    public sealed record PauseTrading : OrderBookAction;
+// Interrupt trading within a session, keeping a quote. The book raises this itself on a
+// volatility band breach; as an action it is the operator-driven equivalent.
+public sealed record PauseTrading : OrderBookAction;
 
-    // Suspend trading with no price discovery. The book raises this itself when a restriction
-    // breach calls for a halt; as an action it is the operator-driven equivalent.
-    public sealed record HaltTrading : OrderBookAction;
+// Suspend trading with no price discovery. The book raises this itself when a restriction
+// breach calls for a halt; as an action it is the operator-driven equivalent.
+public sealed record HaltTrading : OrderBookAction;
 
-    // Nothing to do but let the clock be noticed. A timed interruption ends on its own, and a book
-    // with no order flow to carry it there needs something to ask - so a caller driving the book
-    // off a clock sends this as it ticks. Carries no time of its own: the book's time provider is
-    // the one authority on what time it is.
-    public sealed record AdvanceTime : OrderBookAction;
+// Nothing to do but let the clock be noticed. A timed interruption ends on its own, and a book
+// with no order flow to carry it there needs something to ask - so a caller driving the book
+// off a clock sends this as it ticks. Carries no time of its own: the book's time provider is
+// the one authority on what time it is.
+public sealed record AdvanceTime : OrderBookAction;
 
-    public abstract record OrderAction : OrderBookAction
-    {
-        public required string CompanyId { get; init; }
-        public required string ClientOrderId { get; init; }
-    }
+public abstract record OrderAction : OrderBookAction
+{
+    public required string CompanyId { get; init; }
+    public required string ClientOrderId { get; init; }
+}
 
-    // Id is required: an instruction with no id is meaningless (nothing to match against), so
-    // rather than let that combination be constructed and silently ignored, opting into self-match
-    // prevention at all means supplying an id - Instruction is the only genuinely optional part,
-    // falling back to CancelResting when omitted.
-    public sealed record SelfMatchPrevention
-    {
-        public required string Id { get; init; }
-        public SelfMatchPreventionInstruction? Instruction { get; init; }
-    }
+// Id is required: an instruction with no id is meaningless (nothing to match against), so
+// rather than let that combination be constructed and silently ignored, opting into self-match
+// prevention at all means supplying an id - Instruction is the only genuinely optional part,
+// falling back to CancelResting when omitted.
+public sealed record SelfMatchPrevention
+{
+    public required string Id { get; init; }
+    public SelfMatchPreventionInstruction? Instruction { get; init; }
+}
 
-    public abstract record CreateOrder : OrderAction
-    {
-        public required OrderValidity OrderValidity { get; init; }
-        public required Side Side { get; init; }
-        public required int Quantity { get; init; }
-        public SelfMatchPrevention? SelfMatchPrevention { get; init; }
+public abstract record CreateOrder : OrderAction
+{
+    public required OrderValidity OrderValidity { get; init; }
+    public required Side Side { get; init; }
+    public required int Quantity { get; init; }
+    public SelfMatchPrevention? SelfMatchPrevention { get; init; }
 
-        // Iceberg/display quantity - the portion shown to the market at a time, with the rest
-        // held in reserve. Not restricted to CreateLimitOrder: Market/MarketLimit/triggered-Stop
-        // orders can all end up resting as a plain limit order too, so display quantity is
-        // meaningful for any of them.
-        public int? MaxVisibleQuantity { get; init; }
-    }
+    // Iceberg/display quantity - the portion shown to the market at a time, with the rest
+    // held in reserve. Not restricted to CreateLimitOrder: Market/MarketLimit/triggered-Stop
+    // orders can all end up resting as a plain limit order too, so display quantity is
+    // meaningful for any of them.
+    public int? MaxVisibleQuantity { get; init; }
+}
 
-    public sealed record CreateLimitOrder : CreateOrder
-    {
-        public required decimal Price { get; init; }
-    }
+public sealed record CreateLimitOrder : CreateOrder
+{
+    public required decimal Price { get; init; }
+}
 
-    public sealed record CreateMarketOrder : CreateOrder;
+public sealed record CreateMarketOrder : CreateOrder;
 
-    public sealed record CreateMarketLimitOrder : CreateOrder;
+public sealed record CreateMarketLimitOrder : CreateOrder;
 
-    public sealed record CreateStopLimitOrder : CreateOrder
-    {
-        public required decimal Price { get; init; }
-        public required decimal TriggerPrice { get; init; }
-    }
+public sealed record CreateStopLimitOrder : CreateOrder
+{
+    public required decimal Price { get; init; }
+    public required decimal TriggerPrice { get; init; }
+}
 
-    public sealed record CreateStopMarketOrder : CreateOrder
-    {
-        public required decimal TriggerPrice { get; init; }
-    }
+public sealed record CreateStopMarketOrder : CreateOrder
+{
+    public required decimal TriggerPrice { get; init; }
+}
 
-    public sealed record UpdateOrder : OrderAction
-    {
-        public required string PreviousClientOrderId { get; init; }
-        public int? NewTotalQuantity { get; init; }
-        public decimal? Price { get; init; }
-        public decimal? TriggerPrice { get; init; }
-    }
+public sealed record UpdateOrder : OrderAction
+{
+    public required string PreviousClientOrderId { get; init; }
+    public int? NewTotalQuantity { get; init; }
+    public decimal? Price { get; init; }
+    public decimal? TriggerPrice { get; init; }
+}
 
-    public sealed record CancelOrder : OrderAction
-    {
-        public required string PreviousClientOrderId { get; init; }
-    }
+public sealed record CancelOrder : OrderAction
+{
+    public required string PreviousClientOrderId { get; init; }
 }

--- a/Circus/OrderBook/OrderBookEvent.cs
+++ b/Circus/OrderBook/OrderBookEvent.cs
@@ -1,103 +1,99 @@
-using System;
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
-{
-    public record OrderBookEvent(Security Security, DateTime Time);
+public record OrderBookEvent(Security Security, DateTime Time);
 
-    // Reason defaults to Requested, which is what every externally driven transition is.
-    //
-    // ResumesAt is when a timed interruption is due to end, and is null for everything else - which
-    // includes an interruption configured to last until told otherwise, and every ordinary
-    // transition, since an explicit one supersedes whatever was pending.
-    public record StatusChanged(Security Security, DateTime Time, OrderBookStatus Status,
-            StatusChangeReason Reason = StatusChangeReason.Requested, DateTime? ResumesAt = null)
-        : OrderBookEvent(Security, Time);
+// Reason defaults to Requested, which is what every externally driven transition is.
+//
+// ResumesAt is when a timed interruption is due to end, and is null for everything else - which
+// includes an interruption configured to last until told otherwise, and every ordinary
+// transition, since an explicit one supersedes whatever was pending.
+public record StatusChanged(Security Security, DateTime Time, OrderBookStatus Status,
+        StatusChangeReason Reason = StatusChangeReason.Requested, DateTime? ResumesAt = null)
+    : OrderBookEvent(Security, Time);
 
-    public record OrderEvent(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
-            string? ExchangeOrderId)
-        : OrderBookEvent(Security, Time);
+public record OrderEvent(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
+        string? ExchangeOrderId)
+    : OrderBookEvent(Security, Time);
 
-    public record OrderConfirmedEvent(Security Security, DateTime Time, string CompanyId, Order Order)
-        : OrderEvent(Security, Time, CompanyId, Order.ClientOrderId, Order.ExchangeOrderId);
+public record OrderConfirmedEvent(Security Security, DateTime Time, string CompanyId, Order Order)
+    : OrderEvent(Security, Time, CompanyId, Order.ClientOrderId, Order.ExchangeOrderId);
 
-    public record CreateOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order)
-        : OrderConfirmedEvent(Security, Time, CompanyId, Order);
+public record CreateOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order)
+    : OrderConfirmedEvent(Security, Time, CompanyId, Order);
 
-    // Previous* describe the working-book state before this update, since Order reflects the state
-    // after it. PreviousPrice is null when the order was not previously in the working book at all
-    // (a stop activating), distinguishing an arrival from a move between levels. PreviousQuantity is
-    // DisplayedQuantity, matching what a level actually contained.
-    //
-    // PreviousExchangeOrderId differs from Order.ExchangeOrderId whenever the update lost time
-    // priority, and is equal for a quantity decrease, which keeps it. A full-book feed uses this to
-    // tell a requeue apart from an in-place modify.
-    public record UpdateOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order,
-            string PreviousClientOrderId, string PreviousExchangeOrderId, decimal? PreviousPrice, int PreviousQuantity)
-        : OrderConfirmedEvent(Security, Time, CompanyId, Order);
+// Previous* describe the working-book state before this update, since Order reflects the state
+// after it. PreviousPrice is null when the order was not previously in the working book at all
+// (a stop activating), distinguishing an arrival from a move between levels. PreviousQuantity is
+// DisplayedQuantity, matching what a level actually contained.
+//
+// PreviousExchangeOrderId differs from Order.ExchangeOrderId whenever the update lost time
+// priority, and is equal for a quantity decrease, which keeps it. A full-book feed uses this to
+// tell a requeue apart from an in-place modify.
+public record UpdateOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order,
+        string PreviousClientOrderId, string PreviousExchangeOrderId, decimal? PreviousPrice, int PreviousQuantity)
+    : OrderConfirmedEvent(Security, Time, CompanyId, Order);
 
-    // PreviousQuantity is DisplayedQuantity before cancellation - an iceberg's hidden reserve was
-    // never part of the level being removed from. PreviousPrice is null when the order was still
-    // Hidden, having never rested in the working book.
-    public record CancelOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order,
-            string PreviousClientOrderId, OrderCancelledReason Reason, decimal? PreviousPrice, int PreviousQuantity)
-        : OrderConfirmedEvent(Security, Time, CompanyId, Order);
+// PreviousQuantity is DisplayedQuantity before cancellation - an iceberg's hidden reserve was
+// never part of the level being removed from. PreviousPrice is null when the order was still
+// Hidden, having never rested in the working book.
+public record CancelOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order,
+        string PreviousClientOrderId, OrderCancelledReason Reason, decimal? PreviousPrice, int PreviousQuantity)
+    : OrderConfirmedEvent(Security, Time, CompanyId, Order);
 
-    // As CancelOrderConfirmed: DisplayedQuantity before expiry, and a null price for an order that
-    // was still Hidden.
-    public record ExpireOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order,
-            decimal? PreviousPrice, int PreviousQuantity)
-        : OrderConfirmedEvent(Security, Time, CompanyId, Order);
+// As CancelOrderConfirmed: DisplayedQuantity before expiry, and a null price for an order that
+// was still Hidden.
+public record ExpireOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order,
+        decimal? PreviousPrice, int PreviousQuantity)
+    : OrderConfirmedEvent(Security, Time, CompanyId, Order);
 
-    // Quantity is what traded; PreviousDisplayedQuantity is the order's DisplayedQuantity before
-    // it did. The two differ whenever an auction sizes a fill off full remaining quantity - an
-    // iceberg can trade more than it was showing, and comes out of it displaying a fresh peak
-    // rather than what is left of the old one. A level aggregate must move by the change in
-    // displayed size, not by the traded quantity.
-    public record FillOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order, decimal Price,
-            int Quantity, int PreviousDisplayedQuantity, bool IsResting)
-        : OrderConfirmedEvent(Security, Time, CompanyId, Order);
+// Quantity is what traded; PreviousDisplayedQuantity is the order's DisplayedQuantity before
+// it did. The two differ whenever an auction sizes a fill off full remaining quantity - an
+// iceberg can trade more than it was showing, and comes out of it displaying a fresh peak
+// rather than what is left of the old one. A level aggregate must move by the change in
+// displayed size, not by the traded quantity.
+public record FillOrderConfirmed(Security Security, DateTime Time, string CompanyId, Order Order, decimal Price,
+        int Quantity, int PreviousDisplayedQuantity, bool IsResting)
+    : OrderConfirmedEvent(Security, Time, CompanyId, Order);
 
-    public record OrderRejectedEvent(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
-            string? ExchangeOrderId, OrderRejectedReason Reason)
-        : OrderEvent(Security, Time, CompanyId, ClientOrderId, ExchangeOrderId);
+public record OrderRejectedEvent(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
+        string? ExchangeOrderId, OrderRejectedReason Reason)
+    : OrderEvent(Security, Time, CompanyId, ClientOrderId, ExchangeOrderId);
 
-    // Create is always rejected before an order (and thus an ExchangeOrderId) exists.
-    public record CreateOrderRejected(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
-            OrderRejectedReason Reason)
-        : OrderRejectedEvent(Security, Time, CompanyId, ClientOrderId, null, Reason);
+// Create is always rejected before an order (and thus an ExchangeOrderId) exists.
+public record CreateOrderRejected(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
+        OrderRejectedReason Reason)
+    : OrderRejectedEvent(Security, Time, CompanyId, ClientOrderId, null, Reason);
 
-    // ExchangeOrderId is populated once the target order has been located (null for rejections
-    // that occur before lookup, e.g. MarketClosed or an invalid ClientOrderId).
-    public record UpdateOrderRejected(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
-            string PreviousClientOrderId, string? ExchangeOrderId, OrderRejectedReason Reason)
-        : OrderRejectedEvent(Security, Time, CompanyId, ClientOrderId, ExchangeOrderId, Reason);
+// ExchangeOrderId is populated once the target order has been located (null for rejections
+// that occur before lookup, e.g. MarketClosed or an invalid ClientOrderId).
+public record UpdateOrderRejected(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
+        string PreviousClientOrderId, string? ExchangeOrderId, OrderRejectedReason Reason)
+    : OrderRejectedEvent(Security, Time, CompanyId, ClientOrderId, ExchangeOrderId, Reason);
 
-    public record CancelOrderRejected(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
-            string PreviousClientOrderId, string? ExchangeOrderId, OrderRejectedReason Reason)
-        : OrderRejectedEvent(Security, Time, CompanyId, ClientOrderId, ExchangeOrderId, Reason);
+public record CancelOrderRejected(Security Security, DateTime Time, string CompanyId, string ClientOrderId,
+        string PreviousClientOrderId, string? ExchangeOrderId, OrderRejectedReason Reason)
+    : OrderRejectedEvent(Security, Time, CompanyId, ClientOrderId, ExchangeOrderId, Reason);
 
-    public record OrdersMatched(Security Security, DateTime Time, decimal Price, int Quantity,
-            IList<FillOrderConfirmed> Fills)
-        : OrderBookEvent(Security, Time);
+public record OrdersMatched(Security Security, DateTime Time, decimal Price, int Quantity,
+        IList<FillOrderConfirmed> Fills)
+    : OrderBookEvent(Security, Time);
 
-    // The price and quantity the current phase would print if it ended right now - an auction's
-    // indicative quote, published as it moves rather than answered on request, so a consumer's
-    // view of it follows from the event stream alone. Emitted only on a change, which makes a
-    // null Price (with Quantity 0) the withdrawal of a quote previously published: the book has
-    // stopped crossing, or the phase quoting it has ended. A phase that trades continuously has
-    // no such price and so publishes none.
-    public record IndicativePriceChanged(Security Security, DateTime Time, decimal? Price, int Quantity)
-        : OrderBookEvent(Security, Time);
+// The price and quantity the current phase would print if it ended right now - an auction's
+// indicative quote, published as it moves rather than answered on request, so a consumer's
+// view of it follows from the event stream alone. Emitted only on a change, which makes a
+// null Price (with Quantity 0) the withdrawal of a quote previously published: the book has
+// stopped crossing, or the phase quoting it has ended. A phase that trades continuously has
+// no such price and so publishes none.
+public record IndicativePriceChanged(Security Security, DateTime Time, decimal? Price, int Quantity)
+    : OrderBookEvent(Security, Time);
 
-    // The market has reached a daily price limit and cannot trade through it, or has come back
-    // inside one. Side is which way it is stuck: Buy for limit up, where buyers cannot push higher,
-    // Sell for limit down. Null with a null Price releases it, and is what a print inside the
-    // limits emits.
-    //
-    // Not a status change - a limit-locked market is open, quoting, and trading at the limit. That
-    // is the whole difference between a limit and a circuit breaker, so it gets an event of its own
-    // rather than a status that would claim otherwise. Emitted only on a change.
-    public record LimitStateChanged(Security Security, DateTime Time, Side? Side, decimal? Price)
-        : OrderBookEvent(Security, Time);
-}
+// The market has reached a daily price limit and cannot trade through it, or has come back
+// inside one. Side is which way it is stuck: Buy for limit up, where buyers cannot push higher,
+// Sell for limit down. Null with a null Price releases it, and is what a print inside the
+// limits emits.
+//
+// Not a status change - a limit-locked market is open, quoting, and trading at the limit. That
+// is the whole difference between a limit and a circuit breaker, so it gets an event of its own
+// rather than a status that would claim otherwise. Emitted only on a change.
+public record LimitStateChanged(Security Security, DateTime Time, Side? Side, decimal? Price)
+    : OrderBookEvent(Security, Time);

--- a/Circus/OrderBook/OrderBookExtensions.cs
+++ b/Circus/OrderBook/OrderBookExtensions.cs
@@ -1,136 +1,132 @@
-using System;
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+public static class OrderBookExtensions
 {
-    public static class OrderBookExtensions
-    {
-        private static SelfMatchPrevention? BuildSelfMatchPrevention(string? id,
-            SelfMatchPreventionInstruction? instruction) =>
-            id == null ? null : new SelfMatchPrevention { Id = id, Instruction = instruction };
+    private static SelfMatchPrevention? BuildSelfMatchPrevention(string? id,
+        SelfMatchPreventionInstruction? instruction) =>
+        id == null ? null : new SelfMatchPrevention { Id = id, Instruction = instruction };
 
-        public static IReadOnlyList<OrderBookEvent> CreateLimitOrder(this IOrderBook book, string companyId,
-            string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
-            string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-            int? maxVisibleQuantity = null) =>
-            book.Process(new CreateLimitOrder
-            {
-                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
-                OrderValidity = orderValidity, Side = side, Quantity = quantity, Price = price,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
-                MaxVisibleQuantity = maxVisibleQuantity
-            });
+    public static IReadOnlyList<OrderBookEvent> CreateLimitOrder(this IOrderBook book, string companyId,
+        string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
+        string? selfMatchPreventionId = null,
+        SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+        int? maxVisibleQuantity = null) =>
+        book.Process(new CreateLimitOrder
+        {
+            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = orderValidity, Side = side, Quantity = quantity, Price = price,
+            SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+            MaxVisibleQuantity = maxVisibleQuantity
+        });
 
-        public static IReadOnlyList<OrderBookEvent> CreateMarketOrder(this IOrderBook book, string companyId,
-            string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
-            string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-            int? maxVisibleQuantity = null) =>
-            book.Process(new CreateMarketOrder
-            {
-                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
-                OrderValidity = orderValidity, Side = side, Quantity = quantity,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
-                MaxVisibleQuantity = maxVisibleQuantity
-            });
+    public static IReadOnlyList<OrderBookEvent> CreateMarketOrder(this IOrderBook book, string companyId,
+        string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
+        string? selfMatchPreventionId = null,
+        SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+        int? maxVisibleQuantity = null) =>
+        book.Process(new CreateMarketOrder
+        {
+            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = orderValidity, Side = side, Quantity = quantity,
+            SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+            MaxVisibleQuantity = maxVisibleQuantity
+        });
 
-        public static IReadOnlyList<OrderBookEvent> CreateMarketLimitOrder(this IOrderBook book, string companyId,
-            string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
-            string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-            int? maxVisibleQuantity = null) =>
-            book.Process(new CreateMarketLimitOrder
-            {
-                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
-                OrderValidity = orderValidity, Side = side, Quantity = quantity,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
-                MaxVisibleQuantity = maxVisibleQuantity
-            });
+    public static IReadOnlyList<OrderBookEvent> CreateMarketLimitOrder(this IOrderBook book, string companyId,
+        string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
+        string? selfMatchPreventionId = null,
+        SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+        int? maxVisibleQuantity = null) =>
+        book.Process(new CreateMarketLimitOrder
+        {
+            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = orderValidity, Side = side, Quantity = quantity,
+            SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+            MaxVisibleQuantity = maxVisibleQuantity
+        });
 
-        public static IReadOnlyList<OrderBookEvent> CreateStopLimitOrder(this IOrderBook book, string companyId,
-            string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
-            decimal triggerPrice, string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-            int? maxVisibleQuantity = null) =>
-            book.Process(new CreateStopLimitOrder
-            {
-                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
-                OrderValidity = orderValidity, Side = side, Quantity = quantity,
-                Price = price, TriggerPrice = triggerPrice,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
-                MaxVisibleQuantity = maxVisibleQuantity
-            });
+    public static IReadOnlyList<OrderBookEvent> CreateStopLimitOrder(this IOrderBook book, string companyId,
+        string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
+        decimal triggerPrice, string? selfMatchPreventionId = null,
+        SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+        int? maxVisibleQuantity = null) =>
+        book.Process(new CreateStopLimitOrder
+        {
+            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = orderValidity, Side = side, Quantity = quantity,
+            Price = price, TriggerPrice = triggerPrice,
+            SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+            MaxVisibleQuantity = maxVisibleQuantity
+        });
 
-        public static IReadOnlyList<OrderBookEvent> CreateStopMarketOrder(this IOrderBook book, string companyId,
-            string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal triggerPrice,
-            string? selfMatchPreventionId = null,
-            SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-            int? maxVisibleQuantity = null) =>
-            book.Process(new CreateStopMarketOrder
-            {
-                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
-                OrderValidity = orderValidity, Side = side, Quantity = quantity,
-                TriggerPrice = triggerPrice,
-                SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
-                MaxVisibleQuantity = maxVisibleQuantity
-            });
+    public static IReadOnlyList<OrderBookEvent> CreateStopMarketOrder(this IOrderBook book, string companyId,
+        string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal triggerPrice,
+        string? selfMatchPreventionId = null,
+        SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
+        int? maxVisibleQuantity = null) =>
+        book.Process(new CreateStopMarketOrder
+        {
+            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = orderValidity, Side = side, Quantity = quantity,
+            TriggerPrice = triggerPrice,
+            SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
+            MaxVisibleQuantity = maxVisibleQuantity
+        });
 
-        public static IReadOnlyList<OrderBookEvent> UpdateOrder(this IOrderBook book, string companyId,
-            string clientOrderId, string previousClientOrderId, int? newTotalQuantity = null, decimal? price = null,
-            decimal? triggerPrice = null) =>
-            book.Process(new UpdateOrder
-            {
-                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
-                PreviousClientOrderId = previousClientOrderId, NewTotalQuantity = newTotalQuantity, Price = price,
-                TriggerPrice = triggerPrice
-            });
+    public static IReadOnlyList<OrderBookEvent> UpdateOrder(this IOrderBook book, string companyId,
+        string clientOrderId, string previousClientOrderId, int? newTotalQuantity = null, decimal? price = null,
+        decimal? triggerPrice = null) =>
+        book.Process(new UpdateOrder
+        {
+            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            PreviousClientOrderId = previousClientOrderId, NewTotalQuantity = newTotalQuantity, Price = price,
+            TriggerPrice = triggerPrice
+        });
 
-        public static IReadOnlyList<OrderBookEvent> CancelOrder(this IOrderBook book, string companyId,
-            string clientOrderId, string previousClientOrderId) =>
-            book.Process(new CancelOrder
-            {
-                Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
-                PreviousClientOrderId = previousClientOrderId
-            });
+    public static IReadOnlyList<OrderBookEvent> CancelOrder(this IOrderBook book, string companyId,
+        string clientOrderId, string previousClientOrderId) =>
+        book.Process(new CancelOrder
+        {
+            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            PreviousClientOrderId = previousClientOrderId
+        });
 
-        public static IReadOnlyList<OrderBookEvent> PreOpenTrading(this IOrderBook book,
-            decimal? referencePrice = null) =>
-            book.Process(new PreOpenTrading { Security = book.Security, ReferencePrice = referencePrice });
+    public static IReadOnlyList<OrderBookEvent> PreOpenTrading(this IOrderBook book,
+        decimal? referencePrice = null) =>
+        book.Process(new PreOpenTrading { Security = book.Security, ReferencePrice = referencePrice });
 
-        public static IReadOnlyList<OrderBookEvent> OpenTrading(this IOrderBook book,
-            decimal? referencePrice = null) =>
-            book.Process(new OpenTrading { Security = book.Security, ReferencePrice = referencePrice });
+    public static IReadOnlyList<OrderBookEvent> OpenTrading(this IOrderBook book,
+        decimal? referencePrice = null) =>
+        book.Process(new OpenTrading { Security = book.Security, ReferencePrice = referencePrice });
 
-        public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book, bool endsTradingDay = true) =>
-            book.Process(new CloseTrading { Security = book.Security, EndsTradingDay = endsTradingDay });
+    public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book, bool endsTradingDay = true) =>
+        book.Process(new CloseTrading { Security = book.Security, EndsTradingDay = endsTradingDay });
 
-        public static IReadOnlyList<OrderBookEvent> PauseTrading(this IOrderBook book) =>
-            book.Process(new PauseTrading { Security = book.Security });
+    public static IReadOnlyList<OrderBookEvent> PauseTrading(this IOrderBook book) =>
+        book.Process(new PauseTrading { Security = book.Security });
 
-        public static IReadOnlyList<OrderBookEvent> HaltTrading(this IOrderBook book) =>
-            book.Process(new HaltTrading { Security = book.Security });
+    public static IReadOnlyList<OrderBookEvent> HaltTrading(this IOrderBook book) =>
+        book.Process(new HaltTrading { Security = book.Security });
 
-        // Returns whatever the elapsed time turned out to imply - a resumption and its print, or
-        // nothing at all.
-        public static IReadOnlyList<OrderBookEvent> AdvanceTime(this IOrderBook book) =>
-            book.Process(new AdvanceTime { Security = book.Security });
+    // Returns whatever the elapsed time turned out to imply - a resumption and its print, or
+    // nothing at all.
+    public static IReadOnlyList<OrderBookEvent> AdvanceTime(this IOrderBook book) =>
+        book.Process(new AdvanceTime { Security = book.Security });
 
-        // Bridge for callers that only know the target status at runtime (e.g. a session/schedule
-        // provider driving the book off a clock) and so can't pick PreOpenTrading/OpenTrading/
-        // CloseTrading directly. ReferencePrice is ignored for every status but the two opening
-        // ones - a reference price is meaningless once the book stops trading - and endsTradingDay
-        // applies only to closing, since nothing else ends a day.
-        public static IReadOnlyList<OrderBookEvent> UpdateStatus(this IOrderBook book, OrderBookStatus status,
-            decimal? referencePrice = null, bool endsTradingDay = true) =>
-            status switch
-            {
-                OrderBookStatus.PreOpen => book.PreOpenTrading(referencePrice),
-                OrderBookStatus.Open => book.OpenTrading(referencePrice),
-                OrderBookStatus.Closed => book.CloseTrading(endsTradingDay),
-                OrderBookStatus.Paused => book.PauseTrading(),
-                OrderBookStatus.Halted => book.HaltTrading(),
-                _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
-            };
-    }
+    // Bridge for callers that only know the target status at runtime (e.g. a session/schedule
+    // provider driving the book off a clock) and so can't pick PreOpenTrading/OpenTrading/
+    // CloseTrading directly. ReferencePrice is ignored for every status but the two opening
+    // ones - a reference price is meaningless once the book stops trading - and endsTradingDay
+    // applies only to closing, since nothing else ends a day.
+    public static IReadOnlyList<OrderBookEvent> UpdateStatus(this IOrderBook book, OrderBookStatus status,
+        decimal? referencePrice = null, bool endsTradingDay = true) =>
+        status switch
+        {
+            OrderBookStatus.PreOpen => book.PreOpenTrading(referencePrice),
+            OrderBookStatus.Open => book.OpenTrading(referencePrice),
+            OrderBookStatus.Closed => book.CloseTrading(endsTradingDay),
+            OrderBookStatus.Paused => book.PauseTrading(),
+            OrderBookStatus.Halted => book.HaltTrading(),
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+        };
 }

--- a/Circus/OrderBook/OrderBookStatus.cs
+++ b/Circus/OrderBook/OrderBookStatus.cs
@@ -1,19 +1,18 @@
-namespace Circus.OrderBook
+namespace Circus.OrderBook;
+
+// Appended rather than reordered, so the numeric value of an existing status never moves.
+public enum OrderBookStatus
 {
-    // Appended rather than reordered, so the numeric value of an existing status never moves.
-    public enum OrderBookStatus
-    {
-        PreOpen,
-        Open,
-        Closed,
+    PreOpen,
+    Open,
+    Closed,
 
-        // Trading interrupted within a session and expected to resume: orders accumulate into an
-        // auction and a quote keeps being published, but nothing matches. What a volatility band
-        // breach moves the book to.
-        Paused,
+    // Trading interrupted within a session and expected to resume: orders accumulate into an
+    // auction and a quote keeps being published, but nothing matches. What a volatility band
+    // breach moves the book to.
+    Paused,
 
-        // Trading suspended with no price discovery at all - no matching and no quote. What a
-        // circuit breaker moves the book to.
-        Halted
-    }
+    // Trading suspended with no price discovery at all - no matching and no quote. What a
+    // circuit breaker moves the book to.
+    Halted
 }

--- a/Circus/OrderBook/OrderCancelledReason.cs
+++ b/Circus/OrderBook/OrderCancelledReason.cs
@@ -1,11 +1,10 @@
-namespace Circus.OrderBook
+namespace Circus.OrderBook;
+
+public enum OrderCancelledReason
 {
-    public enum OrderCancelledReason
-    {
-        Cancelled,
-        UpdatedQuantityLowerThanFilledQuantity,
-        NoOrdersToMatchMarketOrder,
-        ImmediateOrCancelNotFilled,
-        SelfMatchPrevention
-    }
+    Cancelled,
+    UpdatedQuantityLowerThanFilledQuantity,
+    NoOrdersToMatchMarketOrder,
+    ImmediateOrCancelNotFilled,
+    SelfMatchPrevention
 }

--- a/Circus/OrderBook/OrderPriceRestriction.cs
+++ b/Circus/OrderBook/OrderPriceRestriction.cs
@@ -1,72 +1,69 @@
-using System;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// The hard band checked at order entry. Sees only client-supplied resting limit prices - trigger
+// and Market/MarketLimit prices are governed elsewhere in InMemoryOrderBook.
+//
+// The reference it measures from follows CME's banding reference price, which moves with the
+// market state: the settlement price pre-open, the indicative price once an auction is quoting
+// one, and the last trade during continuous trading. Expressed as a precedence between three
+// anchors rather than as a rule about phases, which comes out the same without this needing to
+// know what phase the book is in - continuous trading publishes no indicative price, so the top
+// rung is simply empty there.
+internal sealed class OrderPriceRestriction : IPriceRestriction
 {
-    // The hard band checked at order entry. Sees only client-supplied resting limit prices - trigger
-    // and Market/MarketLimit prices are governed elsewhere in InMemoryOrderBook.
-    //
-    // The reference it measures from follows CME's banding reference price, which moves with the
-    // market state: the settlement price pre-open, the indicative price once an auction is quoting
-    // one, and the last trade during continuous trading. Expressed as a precedence between three
-    // anchors rather than as a rule about phases, which comes out the same without this needing to
-    // know what phase the book is in - continuous trading publishes no indicative price, so the top
-    // rung is simply empty there.
-    internal sealed class OrderPriceRestriction : IPriceRestriction
+    private readonly int _bandTicks;
+
+    private long? _indicativePriceTicks;
+    private long? _lastTradePriceTicks;
+    private long? _sessionPriceTicks;
+
+    internal OrderPriceRestriction(int bandTicks)
     {
-        private readonly int _bandTicks;
+        _bandTicks = bandTicks;
+    }
 
-        private long? _indicativePriceTicks;
-        private long? _lastTradePriceTicks;
-        private long? _sessionPriceTicks;
+    public RestrictionScope Scope => RestrictionScope.OrderEntry;
+    public RestrictionBreachAction OnBreach => RestrictionBreachAction.Reject;
 
-        internal OrderPriceRestriction(int bandTicks)
-        {
-            _bandTicks = bandTicks;
-        }
+    public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
 
-        public RestrictionScope Scope => RestrictionScope.OrderEntry;
-        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Reject;
+    // A rejection interrupts nothing, so there is nothing to resume from.
+    public TimeSpan? ResumeAfter => null;
 
-        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
+    private long? ReferencePriceTicks =>
+        _indicativePriceTicks ?? _lastTradePriceTicks ?? _sessionPriceTicks;
 
-        // A rejection interrupts nothing, so there is nothing to resume from.
-        public TimeSpan? ResumeAfter => null;
+    // Inactive until some anchor exists. A band with no width is not modelled here at all - a
+    // security that wants none leaves the restriction out.
+    public bool Allows(long priceTicks, DateTime time)
+    {
+        var reference = ReferencePriceTicks;
+        return !reference.HasValue || Math.Abs(priceTicks - reference.Value) <= _bandTicks;
+    }
 
-        private long? ReferencePriceTicks =>
-            _indicativePriceTicks ?? _lastTradePriceTicks ?? _sessionPriceTicks;
+    // CME governs the gap between a stop's trigger and limit prices with the same band width
+    // that governs how far an order may be priced from the reference.
+    public bool AllowsStopSpread(long spreadTicks) => spreadTicks <= _bandTicks;
 
-        // Inactive until some anchor exists. A band with no width is not modelled here at all - a
-        // security that wants none leaves the restriction out.
-        public bool Allows(long priceTicks, DateTime time)
-        {
-            var reference = ReferencePriceTicks;
-            return !reference.HasValue || Math.Abs(priceTicks - reference.Value) <= _bandTicks;
-        }
+    // An entry band rejects orders; it never interrupts trading, so it has nothing to say about
+    // when an interruption should end.
+    public bool AllowsResumption(long priceTicks, DateTime time) => true;
 
-        // CME governs the gap between a stop's trigger and limit prices with the same band width
-        // that governs how far an order may be priced from the reference.
-        public bool AllowsStopSpread(long spreadTicks) => spreadTicks <= _bandTicks;
+    public void OnTrade(long priceTicks, DateTime time) => _lastTradePriceTicks = priceTicks;
 
-        // An entry band rejects orders; it never interrupts trading, so it has nothing to say about
-        // when an interruption should end.
-        public bool AllowsResumption(long priceTicks, DateTime time) => true;
+    // Null withdraws the quote, dropping the reference back to the last trade.
+    public void OnIndicativePrice(long? priceTicks) => _indicativePriceTicks = priceTicks;
 
-        public void OnTrade(long priceTicks, DateTime time) => _lastTradePriceTicks = priceTicks;
+    // An explicit reference means "start from here", so it clears what it supersedes rather than
+    // sitting underneath it: a new session's settlement price has to beat the previous session's
+    // last trade, and it could never do that from the bottom of the precedence.
+    public void OnSessionChange(long? referencePriceTicks)
+    {
+        if (!referencePriceTicks.HasValue)
+            return;
 
-        // Null withdraws the quote, dropping the reference back to the last trade.
-        public void OnIndicativePrice(long? priceTicks) => _indicativePriceTicks = priceTicks;
-
-        // An explicit reference means "start from here", so it clears what it supersedes rather than
-        // sitting underneath it: a new session's settlement price has to beat the previous session's
-        // last trade, and it could never do that from the bottom of the precedence.
-        public void OnSessionChange(long? referencePriceTicks)
-        {
-            if (!referencePriceTicks.HasValue)
-                return;
-
-            _sessionPriceTicks = referencePriceTicks;
-            _lastTradePriceTicks = null;
-            _indicativePriceTicks = null;
-        }
+        _sessionPriceTicks = referencePriceTicks;
+        _lastTradePriceTicks = null;
+        _indicativePriceTicks = null;
     }
 }

--- a/Circus/OrderBook/OrderRejectedReason.cs
+++ b/Circus/OrderBook/OrderRejectedReason.cs
@@ -1,45 +1,44 @@
-namespace Circus.OrderBook
+namespace Circus.OrderBook;
+
+public enum OrderRejectedReason
 {
-    public enum OrderRejectedReason
-    {
-        MarketClosed,
+    MarketClosed,
 
-        // The phase takes orders but not ones with no limit of their own - pre-open, and now a
-        // pause or a halt too, none of which have a book to price a market order against.
-        MarketOrdersNotAccepted,
-        InvalidQuantity,
-        InvalidPriceIncrement,
-        OrderNotInBook,
-        OrderInBook,
-        OrderIdAlreadyUsed,
-        TooLateToCancel,
-        NoOrdersToMatchMarketOrder,
-        NoLastTradedPrice,
-        TriggerPriceMustBeLessThanLastTradedPrice,
-        TriggerPriceMustBeGreaterThanLastTradedPrice,
-        TriggerPriceMustBeLessThanPrice,
-        TriggerPriceMustBeGreaterThanPrice,
-        NoChange,
-        InvalidExpireDate,
-        ClientOrderIdRequired,
-        ClientOrderIdTooLong,
-        CompanyIdRequired,
-        CompanyIdTooLong,
-        SelfMatchPreventionIdTooLong,
-        PriceOutsideBands,
-        MinQuantityOutOfRange,
-        InsufficientLiquidityForMinQuantity,
-        MaxVisibleQuantityOutOfRange,
+    // The phase takes orders but not ones with no limit of their own - pre-open, and now a
+    // pause or a halt too, none of which have a book to price a market order against.
+    MarketOrdersNotAccepted,
+    InvalidQuantity,
+    InvalidPriceIncrement,
+    OrderNotInBook,
+    OrderInBook,
+    OrderIdAlreadyUsed,
+    TooLateToCancel,
+    NoOrdersToMatchMarketOrder,
+    NoLastTradedPrice,
+    TriggerPriceMustBeLessThanLastTradedPrice,
+    TriggerPriceMustBeGreaterThanLastTradedPrice,
+    TriggerPriceMustBeLessThanPrice,
+    TriggerPriceMustBeGreaterThanPrice,
+    NoChange,
+    InvalidExpireDate,
+    ClientOrderIdRequired,
+    ClientOrderIdTooLong,
+    CompanyIdRequired,
+    CompanyIdTooLong,
+    SelfMatchPreventionIdTooLong,
+    PriceOutsideBands,
+    MinQuantityOutOfRange,
+    InsufficientLiquidityForMinQuantity,
+    MaxVisibleQuantityOutOfRange,
 
-        // The trigger and limit prices are on the right sides of each other but too far apart: a
-        // stop elected this far from its trigger would rest where the band would never have
-        // accepted it directly. Appended rather than filed with the other TriggerPrice reasons, so
-        // that no existing member's numeric value moves.
-        TriggerPriceTooFarFromPrice,
+    // The trigger and limit prices are on the right sides of each other but too far apart: a
+    // stop elected this far from its trigger would rest where the band would never have
+    // accepted it directly. Appended rather than filed with the other TriggerPrice reasons, so
+    // that no existing member's numeric value moves.
+    TriggerPriceTooFarFromPrice,
 
-        // Beyond the session's ceiling or floor. Distinct from PriceOutsideBands because the two
-        // mean different things to whoever sent the order: a band moves with the market and will
-        // very likely accept the same price shortly, a daily limit stands for the session.
-        BeyondDailyPriceLimit
-    }
+    // Beyond the session's ceiling or floor. Distinct from PriceOutsideBands because the two
+    // mean different things to whoever sent the order: a band moves with the market and will
+    // very likely accept the same price shortly, a daily limit stands for the session.
+    BeyondDailyPriceLimit
 }

--- a/Circus/OrderBook/PriceLadder.cs
+++ b/Circus/OrderBook/PriceLadder.cs
@@ -1,204 +1,200 @@
-using System;
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// All anything outside Matcher is handed. Writes go through Matcher's own Rest/Unrest/Reprice,
+// so the ladders it owns cannot be mutated from outside.
+internal interface IReadOnlyPriceLadder
 {
-    // All anything outside Matcher is handed. Writes go through Matcher's own Rest/Unrest/Reprice,
-    // so the ladders it owns cannot be mutated from outside.
-    internal interface IReadOnlyPriceLadder
-    {
-        bool TryGetBest(out long tick, out InternalOrder? firstOrder);
+    bool TryGetBest(out long tick, out InternalOrder? firstOrder);
 
-        IEnumerable<(long Tick, InternalOrder First, int Count)> EnumerateFromBest();
+    IEnumerable<(long Tick, InternalOrder First, int Count)> EnumerateFromBest();
+}
+
+// Dense, array-backed replacement for SortedDictionary<long, SortedDictionary<long, InternalOrder>>
+// keyed by price tick: the tick is used directly as an array offset (tick - _minTick) for O(1)
+// level access instead of an O(log n) tree lookup, with a cached best-price index so callers
+// don't need to scan the array to find the touch.
+//
+// Each level is an intrusive doubly-linked list threaded through InternalOrder.LevelNext/Prev
+// rather than a LinkedList<T>, which would allocate a node wrapper per order - the very cost
+// this exists to avoid. A newly-touched level costs nothing but flipping array slots.
+//
+// Grows on demand if an order arrives outside the allocated range, so it needs no pre-sizing.
+//
+// descending is true for sides whose priority runs from high tick to low - Side.Buy in the
+// working book, Side.Sell in the stops book.
+internal sealed class PriceLadder(bool descending) : IReadOnlyPriceLadder
+{
+    private const int InitialRadius = 64;
+
+    private InternalOrder?[] _heads = [];
+    private InternalOrder?[] _tails = [];
+    private int[] _counts = [];
+    private long _minTick;
+    private int _bestIndex; // index of the best (nearest-to-crossing) occupied slot; _heads.Length means "none"
+
+    public void Add(long tick, InternalOrder order)
+    {
+        EnsureCapacity(tick);
+        var index = (int) (tick - _minTick);
+
+        var tail = _tails[index];
+        order.LevelPrev = tail;
+        order.LevelNext = null;
+
+        if (tail != null)
+        {
+            tail.LevelNext = order;
+        }
+        else
+        {
+            _heads[index] = order;
+            if (IsBetter(index, _bestIndex))
+            {
+                _bestIndex = index;
+            }
+        }
+
+        _tails[index] = order;
+        _counts[index]++;
     }
 
-    // Dense, array-backed replacement for SortedDictionary<long, SortedDictionary<long, InternalOrder>>
-    // keyed by price tick: the tick is used directly as an array offset (tick - _minTick) for O(1)
-    // level access instead of an O(log n) tree lookup, with a cached best-price index so callers
-    // don't need to scan the array to find the touch.
-    //
-    // Each level is an intrusive doubly-linked list threaded through InternalOrder.LevelNext/Prev
-    // rather than a LinkedList<T>, which would allocate a node wrapper per order - the very cost
-    // this exists to avoid. A newly-touched level costs nothing but flipping array slots.
-    //
-    // Grows on demand if an order arrives outside the allocated range, so it needs no pre-sizing.
-    //
-    // descending is true for sides whose priority runs from high tick to low - Side.Buy in the
-    // working book, Side.Sell in the stops book.
-    internal sealed class PriceLadder(bool descending) : IReadOnlyPriceLadder
+    public void Remove(long tick, InternalOrder order)
     {
-        private const int InitialRadius = 64;
+        var index = (int) (tick - _minTick);
 
-        private InternalOrder?[] _heads = [];
-        private InternalOrder?[] _tails = [];
-        private int[] _counts = [];
-        private long _minTick;
-        private int _bestIndex; // index of the best (nearest-to-crossing) occupied slot; _heads.Length means "none"
+        if (order.LevelPrev != null)
+            order.LevelPrev.LevelNext = order.LevelNext;
+        else
+            _heads[index] = order.LevelNext;
 
-        public void Add(long tick, InternalOrder order)
+        if (order.LevelNext != null)
+            order.LevelNext.LevelPrev = order.LevelPrev;
+        else
+            _tails[index] = order.LevelPrev;
+
+        order.LevelNext = null;
+        order.LevelPrev = null;
+        _counts[index]--;
+
+        if (_heads[index] == null && index == _bestIndex)
         {
-            EnsureCapacity(tick);
-            var index = (int) (tick - _minTick);
+            AdvanceBest();
+        }
+    }
 
-            var tail = _tails[index];
-            order.LevelPrev = tail;
-            order.LevelNext = null;
-
-            if (tail != null)
-            {
-                tail.LevelNext = order;
-            }
-            else
-            {
-                _heads[index] = order;
-                if (IsBetter(index, _bestIndex))
-                {
-                    _bestIndex = index;
-                }
-            }
-
-            _tails[index] = order;
-            _counts[index]++;
+    public bool TryGetBest(out long tick, out InternalOrder? firstOrder)
+    {
+        if (_bestIndex >= _heads.Length || _heads[_bestIndex] == null)
+        {
+            tick = 0;
+            firstOrder = null;
+            return false;
         }
 
-        public void Remove(long tick, InternalOrder order)
+        tick = _minTick + _bestIndex;
+        firstOrder = _heads[_bestIndex];
+        return true;
+    }
+
+    // Yields, from best outward, each occupied level's tick, its first (FIFO-earliest) order —
+    // walk `.LevelNext` from there to see the rest — and its order count.
+    public IEnumerable<(long Tick, InternalOrder First, int Count)> EnumerateFromBest()
+    {
+        var step = descending ? -1 : 1;
+        for (var i = _bestIndex; i >= 0 && i < _heads.Length; i += step)
         {
-            var index = (int) (tick - _minTick);
-
-            if (order.LevelPrev != null)
-                order.LevelPrev.LevelNext = order.LevelNext;
-            else
-                _heads[index] = order.LevelNext;
-
-            if (order.LevelNext != null)
-                order.LevelNext.LevelPrev = order.LevelPrev;
-            else
-                _tails[index] = order.LevelPrev;
-
-            order.LevelNext = null;
-            order.LevelPrev = null;
-            _counts[index]--;
-
-            if (_heads[index] == null && index == _bestIndex)
+            if (_heads[i] != null)
             {
-                AdvanceBest();
+                yield return (_minTick + i, _heads[i]!, _counts[i]);
             }
         }
+    }
 
-        public bool TryGetBest(out long tick, out InternalOrder? firstOrder)
+    private bool IsBetter(int candidateIndex, int currentBestIndex) =>
+        currentBestIndex >= _heads.Length ||
+        (descending ? candidateIndex > currentBestIndex : candidateIndex < currentBestIndex);
+
+    private void AdvanceBest()
+    {
+        var step = descending ? -1 : 1;
+        var i = _bestIndex + step;
+        while (i >= 0 && i < _heads.Length && _heads[i] == null)
         {
-            if (_bestIndex >= _heads.Length || _heads[_bestIndex] == null)
-            {
-                tick = 0;
-                firstOrder = null;
-                return false;
-            }
-
-            tick = _minTick + _bestIndex;
-            firstOrder = _heads[_bestIndex];
-            return true;
+            i += step;
         }
 
-        // Yields, from best outward, each occupied level's tick, its first (FIFO-earliest) order —
-        // walk `.LevelNext` from there to see the rest — and its order count.
-        public IEnumerable<(long Tick, InternalOrder First, int Count)> EnumerateFromBest()
+        _bestIndex = (i < 0 || i >= _heads.Length) ? _heads.Length : i;
+    }
+
+    private void EnsureCapacity(long tick)
+    {
+        if (_heads.Length == 0)
         {
-            var step = descending ? -1 : 1;
-            for (var i = _bestIndex; i >= 0 && i < _heads.Length; i += step)
-            {
-                if (_heads[i] != null)
-                {
-                    yield return (_minTick + i, _heads[i]!, _counts[i]);
-                }
-            }
-        }
-
-        private bool IsBetter(int candidateIndex, int currentBestIndex) =>
-            currentBestIndex >= _heads.Length ||
-            (descending ? candidateIndex > currentBestIndex : candidateIndex < currentBestIndex);
-
-        private void AdvanceBest()
-        {
-            var step = descending ? -1 : 1;
-            var i = _bestIndex + step;
-            while (i >= 0 && i < _heads.Length && _heads[i] == null)
-            {
-                i += step;
-            }
-
-            _bestIndex = (i < 0 || i >= _heads.Length) ? _heads.Length : i;
-        }
-
-        private void EnsureCapacity(long tick)
-        {
-            if (_heads.Length == 0)
-            {
-                _minTick = tick - InitialRadius;
-                var length = InitialRadius * 2 + 1;
-                _heads = new InternalOrder?[length];
-                _tails = new InternalOrder?[length];
-                _counts = new int[length];
-                _bestIndex = _heads.Length;
-                return;
-            }
-
-            var maxTick = _minTick + _heads.Length - 1;
-            if (tick >= _minTick && tick <= maxTick)
-                return;
-
-            var newMin = _minTick;
-            var newMax = maxTick;
-
-            if (tick < _minTick)
-            {
-                var deficit = _minTick - tick;
-                newMin = _minTick - Math.Max(deficit, _heads.Length);
-            }
-
-            if (tick > maxTick)
-            {
-                var deficit = tick - maxTick;
-                newMax = maxTick + Math.Max(deficit, _heads.Length);
-            }
-
-            Grow(newMin, newMax);
-        }
-
-        // Preserves existing levels while growing the backing arrays to cover [newMin, newMax].
-        private void Grow(long newMin, long newMax)
-        {
-            var newLength = checked((int) (newMax - newMin + 1));
-            var newHeads = new InternalOrder?[newLength];
-            var newTails = new InternalOrder?[newLength];
-            var newCounts = new int[newLength];
-
-            for (var i = 0; i < _heads.Length; i++)
-            {
-                if (_heads[i] == null)
-                    continue;
-
-                var newIndex = (int) ((_minTick + i) - newMin);
-                newHeads[newIndex] = _heads[i];
-                newTails[newIndex] = _tails[i];
-                newCounts[newIndex] = _counts[i];
-            }
-
-            _heads = newHeads;
-            _tails = newTails;
-            _counts = newCounts;
-            _minTick = newMin;
-
-            // Grow is rare (amortized via doubling), so a full recompute here is cheap relative to
-            // how infrequently it happens.
+            _minTick = tick - InitialRadius;
+            var length = InitialRadius * 2 + 1;
+            _heads = new InternalOrder?[length];
+            _tails = new InternalOrder?[length];
+            _counts = new int[length];
             _bestIndex = _heads.Length;
-            var step = descending ? -1 : 1;
-            for (var i = descending ? _heads.Length - 1 : 0; i >= 0 && i < _heads.Length; i += step)
+            return;
+        }
+
+        var maxTick = _minTick + _heads.Length - 1;
+        if (tick >= _minTick && tick <= maxTick)
+            return;
+
+        var newMin = _minTick;
+        var newMax = maxTick;
+
+        if (tick < _minTick)
+        {
+            var deficit = _minTick - tick;
+            newMin = _minTick - Math.Max(deficit, _heads.Length);
+        }
+
+        if (tick > maxTick)
+        {
+            var deficit = tick - maxTick;
+            newMax = maxTick + Math.Max(deficit, _heads.Length);
+        }
+
+        Grow(newMin, newMax);
+    }
+
+    // Preserves existing levels while growing the backing arrays to cover [newMin, newMax].
+    private void Grow(long newMin, long newMax)
+    {
+        var newLength = checked((int) (newMax - newMin + 1));
+        var newHeads = new InternalOrder?[newLength];
+        var newTails = new InternalOrder?[newLength];
+        var newCounts = new int[newLength];
+
+        for (var i = 0; i < _heads.Length; i++)
+        {
+            if (_heads[i] == null)
+                continue;
+
+            var newIndex = (int) ((_minTick + i) - newMin);
+            newHeads[newIndex] = _heads[i];
+            newTails[newIndex] = _tails[i];
+            newCounts[newIndex] = _counts[i];
+        }
+
+        _heads = newHeads;
+        _tails = newTails;
+        _counts = newCounts;
+        _minTick = newMin;
+
+        // Grow is rare (amortized via doubling), so a full recompute here is cheap relative to
+        // how infrequently it happens.
+        _bestIndex = _heads.Length;
+        var step = descending ? -1 : 1;
+        for (var i = descending ? _heads.Length - 1 : 0; i >= 0 && i < _heads.Length; i += step)
+        {
+            if (_heads[i] != null)
             {
-                if (_heads[i] != null)
-                {
-                    _bestIndex = i;
-                    break;
-                }
+                _bestIndex = i;
+                break;
             }
         }
     }

--- a/Circus/OrderBook/PriceTime.cs
+++ b/Circus/OrderBook/PriceTime.cs
@@ -1,42 +1,38 @@
-using System;
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// Continuous trading under price-time priority. The aggressor trades against the FIFO-earliest
+// order at the best crossing level - taking the head and only moving on once it is consumed is
+// the time-priority rule - at that order's own limit price, so an aggressor whose limit was
+// better than the touch gets the improvement. Sized off displayed quantity, since an iceberg
+// shows one peak at a time.
+internal sealed class PriceTime : IMatchingAlgorithm
 {
-    // Continuous trading under price-time priority. The aggressor trades against the FIFO-earliest
-    // order at the best crossing level - taking the head and only moving on once it is consumed is
-    // the time-priority rule - at that order's own limit price, so an aggressor whose limit was
-    // better than the touch gets the improvement. Sized off displayed quantity, since an iceberg
-    // shows one peak at a time.
-    internal sealed class PriceTime : IMatchingAlgorithm
+    public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
+
+    // Prints at as many prices as the sweep touches, and the best of them is the visible touch.
+    public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+        out long priceTicks, out int quantity)
     {
-        public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
+        priceTicks = 0;
+        quantity = 0;
+        return false;
+    }
 
-        // Prints at as many prices as the sweep touches, and the best of them is the visible touch.
-        public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
-            out long priceTicks, out int quantity)
-        {
-            priceTicks = 0;
-            quantity = 0;
-            return false;
-        }
+    public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
+        new Allocation(restingHead,
+            Math.Min(restingHead.DisplayedQuantity, aggressor.DisplayedQuantity),
+            restingHead.Price ?? throw new InvalidOperationException("limit order requires price"));
 
-        public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor) =>
-            new Allocation(restingHead,
-                Math.Min(restingHead.DisplayedQuantity, aggressor.DisplayedQuantity),
-                restingHead.Price ?? throw new InvalidOperationException("limit order requires price"));
+    public bool UsesFullRemainingQuantity => false;
 
-        public bool UsesFullRemainingQuantity => false;
+    public bool ChecksTradeRestrictions => true;
 
-        public bool ChecksTradeRestrictions => true;
+    // No anchor: every price comes from the two orders at the touch.
+    public void OnTrade(long priceTicks)
+    {
+    }
 
-        // No anchor: every price comes from the two orders at the touch.
-        public void OnTrade(long priceTicks)
-        {
-        }
-
-        public void OnSessionChange(long? referencePriceTicks)
-        {
-        }
+    public void OnSessionChange(long? referencePriceTicks)
+    {
     }
 }

--- a/Circus/OrderBook/SessionLimitAnchor.cs
+++ b/Circus/OrderBook/SessionLimitAnchor.cs
@@ -1,48 +1,45 @@
-using System;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// The reference and resolved width shared by the two restrictions set against a settlement
+// price rather than against a moving market. Both are inert until a reference arrives, because
+// a percentage width has no size until there is something to take a percentage of.
+//
+// Deaf to trades by construction: a limit that followed the market would never be reached.
+internal sealed class SessionLimitAnchor
 {
-    // The reference and resolved width shared by the two restrictions set against a settlement
-    // price rather than against a moving market. Both are inert until a reference arrives, because
-    // a percentage width has no size until there is something to take a percentage of.
-    //
-    // Deaf to trades by construction: a limit that followed the market would never be reached.
-    internal sealed class SessionLimitAnchor
+    private readonly PriceLimitWidth _width;
+
+    private long? _referencePriceTicks;
+    private long _widthTicks;
+
+    internal SessionLimitAnchor(PriceLimitWidth width)
     {
-        private readonly PriceLimitWidth _width;
-
-        private long? _referencePriceTicks;
-        private long _widthTicks;
-
-        internal SessionLimitAnchor(PriceLimitWidth width)
-        {
-            _width = width;
-        }
-
-        internal bool Allows(long priceTicks) =>
-            !_referencePriceTicks.HasValue || Math.Abs(priceTicks - _referencePriceTicks.Value) <= _widthTicks;
-
-        // How far beyond the limit this width reaches, for ranking one against another. Zero until
-        // a reference resolves it.
-        internal long WidthTicks => _referencePriceTicks.HasValue ? _widthTicks : 0;
-
-        internal void OnSessionChange(long? referencePriceTicks)
-        {
-            if (!referencePriceTicks.HasValue)
-                return;
-
-            _referencePriceTicks = referencePriceTicks;
-            _widthTicks = Resolve(referencePriceTicks.Value);
-        }
-
-        // A percentage of the reference in ticks is a percentage of it in price, so the tick size
-        // never enters into it. Rounded to the nearest tick - a limit lands on a tradable price.
-        private long Resolve(long referencePriceTicks) => _width switch
-        {
-            PriceLimitWidth.Ticks ticks => ticks.Count,
-            PriceLimitWidth.Percent percent =>
-                (long) Math.Round(Math.Abs(referencePriceTicks) * percent.Value / 100m, MidpointRounding.AwayFromZero),
-            _ => throw new ArgumentException($"Unknown price limit width {_width.GetType().Name}")
-        };
+        _width = width;
     }
+
+    internal bool Allows(long priceTicks) =>
+        !_referencePriceTicks.HasValue || Math.Abs(priceTicks - _referencePriceTicks.Value) <= _widthTicks;
+
+    // How far beyond the limit this width reaches, for ranking one against another. Zero until
+    // a reference resolves it.
+    internal long WidthTicks => _referencePriceTicks.HasValue ? _widthTicks : 0;
+
+    internal void OnSessionChange(long? referencePriceTicks)
+    {
+        if (!referencePriceTicks.HasValue)
+            return;
+
+        _referencePriceTicks = referencePriceTicks;
+        _widthTicks = Resolve(referencePriceTicks.Value);
+    }
+
+    // A percentage of the reference in ticks is a percentage of it in price, so the tick size
+    // never enters into it. Rounded to the nearest tick - a limit lands on a tradable price.
+    private long Resolve(long referencePriceTicks) => _width switch
+    {
+        PriceLimitWidth.Ticks ticks => ticks.Count,
+        PriceLimitWidth.Percent percent =>
+            (long) Math.Round(Math.Abs(referencePriceTicks) * percent.Value / 100m, MidpointRounding.AwayFromZero),
+        _ => throw new ArgumentException($"Unknown price limit width {_width.GetType().Name}")
+    };
 }

--- a/Circus/OrderBook/StaticPriceRangeRestriction.cs
+++ b/Circus/OrderBook/StaticPriceRangeRestriction.cs
@@ -1,57 +1,54 @@
-using System;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// A range measured from a fixed reference rather than from recent trades. Eurex's static
+// volatility interruption, which exists because a range that follows the market can be walked
+// anywhere over a day without ever being breached - every step is small next to the last one.
+//
+// Deliberately deaf to trades. That is the whole difference between this and the dynamic range,
+// and it is why the two are separate adapters rather than one with a mode: each owns its anchor.
+internal sealed class StaticPriceRangeRestriction : IPriceRestriction
 {
-    // A range measured from a fixed reference rather than from recent trades. Eurex's static
-    // volatility interruption, which exists because a range that follows the market can be walked
-    // anywhere over a day without ever being breached - every step is small next to the last one.
-    //
-    // Deliberately deaf to trades. That is the whole difference between this and the dynamic range,
-    // and it is why the two are separate adapters rather than one with a mode: each owns its anchor.
-    internal sealed class StaticPriceRangeRestriction : IPriceRestriction
+    private readonly int _rangeTicks;
+    private readonly TimeSpan? _resumeAfter;
+    private long? _referencePriceTicks;
+
+    internal StaticPriceRangeRestriction(int rangeTicks, TimeSpan? resumeAfter = null)
     {
-        private readonly int _rangeTicks;
-        private readonly TimeSpan? _resumeAfter;
-        private long? _referencePriceTicks;
+        _rangeTicks = rangeTicks;
+        _resumeAfter = resumeAfter;
+    }
 
-        internal StaticPriceRangeRestriction(int rangeTicks, TimeSpan? resumeAfter = null)
-        {
-            _rangeTicks = rangeTicks;
-            _resumeAfter = resumeAfter;
-        }
+    public RestrictionScope Scope => RestrictionScope.Trade;
+    public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
 
-        public RestrictionScope Scope => RestrictionScope.Trade;
-        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
+    // Trade-scoped only, so this is never asked.
+    public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
 
-        // Trade-scoped only, so this is never asked.
-        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
+    public TimeSpan? ResumeAfter => _resumeAfter;
 
-        public TimeSpan? ResumeAfter => _resumeAfter;
+    // Inactive until a reference exists - nothing but a status change can supply one.
+    public bool Allows(long priceTicks, DateTime time) =>
+        !_referencePriceTicks.HasValue ||
+        Math.Abs(priceTicks - _referencePriceTicks.Value) <= _rangeTicks;
 
-        // Inactive until a reference exists - nothing but a status change can supply one.
-        public bool Allows(long priceTicks, DateTime time) =>
-            !_referencePriceTicks.HasValue ||
-            Math.Abs(priceTicks - _referencePriceTicks.Value) <= _rangeTicks;
+    // No wider range of its own: a static range is already the outer bound, so it never has an
+    // opinion about whether an interruption should keep running.
+    public bool AllowsResumption(long priceTicks, DateTime time) => true;
 
-        // No wider range of its own: a static range is already the outer bound, so it never has an
-        // opinion about whether an interruption should keep running.
-        public bool AllowsResumption(long priceTicks, DateTime time) => true;
+    public bool AllowsStopSpread(long spreadTicks) => true;
 
-        public bool AllowsStopSpread(long spreadTicks) => true;
+    // Static: where the market has traded since is exactly what this is measuring away from.
+    public void OnTrade(long priceTicks, DateTime time)
+    {
+    }
 
-        // Static: where the market has traded since is exactly what this is measuring away from.
-        public void OnTrade(long priceTicks, DateTime time)
-        {
-        }
+    public void OnIndicativePrice(long? priceTicks)
+    {
+    }
 
-        public void OnIndicativePrice(long? priceTicks)
-        {
-        }
-
-        public void OnSessionChange(long? referencePriceTicks)
-        {
-            if (referencePriceTicks.HasValue)
-                _referencePriceTicks = referencePriceTicks;
-        }
+    public void OnSessionChange(long? referencePriceTicks)
+    {
+        if (referencePriceTicks.HasValue)
+            _referencePriceTicks = referencePriceTicks;
     }
 }

--- a/Circus/OrderBook/StatusChangeReason.cs
+++ b/Circus/OrderBook/StatusChangeReason.cs
@@ -1,18 +1,17 @@
-namespace Circus.OrderBook
+namespace Circus.OrderBook;
+
+// Why the book changed status. Distinguishes the transitions a consumer would otherwise have to
+// infer from context - a session opening looks nothing like a volatility pause on a feed, but
+// both are just a status. Only what the book itself can tell apart: which restriction fired is
+// not yet part of this, since the book sees a breach action rather than a named restriction.
+public enum StatusChangeReason
 {
-    // Why the book changed status. Distinguishes the transitions a consumer would otherwise have to
-    // infer from context - a session opening looks nothing like a volatility pause on a feed, but
-    // both are just a status. Only what the book itself can tell apart: which restriction fired is
-    // not yet part of this, since the book sees a breach action rather than a named restriction.
-    public enum StatusChangeReason
-    {
-        // Driven from outside - a session schedule, or an operator.
-        Requested,
+    // Driven from outside - a session schedule, or an operator.
+    Requested,
 
-        // A prospective trade breached a price restriction.
-        PriceRestriction,
+    // A prospective trade breached a price restriction.
+    PriceRestriction,
 
-        // A timed interruption ran its course and the book returned by itself.
-        InterruptionElapsed
-    }
+    // A timed interruption ran its course and the book returned by itself.
+    InterruptionElapsed
 }

--- a/Circus/OrderBook/TradingPhase.cs
+++ b/Circus/OrderBook/TradingPhase.cs
@@ -1,18 +1,17 @@
-namespace Circus.OrderBook
+namespace Circus.OrderBook;
+
+// What a phase permits and which algorithm governs it. Everything the book does differently
+// between phases lives here rather than in comparisons against OrderBookStatus, so adding a
+// phase is adding a row.
+internal sealed record TradingPhase(
+    IMatchingAlgorithm? Algorithm,
+    bool AcceptsOrderActions,
+    bool AcceptsMarketOrders,
+    bool MatchesContinuously,
+    bool StartsSession,
+    bool ExpiresDayOrders)
 {
-    // What a phase permits and which algorithm governs it. Everything the book does differently
-    // between phases lives here rather than in comparisons against OrderBookStatus, so adding a
-    // phase is adding a row.
-    internal sealed record TradingPhase(
-        IMatchingAlgorithm? Algorithm,
-        bool AcceptsOrderActions,
-        bool AcceptsMarketOrders,
-        bool MatchesContinuously,
-        bool StartsSession,
-        bool ExpiresDayOrders)
-    {
-        // A phase that quotes without trading is accumulating orders for a print, so leaving it is
-        // where that print belongs - the opening print is pre-open's auction, not the open phase's.
-        public bool PrintsOnExit => Algorithm != null && !MatchesContinuously;
-    }
+    // A phase that quotes without trading is accumulating orders for a print, so leaving it is
+    // where that print belongs - the opening print is pre-open's auction, not the open phase's.
+    public bool PrintsOnExit => Algorithm != null && !MatchesContinuously;
 }

--- a/Circus/OrderBook/VolatilityBandRestriction.cs
+++ b/Circus/OrderBook/VolatilityBandRestriction.cs
@@ -1,121 +1,117 @@
-using System;
-using System.Collections.Generic;
+namespace Circus.OrderBook;
 
-namespace Circus.OrderBook
+// A range checked against the prospective trade price rather than the submitted one. A breach
+// interrupts continuous trading into an auction rather than rejecting, Eurex-style.
+//
+// Named for what it is - a volatility interruption - which leaves "daily limit" free for the
+// thing that actually is one: a session-long ceiling trading stops at rather than pauses on.
+//
+// Measured against the trades inside a lookback window, which is Eurex's dynamic range and, at
+// a shorter window, CME's velocity logic. With no window it keeps only the newest trade, which
+// is the plain "within range of the last trade" check.
+internal sealed class VolatilityBandRestriction : IPriceRestriction
 {
-    // A range checked against the prospective trade price rather than the submitted one. A breach
-    // interrupts continuous trading into an auction rather than rejecting, Eurex-style.
-    //
-    // Named for what it is - a volatility interruption - which leaves "daily limit" free for the
-    // thing that actually is one: a session-long ceiling trading stops at rather than pauses on.
-    //
-    // Measured against the trades inside a lookback window, which is Eurex's dynamic range and, at
-    // a shorter window, CME's velocity logic. With no window it keeps only the newest trade, which
-    // is the plain "within range of the last trade" check.
-    internal sealed class VolatilityBandRestriction : IPriceRestriction
+    private readonly int _rangeTicks;
+    private readonly TimeSpan? _window;
+    private readonly TimeSpan? _resumeAfter;
+    private readonly int? _extendedRangeTicks;
+
+    // Oldest first, so ageing out is a walk from the front. Holds at most one entry when no
+    // window is configured.
+    private readonly Queue<(long PriceTicks, DateTime Time)> _recentTrades = new();
+
+    // Used only before anything has traded, or after a status change re-seeds the anchor.
+    private long? _sessionPriceTicks;
+
+    internal VolatilityBandRestriction(int rangeTicks, TimeSpan? resumeAfter = null,
+        TimeSpan? window = null, int? extendedRangeTicks = null)
     {
-        private readonly int _rangeTicks;
-        private readonly TimeSpan? _window;
-        private readonly TimeSpan? _resumeAfter;
-        private readonly int? _extendedRangeTicks;
+        _rangeTicks = rangeTicks;
+        _resumeAfter = resumeAfter;
+        _window = window;
+        _extendedRangeTicks = extendedRangeTicks;
+    }
 
-        // Oldest first, so ageing out is a walk from the front. Holds at most one entry when no
-        // window is configured.
-        private readonly Queue<(long PriceTicks, DateTime Time)> _recentTrades = new();
+    public RestrictionScope Scope => RestrictionScope.Trade;
+    public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
 
-        // Used only before anything has traded, or after a status change re-seeds the anchor.
-        private long? _sessionPriceTicks;
+    // Trade-scoped only, so this is never asked.
+    public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
 
-        internal VolatilityBandRestriction(int rangeTicks, TimeSpan? resumeAfter = null,
-            TimeSpan? window = null, int? extendedRangeTicks = null)
-        {
-            _rangeTicks = rangeTicks;
-            _resumeAfter = resumeAfter;
-            _window = window;
-            _extendedRangeTicks = extendedRangeTicks;
-        }
+    // Eurex times its volatility interruptions rather than leaving them open; configuring no
+    // duration leaves the pause standing until someone ends it.
+    public TimeSpan? ResumeAfter => _resumeAfter;
 
-        public RestrictionScope Scope => RestrictionScope.Trade;
-        public RestrictionBreachAction OnBreach => RestrictionBreachAction.Pause;
+    public bool Allows(long priceTicks, DateTime time) => Within(priceTicks, time, _rangeTicks);
 
-        // Trade-scoped only, so this is never asked.
-        public OrderRejectedReason EntryRejectionReason => OrderRejectedReason.PriceOutsideBands;
+    // The wider range an interruption's would-be closing price is held to. Without one
+    // configured an interruption simply ends when its time is up.
+    public bool AllowsResumption(long priceTicks, DateTime time) =>
+        !_extendedRangeTicks.HasValue || Within(priceTicks, time, _extendedRangeTicks.Value);
 
-        // Eurex times its volatility interruptions rather than leaving them open; configuring no
-        // duration leaves the pause standing until someone ends it.
-        public TimeSpan? ResumeAfter => _resumeAfter;
+    // Not an entry restriction, so it has no say in how a stop is priced.
+    public bool AllowsStopSpread(long spreadTicks) => true;
 
-        public bool Allows(long priceTicks, DateTime time) => Within(priceTicks, time, _rangeTicks);
-
-        // The wider range an interruption's would-be closing price is held to. Without one
-        // configured an interruption simply ends when its time is up.
-        public bool AllowsResumption(long priceTicks, DateTime time) =>
-            !_extendedRangeTicks.HasValue || Within(priceTicks, time, _extendedRangeTicks.Value);
-
-        // Not an entry restriction, so it has no say in how a stop is priced.
-        public bool AllowsStopSpread(long spreadTicks) => true;
-
-        public void OnTrade(long priceTicks, DateTime time)
-        {
-            if (!_window.HasValue)
-                _recentTrades.Clear();
-
-            _recentTrades.Enqueue((priceTicks, time));
-        }
-
-        // Ignored: CME and Eurex both measure volatility against prices that actually traded, not
-        // against one an auction is only quoting. The entry band does follow it - each restriction
-        // owning its own anchor is what lets the two disagree.
-        public void OnIndicativePrice(long? priceTicks)
-        {
-        }
-
-        // An explicit reference supersedes what the market did before it, so the window goes with
-        // it - otherwise a fresh settlement price would be measured against yesterday's trades.
-        public void OnSessionChange(long? referencePriceTicks)
-        {
-            if (!referencePriceTicks.HasValue)
-                return;
-
-            _sessionPriceTicks = referencePriceTicks;
+    public void OnTrade(long priceTicks, DateTime time)
+    {
+        if (!_window.HasValue)
             _recentTrades.Clear();
-        }
 
-        // Within range of every trade still in the window, or of the session reference when nothing
-        // has traded yet. Inactive until one or the other exists.
-        //
-        // The window cannot come to span more than the range allows, because a trade only prints if
-        // it was itself in range of everything then inside it. An interruption is the one thing that
-        // can move the price further than that in one go, and one lasting longer than the window -
-        // which is the usual configuration - has aged the whole window out before trading resumes.
-        private bool Within(long priceTicks, DateTime time, int rangeTicks)
+        _recentTrades.Enqueue((priceTicks, time));
+    }
+
+    // Ignored: CME and Eurex both measure volatility against prices that actually traded, not
+    // against one an auction is only quoting. The entry band does follow it - each restriction
+    // owning its own anchor is what lets the two disagree.
+    public void OnIndicativePrice(long? priceTicks)
+    {
+    }
+
+    // An explicit reference supersedes what the market did before it, so the window goes with
+    // it - otherwise a fresh settlement price would be measured against yesterday's trades.
+    public void OnSessionChange(long? referencePriceTicks)
+    {
+        if (!referencePriceTicks.HasValue)
+            return;
+
+        _sessionPriceTicks = referencePriceTicks;
+        _recentTrades.Clear();
+    }
+
+    // Within range of every trade still in the window, or of the session reference when nothing
+    // has traded yet. Inactive until one or the other exists.
+    //
+    // The window cannot come to span more than the range allows, because a trade only prints if
+    // it was itself in range of everything then inside it. An interruption is the one thing that
+    // can move the price further than that in one go, and one lasting longer than the window -
+    // which is the usual configuration - has aged the whole window out before trading resumes.
+    private bool Within(long priceTicks, DateTime time, int rangeTicks)
+    {
+        Evict(time);
+
+        if (_recentTrades.Count == 0)
+            return !_sessionPriceTicks.HasValue ||
+                   Math.Abs(priceTicks - _sessionPriceTicks.Value) <= rangeTicks;
+
+        foreach (var (tradePriceTicks, _) in _recentTrades)
         {
-            Evict(time);
-
-            if (_recentTrades.Count == 0)
-                return !_sessionPriceTicks.HasValue ||
-                       Math.Abs(priceTicks - _sessionPriceTicks.Value) <= rangeTicks;
-
-            foreach (var (tradePriceTicks, _) in _recentTrades)
-            {
-                if (Math.Abs(priceTicks - tradePriceTicks) > rangeTicks)
-                    return false;
-            }
-
-            return true;
+            if (Math.Abs(priceTicks - tradePriceTicks) > rangeTicks)
+                return false;
         }
 
-        // Never empties the queue when a window is configured: the newest trade is kept whatever its
-        // age, so a market that has gone quiet is still measured against where it last traded rather
-        // than falling back to a stale session reference.
-        private void Evict(DateTime time)
-        {
-            if (!_window.HasValue)
-                return;
+        return true;
+    }
 
-            var cutoff = time - _window.Value;
-            while (_recentTrades.Count > 1 && _recentTrades.Peek().Time < cutoff)
-                _recentTrades.Dequeue();
-        }
+    // Never empties the queue when a window is configured: the newest trade is kept whatever its
+    // age, so a market that has gone quiet is still measured against where it last traded rather
+    // than falling back to a stale session reference.
+    private void Evict(DateTime time)
+    {
+        if (!_window.HasValue)
+            return;
+
+        var cutoff = time - _window.Value;
+        while (_recentTrades.Count > 1 && _recentTrades.Peek().Time < cutoff)
+            _recentTrades.Dequeue();
     }
 }

--- a/Circus/OrderStatus.cs
+++ b/Circus/OrderStatus.cs
@@ -1,14 +1,11 @@
-using System;
+namespace Circus;
 
-namespace Circus
+[Flags]
+public enum OrderStatus
 {
-    [Flags]
-    public enum OrderStatus
-    {
-        Hidden,
-        Working,
-        Filled,
-        Cancelled,
-        Expired,
-    }
+    Hidden,
+    Working,
+    Filled,
+    Cancelled,
+    Expired,
 }

--- a/Circus/OrderType.cs
+++ b/Circus/OrderType.cs
@@ -1,11 +1,10 @@
-namespace Circus
+namespace Circus;
+
+public enum OrderType
 {
-    public enum OrderType
-    {
-        Market,
-        MarketLimit,
-        Limit,
-        StopMarket,
-        StopLimit
-    }
+    Market,
+    MarketLimit,
+    Limit,
+    StopMarket,
+    StopLimit
 }

--- a/Circus/OrderValidity.cs
+++ b/Circus/OrderValidity.cs
@@ -1,29 +1,26 @@
-using System;
+namespace Circus;
 
-namespace Circus
+public abstract record OrderValidity
 {
-    public abstract record OrderValidity
+    public sealed record Day : OrderValidity;
+    public sealed record GoodTilCanceled : OrderValidity;
+
+    public sealed record GoodTilDate : OrderValidity
     {
-        public sealed record Day : OrderValidity;
-        public sealed record GoodTilCanceled : OrderValidity;
+        public required DateOnly Date { get; init; }
+    }
 
-        public sealed record GoodTilDate : OrderValidity
-        {
-            public required DateOnly Date { get; init; }
-        }
-
-        // Consolidates what CME's own FIX protocol treats as one concept: IOC (tag 59=3) with an
-        // optional MinQty (tag 110) qualifier - there's no separate "FOK" time-in-force at the
-        // wire level. MinQuantity null (or less than the order's own Quantity) behaves like
-        // classic IOC/FillAndKill: fills whatever's immediately available, cancels the remainder,
-        // no minimum required. Setting MinQuantity equal to the order's Quantity reproduces
-        // FillOrKill exactly - HasSufficientLiquidity walks the same liquidity Match() would
-        // actually consume, so if the gate passes at MinQuantity == Quantity the whole order is
-        // guaranteed to fill; if it fails, the order is rejected before ever entering the book.
-        // No special-casing needed for either.
-        public sealed record ImmediateOrCancel : OrderValidity
-        {
-            public int? MinQuantity { get; init; }
-        }
+    // Consolidates what CME's own FIX protocol treats as one concept: IOC (tag 59=3) with an
+    // optional MinQty (tag 110) qualifier - there's no separate "FOK" time-in-force at the
+    // wire level. MinQuantity null (or less than the order's own Quantity) behaves like
+    // classic IOC/FillAndKill: fills whatever's immediately available, cancels the remainder,
+    // no minimum required. Setting MinQuantity equal to the order's Quantity reproduces
+    // FillOrKill exactly - HasSufficientLiquidity walks the same liquidity Match() would
+    // actually consume, so if the gate passes at MinQuantity == Quantity the whole order is
+    // guaranteed to fill; if it fails, the order is rejected before ever entering the book.
+    // No special-casing needed for either.
+    public sealed record ImmediateOrCancel : OrderValidity
+    {
+        public int? MinQuantity { get; init; }
     }
 }

--- a/Circus/PriceRestrictionConfig.cs
+++ b/Circus/PriceRestrictionConfig.cs
@@ -1,74 +1,71 @@
-using System;
+namespace Circus;
 
-namespace Circus
+// What restrictions a security trades under, as data. The book turns each of these into the
+// adapter that enforces it, so adding a restriction is adding a case here rather than another
+// optional parameter on Security - which is what these replaced.
+//
+// A restriction that does not apply is left out of the list rather than configured with no
+// width: absence is modelled by absence.
+public abstract record PriceRestrictionConfig;
+
+// Rejects an order priced too far from the reference, at entry. CME's price banding.
+public sealed record OrderPriceBand(int BandTicks) : PriceRestrictionConfig;
+
+// Interrupts trading when a prospective trade price falls too far from where the market has
+// recently traded, rather than rejecting the order that would have caused it. Eurex's dynamic
+// volatility interruption.
+//
+// Window is the lookback: the price must be within RangeTicks of every trade inside it. Unset
+// measures against the last trade alone. ExtendedRangeTicks is the wider range Eurex checks an
+// interruption's would-be closing price against - outside it, the interruption is extended
+// rather than allowed to resolve. Unset means an interruption always ends when its time is up.
+// PauseFor null leaves the interruption standing until something ends it explicitly.
+public sealed record VolatilityBand(
+    int RangeTicks,
+    TimeSpan? PauseFor = null,
+    TimeSpan? Window = null,
+    int? ExtendedRangeTicks = null) : PriceRestrictionConfig;
+
+// Interrupts trading on distance from a fixed reference rather than from recent trades, so it
+// catches a whole day's drift that a range following the market never notices. Eurex's static
+// volatility interruption. Anchored only by the reference prices supplied at status changes.
+public sealed record StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null) : PriceRestrictionConfig;
+
+// "Too far, too fast": the same windowed range a dynamic volatility interruption uses, at the
+// short timescale that catches a run of steps each unremarkable next to the last. CME's
+// velocity logic, which it describes as watching what price banding cannot - banding catches a
+// price that goes too far, this catches one that gets there too quickly.
+//
+// Not a different mechanism from VolatilityBand and deliberately not a different adapter: the
+// window is the whole of what separates them. It is a config of its own so that a product says
+// which it means, rather than leaving a reader to infer it from how short the window is.
+//
+// Window is required, unlike VolatilityBand's - a velocity limit without one would just be a
+// range around the last trade, which is the other config.
+public sealed record VelocityLimit(int RangeTicks, TimeSpan Window, TimeSpan? PauseFor = null)
+    : PriceRestrictionConfig;
+
+// How wide a limit is. Every restriction above measures in ticks because it tracks a market
+// that has already moved; the ones below are set against a settlement price before the day
+// starts, and CME states those as percentages - 7, 13 and 20 percent for equity index. Resolved
+// to ticks the moment a reference exists, since a percentage of nothing is not a width.
+public abstract record PriceLimitWidth
 {
-    // What restrictions a security trades under, as data. The book turns each of these into the
-    // adapter that enforces it, so adding a restriction is adding a case here rather than another
-    // optional parameter on Security - which is what these replaced.
-    //
-    // A restriction that does not apply is left out of the list rather than configured with no
-    // width: absence is modelled by absence.
-    public abstract record PriceRestrictionConfig;
+    public sealed record Ticks(int Count) : PriceLimitWidth;
 
-    // Rejects an order priced too far from the reference, at entry. CME's price banding.
-    public sealed record OrderPriceBand(int BandTicks) : PriceRestrictionConfig;
-
-    // Interrupts trading when a prospective trade price falls too far from where the market has
-    // recently traded, rather than rejecting the order that would have caused it. Eurex's dynamic
-    // volatility interruption.
-    //
-    // Window is the lookback: the price must be within RangeTicks of every trade inside it. Unset
-    // measures against the last trade alone. ExtendedRangeTicks is the wider range Eurex checks an
-    // interruption's would-be closing price against - outside it, the interruption is extended
-    // rather than allowed to resolve. Unset means an interruption always ends when its time is up.
-    // PauseFor null leaves the interruption standing until something ends it explicitly.
-    public sealed record VolatilityBand(
-        int RangeTicks,
-        TimeSpan? PauseFor = null,
-        TimeSpan? Window = null,
-        int? ExtendedRangeTicks = null) : PriceRestrictionConfig;
-
-    // Interrupts trading on distance from a fixed reference rather than from recent trades, so it
-    // catches a whole day's drift that a range following the market never notices. Eurex's static
-    // volatility interruption. Anchored only by the reference prices supplied at status changes.
-    public sealed record StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null) : PriceRestrictionConfig;
-
-    // "Too far, too fast": the same windowed range a dynamic volatility interruption uses, at the
-    // short timescale that catches a run of steps each unremarkable next to the last. CME's
-    // velocity logic, which it describes as watching what price banding cannot - banding catches a
-    // price that goes too far, this catches one that gets there too quickly.
-    //
-    // Not a different mechanism from VolatilityBand and deliberately not a different adapter: the
-    // window is the whole of what separates them. It is a config of its own so that a product says
-    // which it means, rather than leaving a reader to infer it from how short the window is.
-    //
-    // Window is required, unlike VolatilityBand's - a velocity limit without one would just be a
-    // range around the last trade, which is the other config.
-    public sealed record VelocityLimit(int RangeTicks, TimeSpan Window, TimeSpan? PauseFor = null)
-        : PriceRestrictionConfig;
-
-    // How wide a limit is. Every restriction above measures in ticks because it tracks a market
-    // that has already moved; the ones below are set against a settlement price before the day
-    // starts, and CME states those as percentages - 7, 13 and 20 percent for equity index. Resolved
-    // to ticks the moment a reference exists, since a percentage of nothing is not a width.
-    public abstract record PriceLimitWidth
-    {
-        public sealed record Ticks(int Count) : PriceLimitWidth;
-
-        public sealed record Percent(decimal Value) : PriceLimitWidth;
-    }
-
-    // A session-long ceiling and floor. Trading continues at the limit price but nothing prints
-    // through it and no order may be entered beyond it - CME's limit-lock, which is not a halt: the
-    // market stays open, quotes, and can trade back inside.
-    public sealed record DailyPriceLimit(PriceLimitWidth Width) : PriceRestrictionConfig;
-
-    // A threshold that stops trading outright rather than capping it. Several are ordinarily
-    // configured together - CME's equity index breakers halt at 7 and 13 percent and end the day at
-    // 20 - and the widest one breached is the one served, so a price through all three halts for
-    // however long the 20 percent level says rather than the 7 percent level.
-    //
-    // HaltFor null never resumes on its own, which is what the level that ends a trading day wants:
-    // whoever drives the book closes it.
-    public sealed record CircuitBreaker(PriceLimitWidth Width, TimeSpan? HaltFor = null) : PriceRestrictionConfig;
+    public sealed record Percent(decimal Value) : PriceLimitWidth;
 }
+
+// A session-long ceiling and floor. Trading continues at the limit price but nothing prints
+// through it and no order may be entered beyond it - CME's limit-lock, which is not a halt: the
+// market stays open, quotes, and can trade back inside.
+public sealed record DailyPriceLimit(PriceLimitWidth Width) : PriceRestrictionConfig;
+
+// A threshold that stops trading outright rather than capping it. Several are ordinarily
+// configured together - CME's equity index breakers halt at 7 and 13 percent and end the day at
+// 20 - and the widest one breached is the one served, so a price through all three halts for
+// however long the 20 percent level says rather than the 7 percent level.
+//
+// HaltFor null never resumes on its own, which is what the level that ends a trading day wants:
+// whoever drives the book closes it.
+public sealed record CircuitBreaker(PriceLimitWidth Width, TimeSpan? HaltFor = null) : PriceRestrictionConfig;

--- a/Circus/Security.cs
+++ b/Circus/Security.cs
@@ -1,16 +1,13 @@
-using System.Collections.Generic;
+namespace Circus;
 
-namespace Circus
-{
-    // MarketOrderProtectionTicks is not a price restriction and stays here: it prices a market
-    // order rather than restricting one, deciding how far through the book an order with no limit
-    // of its own may sweep.
-    public record Security(
-        string Name,
-        SecurityType Type,
-        decimal TickSize,
-        decimal TickValue,
-        int MarketOrderProtectionTicks = 10,
-        IReadOnlyList<PriceRestrictionConfig>? PriceRestrictions = null
-    );
-}
+// MarketOrderProtectionTicks is not a price restriction and stays here: it prices a market
+// order rather than restricting one, deciding how far through the book an order with no limit
+// of its own may sweep.
+public record Security(
+    string Name,
+    SecurityType Type,
+    decimal TickSize,
+    decimal TickValue,
+    int MarketOrderProtectionTicks = 10,
+    IReadOnlyList<PriceRestrictionConfig>? PriceRestrictions = null
+);

--- a/Circus/SecurityType.cs
+++ b/Circus/SecurityType.cs
@@ -1,10 +1,9 @@
-namespace Circus
+namespace Circus;
+
+public enum SecurityType
 {
-    public enum SecurityType
-    {
-        Stock,
-        Etf,
-        Future,
-        Option
-    }
+    Stock,
+    Etf,
+    Future,
+    Option
 }

--- a/Circus/SelfMatchPreventionInstruction.cs
+++ b/Circus/SelfMatchPreventionInstruction.cs
@@ -1,9 +1,8 @@
-namespace Circus
+namespace Circus;
+
+public enum SelfMatchPreventionInstruction
 {
-    public enum SelfMatchPreventionInstruction
-    {
-        CancelResting,
-        CancelAggressor,
-        CancelBoth
-    }
+    CancelResting,
+    CancelAggressor,
+    CancelBoth
 }

--- a/Circus/SessionProviders/ISessionProvider.cs
+++ b/Circus/SessionProviders/ISessionProvider.cs
@@ -1,17 +1,15 @@
-using System;
 using Circus.OrderBook;
 
-namespace Circus.SessionProviders
+namespace Circus.SessionProviders;
+
+public interface ISessionProvider
 {
-    public interface ISessionProvider
-    {
-        event EventHandler<SessionStatusChangedArgs> Changed;
+    event EventHandler<SessionStatusChangedArgs> Changed;
 
-        void Update(DateTime current);
-    }
-
-    // EndsTradingDay is meaningful only when Status is Closed: false for a session closing with
-    // another still to come the same day, so a consumer can forward it to the book and leave Day
-    // orders resting across the break. True (the default) for every other status, which ends nothing.
-    public record SessionStatusChangedArgs(OrderBookStatus Status, DateTime Time, bool EndsTradingDay = true);
+    void Update(DateTime current);
 }
+
+// EndsTradingDay is meaningful only when Status is Closed: false for a session closing with
+// another still to come the same day, so a consumer can forward it to the book and leave Day
+// orders resting across the break. True (the default) for every other status, which ends nothing.
+public record SessionStatusChangedArgs(OrderBookStatus Status, DateTime Time, bool EndsTradingDay = true);

--- a/Circus/SessionProviders/SessionProvider.cs
+++ b/Circus/SessionProviders/SessionProvider.cs
@@ -1,123 +1,120 @@
-using System;
-using System.Collections.Generic;
 using Circus.OrderBook;
 
-namespace Circus.SessionProviders
+namespace Circus.SessionProviders;
+
+// Drives an order book's status off a clock, given a day's schedule. Update() is pushed the
+// current time and fires whatever boundaries have been passed since it was last called, so a
+// caller that goes quiet for a day catches up rather than replaying every boundary it missed.
+public class SessionProvider : ISessionProvider
 {
-    // Drives an order book's status off a clock, given a day's schedule. Update() is pushed the
-    // current time and fires whatever boundaries have been passed since it was last called, so a
-    // caller that goes quiet for a day catches up rather than replaying every boundary it missed.
-    public class SessionProvider : ISessionProvider
+    private readonly IReadOnlyList<TradingSession> _sessions;
+    public event EventHandler<SessionStatusChangedArgs>? Changed;
+
+    private OrderBookStatus? _status;
+
+    // The session the current (or upcoming) PreOpen/Open/Closed run belongs to. Resolved when
+    // leaving Closed, then reused for that session's open and close.
+    private int _sessionIndex;
+    private int _nextSessionIndex;
+
+    private DateTime _nextTime;
+    private OrderBookStatus _nextStatus;
+    private bool _nextEndsTradingDay = true;
+
+    // A single continuous session, the common case.
+    public SessionProvider(TimeSpan preOpenTime, TimeSpan openTime, TimeSpan closeTime)
+        : this(new[] {new TradingSession(preOpenTime, openTime, closeTime)})
     {
-        private readonly IReadOnlyList<TradingSession> _sessions;
-        public event EventHandler<SessionStatusChangedArgs>? Changed;
+    }
 
-        private OrderBookStatus? _status;
+    public SessionProvider(IReadOnlyList<TradingSession> sessions)
+    {
+        if (sessions.Count == 0) throw new ArgumentException("at least one session is required");
 
-        // The session the current (or upcoming) PreOpen/Open/Closed run belongs to. Resolved when
-        // leaving Closed, then reused for that session's open and close.
-        private int _sessionIndex;
-        private int _nextSessionIndex;
-
-        private DateTime _nextTime;
-        private OrderBookStatus _nextStatus;
-        private bool _nextEndsTradingDay = true;
-
-        // A single continuous session, the common case.
-        public SessionProvider(TimeSpan preOpenTime, TimeSpan openTime, TimeSpan closeTime)
-            : this(new[] {new TradingSession(preOpenTime, openTime, closeTime)})
+        for (var i = 0; i < sessions.Count; i++)
         {
+            var session = sessions[i];
+            if (session.PreOpen > session.Open) throw new ArgumentException("pre-open must be before open");
+            if (session.Open > session.Close) throw new ArgumentException("open must be before close");
+
+            // Ordered and non-overlapping in one check: a session may begin the moment the
+            // previous one closes, but not before.
+            if (i > 0 && session.PreOpen < sessions[i - 1].Close)
+                throw new ArgumentException("sessions must be ordered and must not overlap");
         }
 
-        public SessionProvider(IReadOnlyList<TradingSession> sessions)
+        _sessions = sessions;
+    }
+
+    public void Update(DateTime time)
+    {
+        if (_status == null)
         {
-            if (sessions.Count == 0) throw new ArgumentException("at least one session is required");
-
-            for (var i = 0; i < sessions.Count; i++)
-            {
-                var session = sessions[i];
-                if (session.PreOpen > session.Open) throw new ArgumentException("pre-open must be before open");
-                if (session.Open > session.Close) throw new ArgumentException("open must be before close");
-
-                // Ordered and non-overlapping in one check: a session may begin the moment the
-                // previous one closes, but not before.
-                if (i > 0 && session.PreOpen < sessions[i - 1].Close)
-                    throw new ArgumentException("sessions must be ordered and must not overlap");
-            }
-
-            _sessions = sessions;
+            _status = OrderBookStatus.Closed;
+            Changed?.Invoke(this, new SessionStatusChangedArgs(_status.Value, time));
+            SetNextTime(time);
         }
 
-        public void Update(DateTime time)
+        while (time >= _nextTime)
         {
-            if (_status == null)
-            {
-                _status = OrderBookStatus.Closed;
-                Changed?.Invoke(this, new SessionStatusChangedArgs(_status.Value, time));
-                SetNextTime(time);
-            }
+            _status = _nextStatus;
+            if (_nextStatus == OrderBookStatus.PreOpen)
+                _sessionIndex = _nextSessionIndex;
 
-            while (time >= _nextTime)
-            {
-                _status = _nextStatus;
-                if (_nextStatus == OrderBookStatus.PreOpen)
-                    _sessionIndex = _nextSessionIndex;
+            Changed?.Invoke(this, new SessionStatusChangedArgs(_status.Value, _nextTime, _nextEndsTradingDay));
+            SetNextTime(time);
+        }
+    }
 
-                Changed?.Invoke(this, new SessionStatusChangedArgs(_status.Value, _nextTime, _nextEndsTradingDay));
-                SetNextTime(time);
+    // Every boundary is anchored on the caller's own date rather than walked forward from the
+    // last one, which is what lets an idle day be skipped instead of replayed.
+    private void SetNextTime(DateTime time)
+    {
+        _nextEndsTradingDay = true;
+
+        switch (_status)
+        {
+            case OrderBookStatus.Closed:
+            {
+                var (index, dayOffset) = ResolveNextSession(time.TimeOfDay);
+                _nextSessionIndex = index;
+                _nextStatus = OrderBookStatus.PreOpen;
+                _nextTime = time.Date.AddDays(dayOffset).Add(_sessions[index].PreOpen);
+                break;
             }
+            case OrderBookStatus.PreOpen:
+                _nextStatus = OrderBookStatus.Open;
+                _nextTime = time.Date.Add(_sessions[_sessionIndex].Open);
+                break;
+            default:
+                _nextStatus = OrderBookStatus.Closed;
+                _nextTime = time.Date.Add(_sessions[_sessionIndex].Close);
+
+                // Only the day's last session ends the trading day; closing for a break leaves
+                // Day orders resting for the session still to come.
+                _nextEndsTradingDay = _sessionIndex == _sessions.Count - 1;
+                break;
+        }
+    }
+
+    // Which session to head for from Closed, and whether it falls on the next day. A session
+    // already in progress wins, so a provider started (or woken) mid-session catches up into
+    // it rather than waiting for the next one.
+    private (int Index, int DayOffset) ResolveNextSession(TimeSpan timeOfDay)
+    {
+        for (var i = 0; i < _sessions.Count; i++)
+        {
+            if (timeOfDay >= _sessions[i].PreOpen && timeOfDay < _sessions[i].Close)
+                return (i, 0);
         }
 
-        // Every boundary is anchored on the caller's own date rather than walked forward from the
-        // last one, which is what lets an idle day be skipped instead of replayed.
-        private void SetNextTime(DateTime time)
+        for (var i = 0; i < _sessions.Count; i++)
         {
-            _nextEndsTradingDay = true;
-
-            switch (_status)
-            {
-                case OrderBookStatus.Closed:
-                {
-                    var (index, dayOffset) = ResolveNextSession(time.TimeOfDay);
-                    _nextSessionIndex = index;
-                    _nextStatus = OrderBookStatus.PreOpen;
-                    _nextTime = time.Date.AddDays(dayOffset).Add(_sessions[index].PreOpen);
-                    break;
-                }
-                case OrderBookStatus.PreOpen:
-                    _nextStatus = OrderBookStatus.Open;
-                    _nextTime = time.Date.Add(_sessions[_sessionIndex].Open);
-                    break;
-                default:
-                    _nextStatus = OrderBookStatus.Closed;
-                    _nextTime = time.Date.Add(_sessions[_sessionIndex].Close);
-
-                    // Only the day's last session ends the trading day; closing for a break leaves
-                    // Day orders resting for the session still to come.
-                    _nextEndsTradingDay = _sessionIndex == _sessions.Count - 1;
-                    break;
-            }
+            if (_sessions[i].PreOpen > timeOfDay)
+                return (i, 0);
         }
 
-        // Which session to head for from Closed, and whether it falls on the next day. A session
-        // already in progress wins, so a provider started (or woken) mid-session catches up into
-        // it rather than waiting for the next one.
-        private (int Index, int DayOffset) ResolveNextSession(TimeSpan timeOfDay)
-        {
-            for (var i = 0; i < _sessions.Count; i++)
-            {
-                if (timeOfDay >= _sessions[i].PreOpen && timeOfDay < _sessions[i].Close)
-                    return (i, 0);
-            }
-
-            for (var i = 0; i < _sessions.Count; i++)
-            {
-                if (_sessions[i].PreOpen > timeOfDay)
-                    return (i, 0);
-            }
-
-            // Past the last close of the day - start again with tomorrow's first session.
-            return (0, 1);
-        }
+        // Past the last close of the day - start again with tomorrow's first session.
+        return (0, 1);
     }
 }

--- a/Circus/SessionProviders/TradingSession.cs
+++ b/Circus/SessionProviders/TradingSession.cs
@@ -1,12 +1,9 @@
-using System;
+namespace Circus.SessionProviders;
 
-namespace Circus.SessionProviders
-{
-    // One session's boundaries as times of day. A day's schedule is an ordered, non-overlapping
-    // list of these - a single continuous session for most products, two or more for one that
-    // breaks (a lunch recess, a separate evening session).
-    //
-    // All three times fall within the same day, so a session cannot span midnight. An overnight
-    // product would need boundaries that carry a day offset, which nothing here models yet.
-    public record TradingSession(TimeSpan PreOpen, TimeSpan Open, TimeSpan Close);
-}
+// One session's boundaries as times of day. A day's schedule is an ordered, non-overlapping
+// list of these - a single continuous session for most products, two or more for one that
+// breaks (a lunch recess, a separate evening session).
+//
+// All three times fall within the same day, so a session cannot span midnight. An overnight
+// product would need boundaries that carry a day offset, which nothing here models yet.
+public record TradingSession(TimeSpan PreOpen, TimeSpan Open, TimeSpan Close);

--- a/Circus/Side.cs
+++ b/Circus/Side.cs
@@ -1,8 +1,7 @@
-namespace Circus
+namespace Circus;
+
+public enum Side
 {
-    public enum Side
-    {
-        Buy,
-        Sell,
-    }
+    Buy,
+    Sell,
 }

--- a/Circus/TimeProviders/TestTimeProvider.cs
+++ b/Circus/TimeProviders/TestTimeProvider.cs
@@ -1,21 +1,18 @@
-using System;
+namespace Circus.TimeProviders;
 
-namespace Circus.TimeProviders
+public class TestTimeProvider : ITimeProvider
 {
-    public class TestTimeProvider : ITimeProvider
+    private DateTime _time;
+
+    public TestTimeProvider(DateTime now)
     {
-        private DateTime _time;
-
-        public TestTimeProvider(DateTime now)
-        {
-            _time = now;
-        }
-
-        public void SetCurrentTime(DateTime time)
-        {
-            _time = time;
-        }
-
-        public DateTime GetCurrentTime() => _time;
+        _time = now;
     }
+
+    public void SetCurrentTime(DateTime time)
+    {
+        _time = time;
+    }
+
+    public DateTime GetCurrentTime() => _time;
 }

--- a/Circus/TimeProviders/TimeProvider.cs
+++ b/Circus/TimeProviders/TimeProvider.cs
@@ -1,9 +1,6 @@
-using System;
+namespace Circus.TimeProviders;
 
-namespace Circus.TimeProviders
+public interface ITimeProvider
 {
-    public interface ITimeProvider
-    {
-        DateTime GetCurrentTime();
-    }
+    DateTime GetCurrentTime();
 }

--- a/Circus/TimeProviders/UtcTimeProvider.cs
+++ b/Circus/TimeProviders/UtcTimeProvider.cs
@@ -1,12 +1,9 @@
-using System;
+namespace Circus.TimeProviders;
 
-namespace Circus.TimeProviders
+public class UtcTimeProvider : ITimeProvider
 {
-    public class UtcTimeProvider : ITimeProvider
+    public DateTime GetCurrentTime()
     {
-        public DateTime GetCurrentTime()
-        {
-            return DateTime.UtcNow;
-        }
+        return DateTime.UtcNow;
     }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Step 2 of the organisation review, following #55. Modernises file structure to match the `net10.0` target. Mechanical throughout — no logic, no API surface, no type or member touched.

**84 files changed, +12,632 / −12,860.** The diff is large but every hunk is one of three shapes.

## File-scoped namespaces

All 82 files that declared a namespace are converted. The wrapping brace bought nothing — no file declares a second namespace — and cost four spaces of indent on every line beneath it. `InMemoryOrderBook`, whose signatures already wrap near the 120-column margin, gets the most back.

```diff
-using System;
 using Circus.OrderBook;

-namespace Circus.SessionProviders
+namespace Circus.SessionProviders;
+
+public interface ISessionProvider
 {
-    public interface ISessionProvider
-    {
-        event EventHandler<SessionStatusChangedArgs> Changed;
+    event EventHandler<SessionStatusChangedArgs> Changed;
```

`Circus.Benchmarks/Program.cs` is untouched — it already uses top-level statements and declares no namespace.

## Implicit usings

`<ImplicitUsings>enable</ImplicitUsings>` in `Directory.Build.props` removes **118** `using` lines that restated `System`, `System.Collections.Generic`, `System.Linq`, `System.Threading` and `System.Threading.Tasks`. What's left in a using block is now a real dependency:

| Using | Count |
|---|---|
| `Circus.OrderBook` | 43 |
| `Circus.TimeProviders` | 31 |
| `NUnit.Framework` | 29 |
| `Circus.DataProducers` | 9 |
| `Circus.SessionProviders` | 2 |
| `Circus.Simulator`, `BenchmarkDotNet.*` | 1 each |

## BOM removal

Eight files carried a UTF-8 BOM. They lose it, matching the `charset = utf-8` the `.editorconfig` in #55 asks for. All eight were pure ASCII once the BOM was stripped, so nothing about how they decode changes. (The only non-ASCII in the repo is three em-dashes, in files that never had a BOM and already relied on the compiler's UTF-8 default.)

## `.editorconfig`

`csharp_style_namespace_declarations` moves from `suggestion` to `warning`, as flagged in #55 — there's no block-scoped namespace left for it to flag.

## How this was verified

There's no dotnet in the sandbox (the network policy blocks the SDK download), so the conversion was scripted rather than done with `dotnet format`, and checked statically:

- **Token-level equivalence.** Every one of the 82 converted files was reduced to a whitespace-free signature, before and after, with the namespace braces and removed usings accounted for. All 82 matched exactly — the transform provably moved no token, dropped no line, and corrupted no indentation-sensitive content. (There are no verbatim or raw string literals anywhere in the repo, which is what makes a blind dedent safe.)
- **Name-collision review.** The risk in enabling implicit usings is a new global `System` type shadowing something in a file that previously had no `using System;`. Checked the full public and internal type inventory against the implicit namespaces: no collisions. `Security` is safe because using-directives don't import nested namespaces, so `System.Security` never enters scope as a type name. NUnit's `[Range]`, `[Random]` and `[Order]` attributes would have been the sharp edge in the test project — none are used.
- **Structural sweep.** No block-scoped namespace remains, no implicit using remains, no BOM remains, and every file ends with a newline.

CI is still the first real compile, as it was for #55.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEKDDgTNbJM6jE8gRcQbZn)_