### PR TITLE
Let a security describe itself without reaching into the book

### DIFF
--- a/src/Circus/OrderBook/Restrictions/IPriceRestriction.cs
+++ b/src/Circus/OrderBook/Restrictions/IPriceRestriction.cs
@@ -2,6 +2,11 @@ using Circus.OrderBook.Events;
 
 namespace Circus.OrderBook.Restrictions;
 
+// The enforcement half of price restrictions. The declarations these are built from are
+// PriceRestrictionConfig and its subtypes, which live beside Security because they describe an
+// instrument rather than the book; each adapter here is named for the config it enforces.
+// InMemoryOrderBook.Adapt is what turns one into the other.
+
 // Flags, because a daily price limit is both: it refuses an order priced beyond the limit and
 // refuses to print through it. Everything else governs one or the other.
 [Flags]

--- a/src/Circus/PriceRestrictionConfig.cs
+++ b/src/Circus/PriceRestrictionConfig.cs
@@ -1,4 +1,4 @@
-namespace Circus.OrderBook.Restrictions;
+namespace Circus;
 
 // What restrictions a security trades under, as data. The book turns each of these into the
 // adapter that enforces it, so adding a restriction is adding a case here rather than another
@@ -6,6 +6,11 @@ namespace Circus.OrderBook.Restrictions;
 //
 // A restriction that does not apply is left out of the list rather than configured with no
 // width: absence is modelled by absence.
+//
+// Declarations only, and deliberately alongside Security rather than with the adapters in
+// OrderBook/Restrictions: this is part of describing an instrument, so a caller building a
+// Security should not have to reach into the book to say what it trades under. Each adapter is
+// named for the config it enforces - VolatilityBand is enforced by VolatilityBandRestriction.
 public abstract record PriceRestrictionConfig;
 
 // Rejects an order priced too far from the reference, at entry. CME's price banding.

--- a/src/Circus/Security.cs
+++ b/src/Circus/Security.cs
@@ -1,5 +1,3 @@
-using Circus.OrderBook.Restrictions;
-
 namespace Circus;
 
 // MarketOrderProtectionTicks is not a price restriction and stays here: it prices a market

--- a/tests/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/DataProducers/SecurityStatusDataProducerTests.cs
@@ -2,7 +2,6 @@ using Circus.DataProducers;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -1,7 +1,6 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
@@ -1,7 +1,6 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
@@ -1,7 +1,6 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
@@ -1,7 +1,6 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -1,7 +1,6 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
@@ -1,7 +1,6 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
@@ -1,7 +1,6 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.OrderBook.Restrictions;
 using Circus.TimeProviders;
 using NUnit.Framework;
 


### PR DESCRIPTION
Follow-up to #58, fixing the dependency direction it introduced. **11 files changed, +11 / −11.**

## The problem

#58 moved `PriceRestrictionConfig` under `OrderBook/Restrictions/` so each config sat beside the adapter enforcing it. That put the dependency the wrong way round:

```csharp
using Circus.OrderBook.Restrictions;   // <- Security had to import this

namespace Circus;

public record Security(
    ...
    IReadOnlyList<PriceRestrictionConfig>? PriceRestrictions = null
);
```

`Security` is instrument data. Making it import the book's internal enforcement namespace means a caller constructing a `Security` has to reach into `OrderBook` to say what its instrument trades under.

Two things confirmed this was misfiled rather than merely awkward:

- **It was the odd one out in that folder.** `PriceRestrictionConfig.cs` held 8 public types; the other seven files there hold 10 internal ones. It was the only public file in `Restrictions/`.
- **It depends on nothing in `OrderBook`.** The sole mention of anything book-related in the whole file is the word `Security` in a comment.

So it's pure instrument-definition data that ended up inside the book's machinery.

## The fix

The configs go back beside `Security`; the adapters stay where they are. The layering that's actually true:

| Layer | Types | Depends on |
|---|---|---|
| Instrument definition | `Security`, `SecurityType`, `PriceRestrictionConfig` + subtypes | nothing |
| Order book API | `IOrderBook`, actions, events | instrument definition |
| Restriction enforcement (internal) | `IPriceRestriction` + 6 adapters | both |

This reintroduces the config/adapter split I complained about in the original review — so both files now say where the other half lives. That's what the complaint was actually asking for: the pairing is by name (`VolatilityBand` → `VolatilityBandRestriction`), and `InMemoryOrderBook.Adapt` is where one becomes the other. On reflection the dependency direction and the public-API ergonomics matter more than the co-location, which is the call this PR makes.

## Effect on the public API

Measured by extracting every top-level public type and its namespace at the pre-review baseline (`eaaa7ae`) and comparing:

| | at 0.6.0 | after #58 | after this |
|---|---|---|---|
| Public types | 111 | 111 | 111 |
| Namespace changed vs 0.6.0 | — | 43 | **35** |
| Types added / removed | — | 0 / 0 | 0 / 0 |

The next release is still breaking — 35 types move to `Circus.OrderBook.Actions` and `.Events` — but the 8 config types (10 counting the two nested under `PriceLimitWidth`) return to `Circus`, where 0.6.0 consumers already expect them. This PR makes the release **less** breaking, not more.

## How this was verified

Same static approach as #58, since there's still no dotnet in the sandbox:

- **Every type reference resolves** — 136 types mapped, all 83 files checked against their visible namespace set. 0 unresolvable.
- **Namespace matches folder** for all 83 files.
- **Extension methods safe** — 0 files call one of the 14 `this IOrderBook` methods without `Circus.OrderBook` in scope.
- **Pruning was precise, not blanket.** Eight files dropped a now-dead `using Circus.OrderBook.Restrictions;`, including `Security`'s own. `InMemoryOrderBookTimedResumeTests` correctly *kept* it — it genuinely uses the internal `IPriceRestriction`, `RestrictionScope` and `RestrictionBreachAction` via `InternalsVisibleTo`. `InMemoryOrderBook` kept it too, since `Adapt` touches both halves. Pruning was only enabled for that one namespace, after confirming it contains no extension methods.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEKDDgTNbJM6jE8gRcQbZn)_