### PR TITLE
Give the order book's parts folders of their own

### DIFF
--- a/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
+++ b/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
 using Circus.Simulator;
 using Circus.TimeProviders;
 

--- a/samples/Circus.Examples/DataProducerExample.cs
+++ b/samples/Circus.Examples/DataProducerExample.cs
@@ -1,5 +1,7 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 
 namespace Circus.Examples;

--- a/samples/Circus.Examples/Example.cs
+++ b/samples/Circus.Examples/Example.cs
@@ -1,5 +1,6 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
 using Circus.TimeProviders;
 
 namespace Circus.Examples;

--- a/samples/Circus.Examples/OrderBookExample.cs
+++ b/samples/Circus.Examples/OrderBookExample.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.SessionProviders;
 using Circus.TimeProviders;
 

--- a/src/Circus.Simulator/OrderFlowSimulator.cs
+++ b/src/Circus.Simulator/OrderFlowSimulator.cs
@@ -1,5 +1,7 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 
 namespace Circus.Simulator;

--- a/src/Circus/DataProducers/FullBookDataProducer.cs
+++ b/src/Circus/DataProducers/FullBookDataProducer.cs
@@ -1,4 +1,5 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Events;
 
 namespace Circus.DataProducers;
 

--- a/src/Circus/DataProducers/IDataProducer.cs
+++ b/src/Circus/DataProducers/IDataProducer.cs
@@ -1,4 +1,5 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Events;
 
 namespace Circus.DataProducers;
 

--- a/src/Circus/DataProducers/IndicativePriceDataProducer.cs
+++ b/src/Circus/DataProducers/IndicativePriceDataProducer.cs
@@ -1,4 +1,5 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Events;
 
 namespace Circus.DataProducers;
 

--- a/src/Circus/DataProducers/LevelDataProducer.cs
+++ b/src/Circus/DataProducers/LevelDataProducer.cs
@@ -1,4 +1,5 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Events;
 
 namespace Circus.DataProducers;
 

--- a/src/Circus/DataProducers/SecurityStatusDataProducer.cs
+++ b/src/Circus/DataProducers/SecurityStatusDataProducer.cs
@@ -1,4 +1,5 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Events;
 
 namespace Circus.DataProducers;
 

--- a/src/Circus/DataProducers/TradeDataProducer.cs
+++ b/src/Circus/DataProducers/TradeDataProducer.cs
@@ -1,4 +1,5 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Events;
 
 namespace Circus.DataProducers;
 

--- a/src/Circus/OrderBook/Actions/OrderBookAction.cs
+++ b/src/Circus/OrderBook/Actions/OrderBookAction.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Actions;
 
 public abstract record OrderBookAction
 {

--- a/src/Circus/OrderBook/Events/OrderBookEvent.cs
+++ b/src/Circus/OrderBook/Events/OrderBookEvent.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Events;
 
 public record OrderBookEvent(Security Security, DateTime Time);
 

--- a/src/Circus/OrderBook/Events/OrderCancelledReason.cs
+++ b/src/Circus/OrderBook/Events/OrderCancelledReason.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Actions;
+
+namespace Circus.OrderBook.Events;
 
 public enum OrderCancelledReason
 {

--- a/src/Circus/OrderBook/Events/OrderRejectedReason.cs
+++ b/src/Circus/OrderBook/Events/OrderRejectedReason.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Events;
 
 public enum OrderRejectedReason
 {

--- a/src/Circus/OrderBook/IOrderBook.cs
+++ b/src/Circus/OrderBook/IOrderBook.cs
@@ -1,3 +1,6 @@
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+
 namespace Circus.OrderBook;
 
 // Actions in, events out. Everything a consumer knows about the book - price levels, trades,

--- a/src/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/src/Circus/OrderBook/InMemoryOrderBook.cs
@@ -1,3 +1,7 @@
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Matching;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 
 namespace Circus.OrderBook;

--- a/src/Circus/OrderBook/Matching/Auction.cs
+++ b/src/Circus/OrderBook/Matching/Auction.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Matching;
 
 // A call-auction print: every trade clears at one price, sized off each side's full remaining
 // quantity. The print is a single atomic allocation, not a sequence of continuous touches an

--- a/src/Circus/OrderBook/Matching/IMatchingAlgorithm.cs
+++ b/src/Circus/OrderBook/Matching/IMatchingAlgorithm.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Matching;
 
 internal readonly record struct Allocation(InternalOrder Resting, int Quantity, long PriceTicks);
 

--- a/src/Circus/OrderBook/Matching/InternalOrder.cs
+++ b/src/Circus/OrderBook/Matching/InternalOrder.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Matching;
 
 // Price/TriggerPrice are tick counts (price / Security.TickSize), not decimal: decimal
 // comparison has no hardware path, so the hot paths stay on long and convert back only at the

--- a/src/Circus/OrderBook/Matching/MatchOutcome.cs
+++ b/src/Circus/OrderBook/Matching/MatchOutcome.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Restrictions;
+
+namespace Circus.OrderBook.Matching;
 
 // What Matcher.Run decided should happen next. Run mutates nothing and emits nothing;
 // InMemoryOrderBook.Apply does both.

--- a/src/Circus/OrderBook/Matching/Matcher.cs
+++ b/src/Circus/OrderBook/Matching/Matcher.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Restrictions;
+
+namespace Circus.OrderBook.Matching;
 
 // Owns the working and stop ladders outright: Rest, Unrest and Reprice are the only ways an
 // order enters, leaves or moves within them, and the ladders never leave this class in a form

--- a/src/Circus/OrderBook/Matching/PriceLadder.cs
+++ b/src/Circus/OrderBook/Matching/PriceLadder.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Matching;
 
 // All anything outside Matcher is handed. Writes go through Matcher's own Rest/Unrest/Reprice,
 // so the ladders it owns cannot be mutated from outside.

--- a/src/Circus/OrderBook/Matching/PriceTime.cs
+++ b/src/Circus/OrderBook/Matching/PriceTime.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Matching;
 
 // Continuous trading under price-time priority. The aggressor trades against the FIFO-earliest
 // order at the best crossing level - taking the head and only moving on once it is consumed is

--- a/src/Circus/OrderBook/OrderBookExtensions.cs
+++ b/src/Circus/OrderBook/OrderBookExtensions.cs
@@ -1,3 +1,6 @@
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+
 namespace Circus.OrderBook;
 
 public static class OrderBookExtensions

--- a/src/Circus/OrderBook/Restrictions/CircuitBreakerRestriction.cs
+++ b/src/Circus/OrderBook/Restrictions/CircuitBreakerRestriction.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Events;
+
+namespace Circus.OrderBook.Restrictions;
 
 // A threshold that stops trading rather than capping it. Set against a settlement price like a
 // daily limit, and unlike one it halts: no matching, no quote, nothing published until it

--- a/src/Circus/OrderBook/Restrictions/DailyPriceLimitRestriction.cs
+++ b/src/Circus/OrderBook/Restrictions/DailyPriceLimitRestriction.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Events;
+
+namespace Circus.OrderBook.Restrictions;
 
 // A session-long ceiling and floor set against a settlement price. The only restriction that
 // neither rejects nor interrupts: trading continues, at the limit price, and simply cannot go

--- a/src/Circus/OrderBook/Restrictions/IPriceRestriction.cs
+++ b/src/Circus/OrderBook/Restrictions/IPriceRestriction.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Events;
+
+namespace Circus.OrderBook.Restrictions;
 
 // Flags, because a daily price limit is both: it refuses an order priced beyond the limit and
 // refuses to print through it. Everything else governs one or the other.

--- a/src/Circus/OrderBook/Restrictions/OrderPriceRestriction.cs
+++ b/src/Circus/OrderBook/Restrictions/OrderPriceRestriction.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Events;
+
+namespace Circus.OrderBook.Restrictions;
 
 // The hard band checked at order entry. Sees only client-supplied resting limit prices - trigger
 // and Market/MarketLimit prices are governed elsewhere in InMemoryOrderBook.

--- a/src/Circus/OrderBook/Restrictions/PriceRestrictionConfig.cs
+++ b/src/Circus/OrderBook/Restrictions/PriceRestrictionConfig.cs
@@ -1,4 +1,4 @@
-namespace Circus;
+namespace Circus.OrderBook.Restrictions;
 
 // What restrictions a security trades under, as data. The book turns each of these into the
 // adapter that enforces it, so adding a restriction is adding a case here rather than another

--- a/src/Circus/OrderBook/Restrictions/SessionLimitAnchor.cs
+++ b/src/Circus/OrderBook/Restrictions/SessionLimitAnchor.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook;
+namespace Circus.OrderBook.Restrictions;
 
 // The reference and resolved width shared by the two restrictions set against a settlement
 // price rather than against a moving market. Both are inert until a reference arrives, because

--- a/src/Circus/OrderBook/Restrictions/StaticPriceRangeRestriction.cs
+++ b/src/Circus/OrderBook/Restrictions/StaticPriceRangeRestriction.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Events;
+
+namespace Circus.OrderBook.Restrictions;
 
 // A range measured from a fixed reference rather than from recent trades. Eurex's static
 // volatility interruption, which exists because a range that follows the market can be walked

--- a/src/Circus/OrderBook/Restrictions/VolatilityBandRestriction.cs
+++ b/src/Circus/OrderBook/Restrictions/VolatilityBandRestriction.cs
@@ -1,4 +1,6 @@
-namespace Circus.OrderBook;
+using Circus.OrderBook.Events;
+
+namespace Circus.OrderBook.Restrictions;
 
 // A range checked against the prospective trade price rather than the submitted one. A breach
 // interrupts continuous trading into an auction rather than rejecting, Eurex-style.

--- a/src/Circus/OrderBook/TradingPhase.cs
+++ b/src/Circus/OrderBook/TradingPhase.cs
@@ -1,3 +1,5 @@
+using Circus.OrderBook.Matching;
+
 namespace Circus.OrderBook;
 
 // What a phase permits and which algorithm governs it. Everything the book does differently

--- a/src/Circus/Security.cs
+++ b/src/Circus/Security.cs
@@ -1,3 +1,5 @@
+using Circus.OrderBook.Restrictions;
+
 namespace Circus;
 
 // MarketOrderProtectionTicks is not a price restriction and stays here: it prices a market

--- a/tests/Circus.Tests/DataProducers/FullBookDataProducerTests.cs
+++ b/tests/Circus.Tests/DataProducers/FullBookDataProducerTests.cs
@@ -1,5 +1,7 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/DataProducers/IndicativePriceDataProducerTests.cs
+++ b/tests/Circus.Tests/DataProducers/IndicativePriceDataProducerTests.cs
@@ -1,5 +1,7 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/DataProducers/LevelDataProducerTests.cs
+++ b/tests/Circus.Tests/DataProducers/LevelDataProducerTests.cs
@@ -1,5 +1,7 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
@@ -1,5 +1,8 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/DataProducers/TradeDataProducerTests.cs
+++ b/tests/Circus.Tests/DataProducers/TradeDataProducerTests.cs
@@ -1,5 +1,6 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
@@ -1,4 +1,6 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
@@ -1,4 +1,7 @@
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
+using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
+++ b/tests/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
@@ -1,5 +1,7 @@
 using Circus.DataProducers;
 using Circus.OrderBook;
+using Circus.OrderBook.Actions;
+using Circus.OrderBook.Events;
 using Circus.TimeProviders;
 
 namespace Circus.Tests.OrderBook;

--- a/tests/Circus.Tests/OrderBook/MatcherTests.cs
+++ b/tests/Circus.Tests/OrderBook/MatcherTests.cs
@@ -1,4 +1,4 @@
-using Circus.OrderBook;
+using Circus.OrderBook.Matching;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;

--- a/tests/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
+++ b/tests/Circus.Tests/OrderBook/OrderPriceRestrictionTests.cs
@@ -1,4 +1,4 @@
-using Circus.OrderBook;
+using Circus.OrderBook.Restrictions;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;

--- a/tests/Circus.Tests/OrderBook/StaticPriceRangeRestrictionTests.cs
+++ b/tests/Circus.Tests/OrderBook/StaticPriceRangeRestrictionTests.cs
@@ -1,4 +1,4 @@
-using Circus.OrderBook;
+using Circus.OrderBook.Restrictions;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;

--- a/tests/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
+++ b/tests/Circus.Tests/OrderBook/VolatilityBandRestrictionTests.cs
@@ -1,4 +1,4 @@
-using Circus.OrderBook;
+using Circus.OrderBook.Restrictions;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;


### PR DESCRIPTION
Step 4 of the organisation review, following #55, #56 and #57.

`OrderBook/` held 24 files in one flat directory — the book, the matching engine, the ladder structures, six price restrictions, the action and event hierarchies, and four enums. Nothing about the folder said which of those a given file belonged to.

```
OrderBook/                 the book itself, its status, and the phase table
OrderBook/Actions/         what goes in
OrderBook/Events/          what comes out, and the reasons carried with them
OrderBook/Matching/        how a trade is found, priced and allocated
OrderBook/Restrictions/    what may not trade, and why
```

**`PriceRestrictionConfig` moves out of the `Circus` root namespace into `Restrictions/`, which is the point of the exercise.** `VolatilityBand` and `VolatilityBandRestriction` described one feature from two different folders *and* two different namespaces; reading either meant already knowing where the other lived. Same for the other four config/adapter pairs.

## ⚠️ This is a breaking change

| Types | From | To |
|---|---|---|
| 17 | `Circus.OrderBook` | `Circus.OrderBook.Actions` |
| 18 | `Circus.OrderBook` | `Circus.OrderBook.Events` |
| 10 | `Circus` | `Circus.OrderBook.Restrictions` |

That's **45 public types** changing namespace — `OrderBookAction` and every `Create*`/`Update`/`Cancel` subtype, `OrderBookEvent` and every subtype, both reason enums, and all the restriction configs. Any consumer's `using` directives break. At 0.6.0 that's the cheapest this will ever be, but it makes the next release a breaking one and probably wants a version bump to match.

The 25 internal types that also moved (`Matching/`, and the restriction adapters) are invisible to consumers.

## Shape of the diff

**64 files changed, +127 / −23.** 19 are renames git tracked at 73–99% similarity; the other 45 are using-directive edits only. No type, member or line of logic was touched.

## How this was verified

No dotnet in the sandbox, so as with the previous three PRs this is static verification and CI is the first real build. This change is materially riskier than #55–#57 — it's the first one that can produce genuine compile errors rather than just moving bytes — so the checking is correspondingly harder:

- **Every type reference resolves.** Built a repo-wide map of all 136 types to their namespaces, then for each of the 83 source files computed the visible set (own namespace + ancestors + usings) and checked every referenced type against it. **0 unresolvable references.** This is the check that stands in for the compiler.
- **No ambiguous simple names.** Confirmed no type name occurs in two namespaces, which is what makes the reference analysis above trustworthy.
- **Extension methods checked separately.** `OrderBookExtensions` has 14 `this IOrderBook` methods. A call site like `book.CreateLimitOrder(...)` never names the type, so type-reference scanning is blind to it — pruning `using Circus.OrderBook;` from the test files would have broken every one silently. Verified 0 files call an extension method without that using in scope.
- **Namespace matches folder** for all 83 files, per the `dotnet_style_namespace_match_folder` rule added in #55.
- **No namespace shadowing.** `Circus.Tests.OrderBook` could shadow `Circus.OrderBook` for any qualified `OrderBook.Foo` reference. There are none — the only matches are comments mentioning `InMemoryOrderBook.Apply`.
- **Dead usings pruned deliberately, not automatically.** Four test files kept a now-unused `using Circus.OrderBook;`. Each removal was assert-guarded to exactly one line, and the full resolver was re-run afterwards.

## One thing this surfaced

`Security` (namespace `Circus`) carries `IReadOnlyList<PriceRestrictionConfig>`, so it now needs `using Circus.OrderBook.Restrictions;` — the root type reaching down into `OrderBook`. That dependency already existed; it was just invisible while both types shared a namespace. Worth a look on its own sometime, not here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEKDDgTNbJM6jE8gRcQbZn)_