### PR TITLE
Name the namespaces for what is in them, and call a clock a clock

### DIFF
--- a/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
+++ b/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
@@ -2,7 +2,7 @@ using BenchmarkDotNet.Attributes;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.Simulator;
-using Circus.TimeProviders;
+using Circus.Time;
 
 namespace Circus.Benchmarks;
 
@@ -29,7 +29,7 @@ public class OrderBookThroughputBenchmarks
     [Benchmark]
     public int ReplayTrace()
     {
-        var book = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
+        var book = new InMemoryOrderBook(_security, new ManualClock(DateTime.UtcNow));
         book.UpdateStatus(OrderBookStatus.Open);
 
         var eventCount = 0;

--- a/samples/Circus.Examples/DataProducerExample.cs
+++ b/samples/Circus.Examples/DataProducerExample.cs
@@ -1,8 +1,8 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 
 namespace Circus.Examples;
 
@@ -10,7 +10,7 @@ public class MarketDataProducerExample
 {
     public static void Run()
     {
-        var time = new UtcTimeProvider();
+        var time = new SystemClock();
 
         var sec1 = new Security("GCZ6", SecurityType.Future, 10, 10);
         var sec2 = new Security("SIZ6", SecurityType.Future, 10, 10);

--- a/samples/Circus.Examples/Example.cs
+++ b/samples/Circus.Examples/Example.cs
@@ -1,7 +1,7 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
-using Circus.TimeProviders;
+using Circus.Time;
 
 namespace Circus.Examples;
 
@@ -9,7 +9,7 @@ public class Example
 {
     public static void Run()
     {
-        var time = new UtcTimeProvider();
+        var time = new SystemClock();
 
         var producer = new TradeDataProducer();
 

--- a/samples/Circus.Examples/OrderBookExample.cs
+++ b/samples/Circus.Examples/OrderBookExample.cs
@@ -1,8 +1,8 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.SessionProviders;
-using Circus.TimeProviders;
+using Circus.Sessions;
+using Circus.Time;
 
 namespace Circus.Examples;
 
@@ -12,8 +12,8 @@ public static class OrderBookExample
     {
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
 
-        var timeProvider = new TestTimeProvider(DateTime.Now);
-        IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
+        var clock = new ManualClock(DateTime.Now);
+        IOrderBook book = new InMemoryOrderBook(sec, clock);
 
         var preOpen = new TimeSpan(1, 0, 0);
         var open = new TimeSpan(1, 10, 0);
@@ -31,8 +31,8 @@ public static class OrderBookExample
     {
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
 
-        var timeProvider = new TestTimeProvider(DateTime.Now);
-        IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
+        var clock = new ManualClock(DateTime.Now);
+        IOrderBook book = new InMemoryOrderBook(sec, clock);
 
         var preOpen = new TimeSpan(1, 0, 0);
         var open = new TimeSpan(1, 10, 0);
@@ -40,7 +40,7 @@ public static class OrderBookExample
         var sessionProvider = new SessionProvider(preOpen, open, close);
         sessionProvider.Changed += (_, args) =>
         {
-            timeProvider.SetCurrentTime(args.Time);
+            clock.SetCurrentTime(args.Time);
             book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
         };
 
@@ -52,7 +52,7 @@ public static class OrderBookExample
             // update status with correct time
             sessionProvider.Update(time);
             // set data time
-            timeProvider.SetCurrentTime(time);
+            clock.SetCurrentTime(time);
             // pass in data - each order needs its own ClientOrderId, since Buyer's ids are
             // permanently reserved once used
             Print(book.CreateLimitOrder("Buyer", $"Order{i}", new OrderValidity.Day(), Side.Buy, 3, 100));
@@ -63,8 +63,8 @@ public static class OrderBookExample
     {
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
 
-        var timeProvider = new UtcTimeProvider();
-        IOrderBook book = new InMemoryOrderBook(sec, timeProvider);
+        var clock = new SystemClock();
+        IOrderBook book = new InMemoryOrderBook(sec, clock);
 
         var preOpen = new TimeSpan(1, 0, 0);
         var open = new TimeSpan(1, 10, 0);
@@ -78,7 +78,7 @@ public static class OrderBookExample
             while (i < 100)
             {
                 // this needs to happen on same thread as book is updated
-                sessionProvider.Update(timeProvider.GetCurrentTime());
+                sessionProvider.Update(clock.GetCurrentTime());
                 Thread.Sleep(100);
                 i++;
             }

--- a/src/Circus.Simulator/OrderFlowSimulator.cs
+++ b/src/Circus.Simulator/OrderFlowSimulator.cs
@@ -1,8 +1,8 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 
 namespace Circus.Simulator;
 
@@ -48,7 +48,7 @@ public sealed class OrderFlowSimulator
         _seed = seed ?? Random.Shared.Next();
         _random = new Random(_seed);
 
-        _shadowBook = new InMemoryOrderBook(_security, new TestTimeProvider(DateTime.UtcNow));
+        _shadowBook = new InMemoryOrderBook(_security, new ManualClock(DateTime.UtcNow));
         _shadowBook.UpdateStatus(OrderBookStatus.Open);
     }
 

--- a/src/Circus/Circus.csproj
+++ b/src/Circus/Circus.csproj
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.6.0</PackageVersion>
+        <PackageVersion>0.7.0</PackageVersion>
         <Title>Circus</Title>
         <Description>Financial exchange simulator.</Description>
         <PackageTags>finance financial exchange orderbook trading simulator simulation backtest</PackageTags>

--- a/src/Circus/MarketData/FullBookDataProducer.cs
+++ b/src/Circus/MarketData/FullBookDataProducer.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Events;
 
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 // Full order-by-order (L3) view of the working book, derived purely from the
 // OrderConfirmedEvent stream - no IOrderBook access, no snapshotting. A consumer replays the

--- a/src/Circus/MarketData/IDataProducer.cs
+++ b/src/Circus/MarketData/IDataProducer.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Events;
 
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 public interface IDataProducer<T>
 {

--- a/src/Circus/MarketData/IndicativePriceDataEvent.cs
+++ b/src/Circus/MarketData/IndicativePriceDataEvent.cs
@@ -1,3 +1,3 @@
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 public record IndicativePriceDataEvent(DateTime Time, decimal? Price, int Quantity);

--- a/src/Circus/MarketData/IndicativePriceDataProducer.cs
+++ b/src/Circus/MarketData/IndicativePriceDataProducer.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Events;
 
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 // Publishes the auction quote a book is running - CME's indicative opening price, Eurex's
 // indicative auction price. Unlike the level producers this holds no state of its own: the

--- a/src/Circus/MarketData/Level.cs
+++ b/src/Circus/MarketData/Level.cs
@@ -1,4 +1,4 @@
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 // Aggregated market data, not a book structure: one publishable line per price.
 public record Level(decimal Price, int Quantity, int Count);

--- a/src/Circus/MarketData/LevelDataProducer.cs
+++ b/src/Circus/MarketData/LevelDataProducer.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Events;
 
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 // Maintains its own view of working-book price levels purely from the OrderConfirmedEvent
 // stream - so one instance is required per IOrderBook, created before that book processes its

--- a/src/Circus/MarketData/LevelsDataEvent.cs
+++ b/src/Circus/MarketData/LevelsDataEvent.cs
@@ -1,3 +1,3 @@
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 public record LevelsDataEvent(DateTime Time, IReadOnlyList<Level> Bids, IReadOnlyList<Level> Offers);

--- a/src/Circus/MarketData/OrderBookDeltaAction.cs
+++ b/src/Circus/MarketData/OrderBookDeltaAction.cs
@@ -1,4 +1,4 @@
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 public enum OrderBookDeltaAction
 {

--- a/src/Circus/MarketData/OrderBookDeltaEvent.cs
+++ b/src/Circus/MarketData/OrderBookDeltaEvent.cs
@@ -1,4 +1,4 @@
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 // ExchangeOrderId only - never CompanyId/ClientOrderId, which identify the originating
 // client and must not be broadcast on a public depth feed.

--- a/src/Circus/MarketData/SecurityStatusDataEvent.cs
+++ b/src/Circus/MarketData/SecurityStatusDataEvent.cs
@@ -1,6 +1,6 @@
 using Circus.OrderBook;
 
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 // ResumesAt is when a timed interruption is due back, null when nothing is pending. LimitState
 // is which way a daily limit has the market stuck - Buy for limit up, where buyers cannot push

--- a/src/Circus/MarketData/SecurityStatusDataProducer.cs
+++ b/src/Circus/MarketData/SecurityStatusDataProducer.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Events;
 
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 // What state an instrument is in, as one thing - CME's Security Status message, Eurex's
 // instrument state. The book publishes the parts separately because they are separate: a status

--- a/src/Circus/MarketData/TradeDataProducer.cs
+++ b/src/Circus/MarketData/TradeDataProducer.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Events;
 
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 public class TradeDataProducer : IDataProducer<TradedDataEvent>
 {

--- a/src/Circus/MarketData/TradedDataEvent.cs
+++ b/src/Circus/MarketData/TradedDataEvent.cs
@@ -1,3 +1,3 @@
-namespace Circus.DataProducers;
+namespace Circus.MarketData;
 
 public record TradedDataEvent(DateTime Time, decimal Price, int Quantity);

--- a/src/Circus/OrderBook/InMemoryOrderBook.cs
+++ b/src/Circus/OrderBook/InMemoryOrderBook.cs
@@ -2,14 +2,14 @@ using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
 using Circus.OrderBook.Matching;
 using Circus.OrderBook.Restrictions;
-using Circus.TimeProviders;
+using Circus.Time;
 
 namespace Circus.OrderBook;
 
 public class InMemoryOrderBook : IOrderBook
 {
     private readonly Security _security;
-    private readonly ITimeProvider _timeProvider;
+    private readonly IClock _clock;
 
     private OrderBookStatus _status = OrderBookStatus.Closed;
     private long _nextSequenceNumber;
@@ -90,8 +90,8 @@ public class InMemoryOrderBook : IOrderBook
 
     private const int MaxClientOrderIdLength = 20;
 
-    public InMemoryOrderBook(Security security, ITimeProvider timeProvider)
-        : this(security, timeProvider, Adapt(security.PriceRestrictions))
+    public InMemoryOrderBook(Security security, IClock clock)
+        : this(security, clock, Adapt(security.PriceRestrictions))
     {
     }
 
@@ -120,15 +120,15 @@ public class InMemoryOrderBook : IOrderBook
     // Restrictions supplied outright rather than derived from the security. Internal because it
     // is a seam, not an API: it exists so combinations a Security cannot yet describe - two
     // trade-scoped restrictions disagreeing about severity, say - can still be exercised.
-    internal InMemoryOrderBook(Security security, ITimeProvider timeProvider,
+    internal InMemoryOrderBook(Security security, IClock clock,
         IReadOnlyList<IPriceRestriction> priceRestrictions)
     {
         _security = security;
-        _timeProvider = timeProvider;
+        _clock = clock;
         _priceRestrictions = priceRestrictions;
     }
 
-    private DateTime Now() => _timeProvider.GetCurrentTime();
+    private DateTime Now() => _clock.GetCurrentTime();
 
     public Security Security => _security;
     public OrderBookStatus Status => _status;

--- a/src/Circus/Sessions/ISessionProvider.cs
+++ b/src/Circus/Sessions/ISessionProvider.cs
@@ -1,4 +1,4 @@
-namespace Circus.SessionProviders;
+namespace Circus.Sessions;
 
 public interface ISessionProvider
 {

--- a/src/Circus/Sessions/SessionProvider.cs
+++ b/src/Circus/Sessions/SessionProvider.cs
@@ -1,6 +1,6 @@
 using Circus.OrderBook;
 
-namespace Circus.SessionProviders;
+namespace Circus.Sessions;
 
 // Drives an order book's status off a clock, given a day's schedule. Update() is pushed the
 // current time and fires whatever boundaries have been passed since it was last called, so a

--- a/src/Circus/Sessions/SessionStatusChangedArgs.cs
+++ b/src/Circus/Sessions/SessionStatusChangedArgs.cs
@@ -1,6 +1,6 @@
 using Circus.OrderBook;
 
-namespace Circus.SessionProviders;
+namespace Circus.Sessions;
 
 // EndsTradingDay is meaningful only when Status is Closed: false for a session closing with
 // another still to come the same day, so a consumer can forward it to the book and leave Day

--- a/src/Circus/Sessions/TradingSession.cs
+++ b/src/Circus/Sessions/TradingSession.cs
@@ -1,4 +1,4 @@
-namespace Circus.SessionProviders;
+namespace Circus.Sessions;
 
 // One session's boundaries as times of day. A day's schedule is an ordered, non-overlapping
 // list of these - a single continuous session for most products, two or more for one that

--- a/src/Circus/Time/IClock.cs
+++ b/src/Circus/Time/IClock.cs
@@ -1,0 +1,6 @@
+namespace Circus.Time;
+
+public interface IClock
+{
+    DateTime GetCurrentTime();
+}

--- a/src/Circus/Time/ManualClock.cs
+++ b/src/Circus/Time/ManualClock.cs
@@ -1,10 +1,10 @@
-namespace Circus.TimeProviders;
+namespace Circus.Time;
 
-public class TestTimeProvider : ITimeProvider
+public class ManualClock : IClock
 {
     private DateTime _time;
 
-    public TestTimeProvider(DateTime now)
+    public ManualClock(DateTime now)
     {
         _time = now;
     }

--- a/src/Circus/Time/SystemClock.cs
+++ b/src/Circus/Time/SystemClock.cs
@@ -1,6 +1,6 @@
-namespace Circus.TimeProviders;
+namespace Circus.Time;
 
-public class UtcTimeProvider : ITimeProvider
+public class SystemClock : IClock
 {
     public DateTime GetCurrentTime()
     {

--- a/src/Circus/TimeProviders/ITimeProvider.cs
+++ b/src/Circus/TimeProviders/ITimeProvider.cs
@@ -1,6 +1,0 @@
-namespace Circus.TimeProviders;
-
-public interface ITimeProvider
-{
-    DateTime GetCurrentTime();
-}

--- a/tests/Circus.Tests/MarketData/FullBookDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/FullBookDataProducerTests.cs
@@ -1,11 +1,11 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers;
+namespace Circus.Tests.MarketData;
 
 public class FullBookDataProducerTests
 {
@@ -32,14 +32,14 @@ public class FullBookDataProducerTests
     private static readonly string OrderId5 = "Order5";
     private static readonly string OrderId6 = "Order6";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     [Test]
@@ -205,17 +205,17 @@ public class FullBookDataProducerTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500);
 
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520);
 
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
 
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510);
 
         // act - trade at the trigger price, converting the stop into a working limit order
-        TimeProvider.SetCurrentTime(Now6);
+        Clock.SetCurrentTime(Now6);
         var bookEvents = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
         var deltas = producer.Process(Book, bookEvents);
 

--- a/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
@@ -1,11 +1,11 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers;
+namespace Circus.Tests.MarketData;
 
 public class IndicativePriceDataProducerTests
 {
@@ -14,14 +14,14 @@ public class IndicativePriceDataProducerTests
     private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
     private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     private static IList<IndicativePriceDataEvent> Publish(IndicativePriceDataProducer producer,
@@ -77,7 +77,7 @@ public class IndicativePriceDataProducerTests
         Publish(producer, Book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 5, 100));
         Publish(producer, Book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
 
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         var events = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
 
         Assert.AreEqual(1, events.Count);

--- a/tests/Circus.Tests/MarketData/LevelDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/LevelDataProducerTests.cs
@@ -1,11 +1,11 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers;
+namespace Circus.Tests.MarketData;
 
 // LevelDataProducer maintains its own state purely from the OrderConfirmedEvent stream, so
 // every test must route every book action through the same producer instance, in order -
@@ -36,14 +36,14 @@ public class LevelDataProducerTests
     private static readonly string OrderId5 = "Order5";
     private static readonly string OrderId6 = "Order6";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     private static LevelsDataEvent Publish(LevelDataProducer producer, IReadOnlyList<OrderBookEvent> bookEvents)
@@ -289,7 +289,7 @@ public class LevelDataProducerTests
         // quantity, so this trades 45, far more than the order was ever showing
         Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
             maxVisibleQuantity: 10));
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100));
 
         var level = Publish(producer, Book.UpdateStatus(OrderBookStatus.Open));
@@ -310,21 +310,21 @@ public class LevelDataProducerTests
         Publish(producer, Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500));
         Publish(producer, Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500));
 
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Publish(producer, Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520));
 
         // still-Hidden stop order: must not appear in the working-book levels yet
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         var afterStopCreate = Publish(producer,
             Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510));
         Assert.IsFalse(afterStopCreate.Bids.Count > 0 && afterStopCreate.Bids[0].Price == 530);
 
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         Publish(producer, Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510));
 
         // act - trade at the trigger price, converting the stop into a working limit order
         // that immediately matches the resting 520 offer
-        TimeProvider.SetCurrentTime(Now6);
+        Clock.SetCurrentTime(Now6);
         var level = Publish(producer,
             Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510));
 

--- a/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
@@ -1,24 +1,24 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers;
+namespace Circus.Tests.MarketData;
 
 public class SecurityStatusDataProducerTests
 {
     private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
     private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
     private SecurityStatusDataProducer Producer;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
         Producer = new SecurityStatusDataProducer();
     }
 
@@ -26,14 +26,14 @@ public class SecurityStatusDataProducerTests
         Producer.Process(book, bookEvents);
 
     private IOrderBook PlainBook() =>
-        new InMemoryOrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), TimeProvider);
+        new InMemoryOrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), Clock);
 
     // A 5-tick volatility range on a reference of 100, pausing for two minutes.
     private IOrderBook PausingBook() =>
         new InMemoryOrderBook(
             new Security("GCZ6", SecurityType.Future, 10, 10,
                 PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)}),
-            TimeProvider);
+            Clock);
 
     [Test]
     public void OrdinaryOpen_PublishesTheStatusAndNothingPending()
@@ -98,7 +98,7 @@ public class SecurityStatusDataProducerTests
         Publish(book, book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Buy, 5, 200));
 
         // act
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         var events = Publish(book, book.AdvanceTime());
 
         // assert
@@ -115,7 +115,7 @@ public class SecurityStatusDataProducerTests
         var book = new InMemoryOrderBook(
             new Security("GCZ6", SecurityType.Future, 10, 10,
                 PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)}),
-            TimeProvider);
+            Clock);
         Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
         book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
 
@@ -140,14 +140,14 @@ public class SecurityStatusDataProducerTests
                 {
                     new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
                 }),
-            TimeProvider);
+            Clock);
 
         Publish(book, book.UpdateStatus(OrderBookStatus.Open, 200));
         book.CreateLimitOrder("Company1", "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
         book.CreateLimitOrder("Company2", "Buy1", new OrderValidity.Day(), Side.Buy, 5, 200);
         book.CreateLimitOrder("Company2", "Buy2", new OrderValidity.Day(), Side.Buy, 5, 240);
 
-        TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
+        Clock.SetCurrentTime(Now1.AddMinutes(1));
         Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
 
         // act - a sell inside the limit, crossing into the buy that is not

--- a/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
@@ -1,10 +1,10 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
-namespace Circus.Tests.DataProducers;
+namespace Circus.Tests.MarketData;
 
 public class TradeDataProducerTests
 {
@@ -14,10 +14,10 @@ public class TradeDataProducerTests
         // arrange
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
         var now = new DateTime(2000, 1, 1, 12, 0, 0);
-        var timeProvider = new TestTimeProvider(now);
+        var clock = new ManualClock(now);
         var producer = new TradeDataProducer();
 
-        var book = new InMemoryOrderBook(sec, timeProvider);
+        var book = new InMemoryOrderBook(sec, clock);
         book.UpdateStatus(OrderBookStatus.Open);
         book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100);
         var bookEvents =

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookAuctionTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -31,12 +31,12 @@ public class InMemoryOrderBookAuctionTests
     private static readonly string OrderId8 = "Order8";
     private static readonly string CancelId1 = "Cancel1";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
     }
 
     [Test]
@@ -48,7 +48,7 @@ public class InMemoryOrderBookAuctionTests
         // sells fully fill (also price improvement - they get 120, not their own lower limit),
         // and the 120 buy (the marginal order) only partially fills for the 1 unit left over
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen);
 
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
@@ -97,14 +97,14 @@ public class InMemoryOrderBookAuctionTests
         // before the later order gets anything - it must not lose its place in the queue just
         // because its displayed peak needs replenishing mid-print.
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen);
 
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
             maxVisibleQuantity: 10);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 60, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 100, 100);
 
         // act
@@ -130,12 +130,12 @@ public class InMemoryOrderBookAuctionTests
         // than the 10-unit peak must not leave DisplayedQuantity negative or stale - it should
         // come out re-derived to a fresh full peak, the same as if it had just been entered.
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen);
 
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 100, 100,
             maxVisibleQuantity: 10);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 45, 100);
 
         // act
@@ -159,7 +159,7 @@ public class InMemoryOrderBookAuctionTests
         // arrange - 120 and 130 tie for max executable volume (10 each), with the surplus on
         // the sell side at both - CME's rule picks the lowest of the tied prices in that case
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen);
 
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
@@ -184,7 +184,7 @@ public class InMemoryOrderBookAuctionTests
         // arrange - same tie as above (120 vs 130), but with a reference price seeded at 130
         // (must be tick-aligned to TickSize 10) - that should win over the default rule
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen, 130);
 
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 140);
@@ -208,7 +208,7 @@ public class InMemoryOrderBookAuctionTests
     {
         // arrange
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
@@ -230,7 +230,7 @@ public class InMemoryOrderBookAuctionTests
         // happen is that governance turning into execution: a crossed book during pre-open is
         // quoted, not printed. Orders sit untouched until the open.
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen);
 
         // act - deeply crossed: the bid is well through the offer
@@ -259,7 +259,7 @@ public class InMemoryOrderBookAuctionTests
     {
         // arrange - a crossed book in pre-open, quoting a price it would clear at
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
         var quoting = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
@@ -288,7 +288,7 @@ public class InMemoryOrderBookAuctionTests
         // arrange - continuous trading is governed by price-time, which has no single price it
         // would print at, so there is no indicative auction price to publish while open
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act + assert - a resting order, then one that crosses it and trades: neither quotes
@@ -313,7 +313,7 @@ public class InMemoryOrderBookAuctionTests
     {
         // arrange
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         var preOpen = book.UpdateStatus(OrderBookStatus.PreOpen);
 
         // assert - nothing resting yet, so nothing to quote
@@ -363,7 +363,7 @@ public class InMemoryOrderBookAuctionTests
         // opposing side), so it must not trigger a pause just for being entered.
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // act
@@ -383,18 +383,18 @@ public class InMemoryOrderBookAuctionTests
         // anything yet (so hasn't paused anything, per the test above)
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 80, 90);
         book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 10, 200);
 
         // act - a buy at 200 would actually cross and trade against the resting 200 sell, at a
         // price 100 away from the 100 reference - breaching the 50-wide volatility band. The
         // trade is prevented (not executed) and the book pauses instead; neither order fills
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         var events = book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 10, 200);
 
         // assert
@@ -416,7 +416,7 @@ public class InMemoryOrderBookAuctionTests
         Assert.AreEqual(10, sellLevels[0].Quantity); // untouched - the trade was prevented
 
         // orders can still be entered/cancelled while paused
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         book.CreateLimitOrder(CompanyId1, OrderId7, new OrderValidity.Day(), Side.Buy, 10, 90);
         book.CreateLimitOrder(CompanyId2, OrderId8, new OrderValidity.Day(), Side.Sell, 10, 90);
 
@@ -439,7 +439,7 @@ public class InMemoryOrderBookAuctionTests
         // band alongside it
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // act

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookCancelOrderTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -24,14 +24,14 @@ public class InMemoryOrderBookCancelOrderTests
     private static readonly string OrderId4 = "Order4";
     private static readonly string OrderId5 = "Order5";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     [Test]
@@ -40,7 +40,7 @@ public class InMemoryOrderBookCancelOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CancelOrder(CompanyId1, OrderId4, OrderId1);
@@ -82,7 +82,7 @@ public class InMemoryOrderBookCancelOrderTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
         Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CancelOrder(CompanyId3, OrderId4, OrderId3);

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookCircuitBreakerTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -18,12 +18,12 @@ public class InMemoryOrderBookCircuitBreakerTests
     private static readonly string CompanyId1 = "Company1";
     private static readonly string CompanyId2 = "Company2";
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
     }
 
     // CME's equity index levels: halt at 7 and 13 percent, end the trading day at 20. On a
@@ -37,7 +37,7 @@ public class InMemoryOrderBookCircuitBreakerTests
                 new CircuitBreaker(new PriceLimitWidth.Percent(13), HaltFor),
                 new CircuitBreaker(new PriceLimitWidth.Percent(20))
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 1000);
         return book;
     }
@@ -64,7 +64,7 @@ public class InMemoryOrderBookCircuitBreakerTests
         book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
         book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
 
-        TimeProvider.SetCurrentTime(Now1 + HaltFor);
+        Clock.SetCurrentTime(Now1 + HaltFor);
         var events = book.AdvanceTime();
 
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
@@ -85,7 +85,7 @@ public class InMemoryOrderBookCircuitBreakerTests
         // act - the two narrower levels would each have ended by now
         book.CancelOrder(CompanyId1, "Cancel1", "Sell1");
         book.CancelOrder(CompanyId2, "Cancel2", "Buy1");
-        TimeProvider.SetCurrentTime(Now1 + HaltFor + HaltFor);
+        Clock.SetCurrentTime(Now1 + HaltFor + HaltFor);
         var events = book.AdvanceTime();
 
         // assert - still halted, because the level it actually reached never resumes on its own
@@ -104,7 +104,7 @@ public class InMemoryOrderBookCircuitBreakerTests
                 new VolatilityBand(2, PauseFor: TimeSpan.FromMinutes(2)),
                 new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor)
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 1000);
 
         // act

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookCreateOrderTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -26,14 +26,14 @@ public class InMemoryOrderBookCreateOrderTests
     private static readonly string OrderId4 = "Order4";
     private static readonly string OrderId5 = "Order5";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     [TestCase(Side.Buy)]
@@ -79,10 +79,10 @@ public class InMemoryOrderBookCreateOrderTests
     {
         // arrange
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
-        var book = new InMemoryOrderBook(sec, TimeProvider);
+        var book = new InMemoryOrderBook(sec, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side == Side.Buy ? Side.Sell : Side.Buy, 3, 500);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = book.CreateMarketOrder(CompanyId2, OrderId2, new OrderValidity.Day(), side, 5);
@@ -176,7 +176,7 @@ public class InMemoryOrderBookCreateOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, price, triggerPrice);
@@ -215,7 +215,7 @@ public class InMemoryOrderBookCreateOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 2, 500);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 5, triggerPrice);
@@ -252,7 +252,7 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
@@ -323,7 +323,7 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
@@ -394,7 +394,7 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
@@ -470,9 +470,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
@@ -543,9 +543,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 120);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
@@ -671,9 +671,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
@@ -749,9 +749,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
@@ -877,9 +877,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
@@ -950,9 +950,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 80);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
@@ -1078,9 +1078,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
@@ -1156,9 +1156,9 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
@@ -1284,11 +1284,11 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 7);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
@@ -1359,11 +1359,11 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
@@ -1489,11 +1489,11 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
@@ -1569,11 +1569,11 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 4, 110);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 8, 100);
@@ -1699,11 +1699,11 @@ public class InMemoryOrderBookCreateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.UpdateStatus(OrderBookStatus.Closed);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.UpdateStatus(OrderBookStatus.Open);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 8, 100);

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookDailyLimitTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -17,12 +17,12 @@ public class InMemoryOrderBookDailyLimitTests
     private static readonly string CompanyId1 = "Company1";
     private static readonly string CompanyId2 = "Company2";
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
     }
 
     // 5 ticks on a tick size of 10, referenced at 100, so the limits are 50 and 150.
@@ -33,7 +33,7 @@ public class InMemoryOrderBookDailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         return book;
     }
@@ -83,7 +83,7 @@ public class InMemoryOrderBookDailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
 
         book.UpdateStatus(OrderBookStatus.Open, 200);
         book.CreateLimitOrder(CompanyId1, "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
@@ -95,7 +95,7 @@ public class InMemoryOrderBookDailyLimitTests
         // hand it to the sell - and price-time prints at the resting order's price. Left at one
         // instant, an incoming sell would price the trade at its own limit rather than at the
         // buy resting above the ceiling, and there would be nothing out of range to refuse.
-        TimeProvider.SetCurrentTime(Now1.AddMinutes(1));
+        Clock.SetCurrentTime(Now1.AddMinutes(1));
         book.UpdateStatus(OrderBookStatus.Open, 100);
         return book;
     }
@@ -153,7 +153,7 @@ public class InMemoryOrderBookDailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Percent(7))
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 1000);
 
         // act + assert - 1070 is exactly on the ceiling
@@ -173,7 +173,7 @@ public class InMemoryOrderBookDailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Percent(7))
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookIcebergTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -25,14 +25,14 @@ public class InMemoryOrderBookIcebergTests
     private static readonly string OrderId3 = "Order3";
     private static readonly string OrderId1B = "Order1b";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static LevelTrackingOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new LevelTrackingOrderBook(Sec, Clock);
     }
 
     [TestCase(0)]
@@ -78,9 +78,9 @@ public class InMemoryOrderBookIcebergTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
             maxVisibleQuantity: 5);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act - an aggressor larger than the peak
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 8, 100);
@@ -129,7 +129,7 @@ public class InMemoryOrderBookIcebergTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
             maxVisibleQuantity: 5);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act - a single aggressor large enough to consume the whole iceberg
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 12, 100);
@@ -161,7 +161,7 @@ public class InMemoryOrderBookIcebergTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
             maxVisibleQuantity: 3);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act - requires the full 15 to fill immediately or nothing does; the published level
         // only shows 3, but the true available liquidity (20) is what the gate actually checks
@@ -189,13 +189,13 @@ public class InMemoryOrderBookIcebergTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100,
             maxVisibleQuantity: 3);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act - grow the iceberg's total size (hidden reserve only, peak is immutable)
         Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
 
         // a sell should still match the iceberg first - no priority lost
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
@@ -212,13 +212,13 @@ public class InMemoryOrderBookIcebergTests
         // regression - confirms the exception added for icebergs doesn't affect plain orders
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         Book.UpdateOrder(CompanyId1, OrderId1B, OrderId1, newTotalQuantity: 15);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
 
         // a sell should now match Company2 first - Company1 lost priority by growing
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
@@ -236,9 +236,9 @@ public class InMemoryOrderBookIcebergTests
         // a larger one behind it for the aggressor to keep working through
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act - the aggressor itself is an iceberg: total 10, peak 3
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 10, 100,

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookImmediateOrCancelTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -36,14 +36,14 @@ public class InMemoryOrderBookImmediateOrCancelTests
     private static readonly string OrderId5 = "Order5";
     private static readonly string OrderId6 = "Order6";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static LevelTrackingOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new LevelTrackingOrderBook(Sec, Clock);
     }
 
     // ----- no MinQuantity (classic IOC/FillAndKill behavior) -----
@@ -54,7 +54,7 @@ public class InMemoryOrderBookImmediateOrCancelTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 3, 100);
@@ -82,7 +82,7 @@ public class InMemoryOrderBookImmediateOrCancelTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 100);
@@ -146,10 +146,10 @@ public class InMemoryOrderBookImmediateOrCancelTests
     {
         // arrange
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
-        var book = new LevelTrackingOrderBook(sec, TimeProvider);
+        var book = new LevelTrackingOrderBook(sec, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         // NB: a Market + GTC/Day order in the same situation would instead rest the
@@ -185,17 +185,17 @@ public class InMemoryOrderBookImmediateOrCancelTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // IOC stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5, 530, 520);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // only 2 available to fill the stop once triggered
         Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
 
         // act - trade at 520 triggers the stop
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
@@ -240,7 +240,7 @@ public class InMemoryOrderBookImmediateOrCancelTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
@@ -265,9 +265,9 @@ public class InMemoryOrderBookImmediateOrCancelTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act - only fills if the 3@100 and 2@110 levels are summed together
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3,
@@ -298,7 +298,7 @@ public class InMemoryOrderBookImmediateOrCancelTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
@@ -331,18 +331,18 @@ public class InMemoryOrderBookImmediateOrCancelTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // FOK-equivalent stop-limit buy: triggers when price rises to/above 520, then willing to pay up to 530
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 },
             Side.Buy, 5, 530, 520);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // only 2 available - not enough to fill the stop's 5 in full
         Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 530);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
 
         // act - trade at 520 triggers the stop
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);
@@ -398,7 +398,7 @@ public class InMemoryOrderBookImmediateOrCancelTests
         // satisfy a MinQuantity of 3
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
@@ -426,7 +426,7 @@ public class InMemoryOrderBookImmediateOrCancelTests
         // arrange - only 2 available, below the MinQuantity of 3
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2,
@@ -452,18 +452,18 @@ public class InMemoryOrderBookImmediateOrCancelTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 500); // last traded price = 500
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // IOC stop-limit buy: triggers at/above 520, willing to pay up to 530, needs at least 2
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 2 },
             Side.Buy, 5, 530, 520);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // only 1 available once the stop triggers - below its MinQuantity of 2
         Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 1, 530);
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 1, 520);
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
 
         // act - a sell crossing the just-rested 520 buy prints a trade at 520, triggering the stop
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 1, 520);

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookMarketLimitOrderTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -22,14 +22,14 @@ public class InMemoryOrderBookMarketLimitOrderTests
     private static readonly string OrderId2 = "Order2";
     private static readonly string OrderId3 = "Order3";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static LevelTrackingOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new LevelTrackingOrderBook(Sec, Clock);
     }
 
     [Test]
@@ -38,7 +38,7 @@ public class InMemoryOrderBookMarketLimitOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 3);
@@ -68,7 +68,7 @@ public class InMemoryOrderBookMarketLimitOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5);
@@ -102,17 +102,17 @@ public class InMemoryOrderBookMarketLimitOrderTests
         // the second level, contrasted against a MarketLimit order in the identical setup
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
 
-        var marketBook = new LevelTrackingOrderBook(sec, TimeProvider);
+        var marketBook = new LevelTrackingOrderBook(sec, Clock);
         marketBook.UpdateStatus(OrderBookStatus.Open);
         marketBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
         marketBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
 
-        var marketLimitBook = new LevelTrackingOrderBook(sec, TimeProvider);
+        var marketLimitBook = new LevelTrackingOrderBook(sec, Clock);
         marketLimitBook.UpdateStatus(OrderBookStatus.Open);
         marketLimitBook.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 500);
         marketLimitBook.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 600);
 
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var marketEvents = marketBook.CreateMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
@@ -167,7 +167,7 @@ public class InMemoryOrderBookMarketLimitOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateMarketLimitOrder(CompanyId2, OrderId2, new OrderValidity.ImmediateOrCancel(), Side.Buy, 5);
@@ -201,7 +201,7 @@ public class InMemoryOrderBookMarketLimitOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateMarketLimitOrder(CompanyId3, OrderId3,
@@ -227,7 +227,7 @@ public class InMemoryOrderBookMarketLimitOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.Process(new CreateMarketLimitOrder

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookMultipleSessionsTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -27,14 +27,14 @@ public class InMemoryOrderBookMultipleSessionsTests
     private static readonly string OrderId3 = "Order3";
     private static readonly string OrderId4 = "Order4";
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
     private IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(MorningSession);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(MorningSession);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     // The seed InMemoryOrderBook derives from a date, so a test can say which run of ids it
@@ -62,7 +62,7 @@ public class InMemoryOrderBookMultipleSessionsTests
         Book.CloseTrading(endsTradingDay: false);
 
         // act - the same date, so the seed is one the counter has already passed
-        TimeProvider.SetCurrentTime(AfternoonSession);
+        Clock.SetCurrentTime(AfternoonSession);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
         var afternoonId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
@@ -86,7 +86,7 @@ public class InMemoryOrderBookMultipleSessionsTests
         Book.CloseTrading(endsTradingDay: false);
 
         // act
-        TimeProvider.SetCurrentTime(AfternoonSession);
+        Clock.SetCurrentTime(AfternoonSession);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 100);
@@ -127,7 +127,7 @@ public class InMemoryOrderBookMultipleSessionsTests
         Book.CloseTrading();
 
         // act
-        TimeProvider.SetCurrentTime(NextDay);
+        Clock.SetCurrentTime(NextDay);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
         var day2Id = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, new OrderValidity.GoodTilCanceled(),
@@ -162,7 +162,7 @@ public class InMemoryOrderBookMultipleSessionsTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         Book.CloseTrading(endsTradingDay: false);
 
-        TimeProvider.SetCurrentTime(AfternoonSession);
+        Clock.SetCurrentTime(AfternoonSession);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
 
@@ -183,7 +183,7 @@ public class InMemoryOrderBookMultipleSessionsTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         Book.CloseTrading(endsTradingDay: false);
 
-        TimeProvider.SetCurrentTime(AfternoonSession);
+        Clock.SetCurrentTime(AfternoonSession);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
 
@@ -210,7 +210,7 @@ public class InMemoryOrderBookMultipleSessionsTests
         // act
         var breakEvents = Book.CloseTrading(endsTradingDay: false);
 
-        TimeProvider.SetCurrentTime(AfternoonSession);
+        Clock.SetCurrentTime(AfternoonSession);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
         var closeEvents = Book.CloseTrading();

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookPausedHaltedTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -25,14 +25,14 @@ public class InMemoryOrderBookPausedHaltedTests
     private static readonly string OrderId2 = "Order2";
     private static readonly string CancelId1 = "Cancel1";
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
     private IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     [TestCase(OrderBookStatus.Paused)]
@@ -93,7 +93,7 @@ public class InMemoryOrderBookPausedHaltedTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act - only a close that ends the trading day retires day orders
         var events = Book.UpdateStatus(status);
@@ -119,7 +119,7 @@ public class InMemoryOrderBookPausedHaltedTests
         var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
 
         // act
-        TimeProvider.SetCurrentTime(NextDay);
+        Clock.SetCurrentTime(NextDay);
         Book.UpdateStatus(status);
         var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
 
@@ -137,7 +137,7 @@ public class InMemoryOrderBookPausedHaltedTests
         var beforeId = ExchangeOrderIdOf(Book, CompanyId1, OrderId1, Side.Buy, 5, 100);
 
         // act
-        TimeProvider.SetCurrentTime(NextDay);
+        Clock.SetCurrentTime(NextDay);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         var afterId = ExchangeOrderIdOf(Book, CompanyId2, OrderId2, Side.Buy, 5, 90);
 
@@ -202,7 +202,7 @@ public class InMemoryOrderBookPausedHaltedTests
         // arrange - a reference of 100 and a 5-tick volatility band
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
 
@@ -221,7 +221,7 @@ public class InMemoryOrderBookPausedHaltedTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         Book.UpdateStatus(OrderBookStatus.Halted);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateStatus(OrderBookStatus.Closed);

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookPriceBandTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -21,12 +21,12 @@ public class InMemoryOrderBookPriceBandTests
     private static readonly string OrderId3 = "Order3";
     private static readonly string OrderId4 = "Order4";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
     }
 
     [Test]
@@ -36,7 +36,7 @@ public class InMemoryOrderBookPriceBandTests
         // seeded. A security without a band leaves the restriction out rather than configuring
         // one with no width.
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // act
@@ -59,7 +59,7 @@ public class InMemoryOrderBookPriceBandTests
                 new OrderPriceBand(1000),
                 new VolatilityBand(5)
             });
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // act - 200 is far outside the narrow volatility band but well inside the wide entry
@@ -81,7 +81,7 @@ public class InMemoryOrderBookPriceBandTests
         // arrange - band is configured, but there's no anchor to check against yet
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act
@@ -97,7 +97,7 @@ public class InMemoryOrderBookPriceBandTests
         // arrange - band of 5 ticks (50) around a seeded reference of 100, so [50, 150]
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // act/assert - at the reference price
@@ -121,7 +121,7 @@ public class InMemoryOrderBookPriceBandTests
         // arrange - reference seeded at 100, band [50, 150]
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // 160 is outside the original [50, 150] band
@@ -148,7 +148,7 @@ public class InMemoryOrderBookPriceBandTests
         // arrange - reference seeded at 100, band [50, 150]
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
@@ -175,7 +175,7 @@ public class InMemoryOrderBookPriceBandTests
     public void PreOpen_ReferenceMovesFromTheSettlementPriceToTheIndicativePrice()
     {
         // arrange - settled at 100, so the band starts out [50, 150]
-        var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
+        var book = new LevelTrackingOrderBook(BandedSecurity(), Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen, 100);
 
         // assert - 200 is outside the band while the settlement price is still the reference
@@ -201,7 +201,7 @@ public class InMemoryOrderBookPriceBandTests
     public void ContinuousTrading_ReferenceReturnsToTheLastTrade_OnceTheQuoteIsWithdrawn()
     {
         // arrange - open on an auction that prints at 150, which withdraws the quote
-        var book = new LevelTrackingOrderBook(BandedSecurity(), TimeProvider);
+        var book = new LevelTrackingOrderBook(BandedSecurity(), Clock);
         book.UpdateStatus(OrderBookStatus.PreOpen, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 10, 150);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 150);
@@ -226,7 +226,7 @@ public class InMemoryOrderBookPriceBandTests
     // far side of it can never be more than a band away from a limit price still inside it.
     private LevelTrackingOrderBook StopSpreadBook(Security security)
     {
-        var book = new LevelTrackingOrderBook(security, TimeProvider);
+        var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookProcessTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -16,14 +16,14 @@ public class InMemoryOrderBookProcessTests
     private static readonly string OrderId2 = "Order2";
     private static readonly string OrderId3 = "Order3";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static LevelTrackingOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new LevelTrackingOrderBook(Sec, Clock);
     }
 
     [Test]

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookSelfTradePreventionTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -25,14 +25,14 @@ public class InMemoryOrderBookSelfTradePreventionTests
     private static readonly string Smp1 = "Smp1";
     private static readonly string Smp2 = "Smp2";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static LevelTrackingOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new LevelTrackingOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new LevelTrackingOrderBook(Sec, Clock);
     }
 
     [Test]
@@ -41,9 +41,9 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act - same SMP id as the first (older) resting sell, so that one is prevented and
         // the aggressor should fall through to the second (different company) resting sell
@@ -84,7 +84,7 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
@@ -115,7 +115,7 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
@@ -147,7 +147,7 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // sides, but different SMP ids, so it should NOT be prevented
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp2);
@@ -171,7 +171,7 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // not automatic for same-company orders
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
@@ -192,7 +192,7 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act - neither side specifies an instruction
         var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
@@ -220,7 +220,7 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // the resting order's instruction should govern
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelBoth);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
@@ -241,7 +241,7 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // must be excluded from the upfront liquidity check rather than partially filled
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1);
@@ -269,9 +269,9 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // order, so the incoming order should keep going and see the liquidity behind it.
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelResting);
@@ -305,9 +305,9 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // quantity and keep counting past it.
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 10, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 100, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);
@@ -339,9 +339,9 @@ public class InMemoryOrderBookSelfTradePreventionTests
         // second price level at all, no matter how much liquidity is sitting there.
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 2, 100, selfMatchPreventionId: Smp1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 20, 110);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.CreateLimitOrder(CompanyId1, OrderId3, new OrderValidity.ImmediateOrCancel { MinQuantity = 5 }, Side.Buy, 5, 110, selfMatchPreventionId: Smp1, selfMatchPreventionInstruction: SelfMatchPreventionInstruction.CancelAggressor);

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookStopTriggerTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -33,14 +33,14 @@ public class InMemoryOrderBookStopTriggerTests
     private static readonly string OrderId6 = "Order6";
     private static readonly string OrderId7 = "Order7";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     [Test]
@@ -51,22 +51,22 @@ public class InMemoryOrderBookStopTriggerTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         var restingOffer = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 520);
         Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
 
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
         Assert.AreEqual(1, stopEvents.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
         Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
 
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         var restingBid = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 510); // to be hit
         Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
 
         // act - trade at the trigger price
-        TimeProvider.SetCurrentTime(Now6);
+        Clock.SetCurrentTime(Now6);
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
 
         // assert
@@ -96,22 +96,22 @@ public class InMemoryOrderBookStopTriggerTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         var restingBid = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 480);
         Assert.IsInstanceOf<CreateOrderConfirmed>(restingBid[0]);
 
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         var stopEvents = Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 470, 490);
         Assert.AreEqual(1, stopEvents.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(stopEvents[0]);
         Assert.AreEqual(OrderStatus.Hidden, ((CreateOrderConfirmed) stopEvents[0]).Order.Status);
 
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         var restingOffer = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 490); // to be hit
         Assert.IsInstanceOf<CreateOrderConfirmed>(restingOffer[0]);
 
         // act - trade at the trigger price
-        TimeProvider.SetCurrentTime(Now6);
+        Clock.SetCurrentTime(Now6);
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 2, 490);
 
         // assert
@@ -140,13 +140,13 @@ public class InMemoryOrderBookStopTriggerTests
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
         // buy stop above market: only triggers once price rises to/through 510
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 520, 510);
 
         // act - trade at a lower price, moving further away from the trigger
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 490);
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 490);
 
         // assert
@@ -170,13 +170,13 @@ public class InMemoryOrderBookStopTriggerTests
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
         // sell stop below market: only triggers once price falls to/through 490
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 480, 490);
 
         // act - trade at a higher price, moving further away from the trigger
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 510);
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 510);
 
         // assert
@@ -201,13 +201,13 @@ public class InMemoryOrderBookStopTriggerTests
 
         // buy stop market above market; when it triggers there must be resting sell orders for it to
         // convert into a priced limit order - here there are none, so it should be cancelled, not throw
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 510);
 
         // act - trade at the trigger price with no resting sell orders left in the book afterwards
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Sell, 2, 510);
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 510);
 
         // assert
@@ -220,7 +220,7 @@ public class InMemoryOrderBookStopTriggerTests
 
         // an order id is a permanent identity once it completes - reuse is rejected, not silently
         // accepted (see issue #1), and book state remains consistent either way
-        TimeProvider.SetCurrentTime(Now6);
+        Clock.SetCurrentTime(Now6);
         var recreate = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 510);
         var rejected = recreate[0] as CreateOrderRejected;
         Assert.IsNotNull(rejected);
@@ -235,17 +235,17 @@ public class InMemoryOrderBookStopTriggerTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 500);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 500); // last traded price -> 500
 
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 1, 530, 510);
 
-        TimeProvider.SetCurrentTime(Now4);
+        Clock.SetCurrentTime(Now4);
         Book.CreateStopLimitOrder(CompanyId4, OrderId4, new OrderValidity.Day(), Side.Buy, 1, 540, 520);
 
-        TimeProvider.SetCurrentTime(Now5);
+        Clock.SetCurrentTime(Now5);
         Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 2, 520); // resting offer for the gap trade
 
         // act - price gaps straight from 500 to 520, passing through both trigger levels
-        TimeProvider.SetCurrentTime(Now6);
+        Clock.SetCurrentTime(Now6);
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 520);
 
         // assert

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookTimedResumeTests.cs
@@ -2,7 +2,7 @@ using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
 using Circus.OrderBook.Restrictions;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -22,12 +22,12 @@ public class InMemoryOrderBookTimedResumeTests
     private static readonly string OrderId2 = "Order2";
     private static readonly string OrderId3 = "Order3";
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
     }
 
     // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it.
@@ -35,7 +35,7 @@ public class InMemoryOrderBookTimedResumeTests
     {
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, duration)});
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         return book;
     }
@@ -57,7 +57,7 @@ public class InMemoryOrderBookTimedResumeTests
         Assert.AreEqual(OrderBookStatus.Paused, book.Status);
 
         // act
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         var events = book.AdvanceTime();
 
         // assert
@@ -75,7 +75,7 @@ public class InMemoryOrderBookTimedResumeTests
         Breach(book);
 
         // act - one second short
-        TimeProvider.SetCurrentTime(Now1 + PauseFor - TimeSpan.FromSeconds(1));
+        Clock.SetCurrentTime(Now1 + PauseFor - TimeSpan.FromSeconds(1));
         var events = book.AdvanceTime();
 
         // assert
@@ -91,7 +91,7 @@ public class InMemoryOrderBookTimedResumeTests
         Breach(book);
 
         // act - however long passes
-        TimeProvider.SetCurrentTime(Now1.AddDays(1));
+        Clock.SetCurrentTime(Now1.AddDays(1));
         var events = book.AdvanceTime();
 
         // assert
@@ -107,7 +107,7 @@ public class InMemoryOrderBookTimedResumeTests
         Breach(book);
 
         // act
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         var events = book.AdvanceTime();
 
         // assert - the pause resolves into one uncrossing print rather than resuming mid-sweep
@@ -124,7 +124,7 @@ public class InMemoryOrderBookTimedResumeTests
         Breach(book);
 
         // act
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         var events = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 90);
 
         // assert - resumed first, so the order arrived into an open book
@@ -143,7 +143,7 @@ public class InMemoryOrderBookTimedResumeTests
         book.CloseTrading();
 
         // act - the deadline the pause had set comes and goes
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         var events = book.AdvanceTime();
 
         // assert - a closed book must not spring back open
@@ -158,7 +158,7 @@ public class InMemoryOrderBookTimedResumeTests
         var book = PausingBook(PauseFor);
 
         // act
-        TimeProvider.SetCurrentTime(Now1.AddDays(1));
+        Clock.SetCurrentTime(Now1.AddDays(1));
         var events = book.AdvanceTime();
 
         // assert
@@ -197,7 +197,7 @@ public class InMemoryOrderBookTimedResumeTests
             : new IPriceRestriction[] {pausing, halting};
 
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new InMemoryOrderBook(security, TimeProvider, restrictions);
+        var book = new InMemoryOrderBook(security, Clock, restrictions);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act
@@ -209,7 +209,7 @@ public class InMemoryOrderBookTimedResumeTests
 
         // and the halting restriction's own (absent) duration is the one that applies, so
         // nothing resumes when the pausing restriction's would have elapsed
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         book.AdvanceTime();
         Assert.AreEqual(OrderBookStatus.Halted, book.Status);
     }

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateOrderTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -27,14 +27,14 @@ public class InMemoryOrderBookUpdateOrderTests
     private static readonly string OrderId6 = "Order6";
     private static readonly string OrderId7 = "Order7";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     [Test]
@@ -44,7 +44,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
             .OfType<CreateOrderConfirmed>().Single();
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act - reprice loses time priority, so ExchangeOrderId is re-derived (the order is
         // functionally a new entry at the back of the queue), same as a real exchange's own
@@ -67,7 +67,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100)
             .OfType<CreateOrderConfirmed>().Single();
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act - a quantity decrease alone preserves time priority, so ExchangeOrderId must not change
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, newTotalQuantity: 3);
@@ -84,7 +84,7 @@ public class InMemoryOrderBookUpdateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: 110);
@@ -101,7 +101,7 @@ public class InMemoryOrderBookUpdateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, newTotalQuantity: 8);
@@ -119,7 +119,7 @@ public class InMemoryOrderBookUpdateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, quantity);
@@ -159,7 +159,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
         Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, quantity);
@@ -199,7 +199,7 @@ public class InMemoryOrderBookUpdateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, price: price);
@@ -241,7 +241,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, triggerPrice, triggerPrice);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, price: newPrice);
@@ -284,7 +284,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
         Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), side, 3, price, triggerPrice);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, triggerPrice: newTriggerPrice);
@@ -321,7 +321,7 @@ public class InMemoryOrderBookUpdateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, triggerPrice: 110);
@@ -360,7 +360,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
         Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 110);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 5);
@@ -399,7 +399,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
         Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 90);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId3, 1);
@@ -437,7 +437,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 2, 100);
@@ -477,7 +477,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 10, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 4, 100); // partial fill: 4@100
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 6, 110);
@@ -502,9 +502,9 @@ public class InMemoryOrderBookUpdateOrderTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 80);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 3, 70);
@@ -701,7 +701,7 @@ public class InMemoryOrderBookUpdateOrderTests
         var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100)
             .OfType<CreateOrderConfirmed>().Single();
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId1, 5, 110);
@@ -728,7 +728,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
         Book.CancelOrder(CompanyId1, OrderId6, OrderId1);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId1, OrderId4, OrderId6, 5, 110);
@@ -780,7 +780,7 @@ public class InMemoryOrderBookUpdateOrderTests
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 90);
         Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 3, 100);
         Book.CancelOrder(CompanyId3, OrderId7, OrderId3);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateOrder(CompanyId3, OrderId5, OrderId7, 5);

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookUpdateStateTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -23,14 +23,14 @@ public class InMemoryOrderBookUpdateStateTests
     private static readonly string OrderId2 = "Order2";
     private static readonly string OrderId3 = "Order3";
 
-    private static TestTimeProvider TimeProvider;
+    private static ManualClock Clock;
     private static IOrderBook Book;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
-        Book = new InMemoryOrderBook(Sec, TimeProvider);
+        Clock = new ManualClock(Now1);
+        Book = new InMemoryOrderBook(Sec, Clock);
     }
 
     [TestCase(OrderBookStatus.PreOpen)]
@@ -59,9 +59,9 @@ public class InMemoryOrderBookUpdateStateTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-        TimeProvider.SetCurrentTime(Now3);
+        Clock.SetCurrentTime(Now3);
 
         // act
         var events = Book.UpdateStatus(OrderBookStatus.Open);
@@ -134,7 +134,7 @@ public class InMemoryOrderBookUpdateStateTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateStatus(OrderBookStatus.Closed);
@@ -175,7 +175,7 @@ public class InMemoryOrderBookUpdateStateTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
         Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
         Book.CreateStopMarketOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 90);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateStatus(OrderBookStatus.Closed);
@@ -214,7 +214,7 @@ public class InMemoryOrderBookUpdateStateTests
         // arrange
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilCanceled(), Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateStatus(OrderBookStatus.Closed);
@@ -237,7 +237,7 @@ public class InMemoryOrderBookUpdateStateTests
         Book.UpdateStatus(OrderBookStatus.Open);
         var goodTilDate = DateOnly.FromDateTime(Now1).AddDays(1);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateStatus(OrderBookStatus.Closed);
@@ -260,7 +260,7 @@ public class InMemoryOrderBookUpdateStateTests
         Book.UpdateStatus(OrderBookStatus.Open);
         var goodTilDate = DateOnly.FromDateTime(Now1);
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.GoodTilDate { Date = goodTilDate }, Side.Buy, 5, 100);
-        TimeProvider.SetCurrentTime(Now2);
+        Clock.SetCurrentTime(Now2);
 
         // act
         var events = Book.UpdateStatus(OrderBookStatus.Closed);
@@ -291,13 +291,13 @@ public class InMemoryOrderBookUpdateStateTests
         Book.UpdateStatus(OrderBookStatus.Closed); // day 1 close, not due
 
         var day2 = Now1.AddDays(1);
-        TimeProvider.SetCurrentTime(day2);
+        Clock.SetCurrentTime(day2);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
         Book.UpdateStatus(OrderBookStatus.Closed); // day 2 close, still not due
 
         var day3 = Now1.AddDays(2);
-        TimeProvider.SetCurrentTime(day3);
+        Clock.SetCurrentTime(day3);
         Book.UpdateStatus(OrderBookStatus.PreOpen);
         Book.UpdateStatus(OrderBookStatus.Open);
 

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookVelocityLogicTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -18,12 +18,12 @@ public class InMemoryOrderBookVelocityLogicTests
     private static readonly string CompanyId1 = "Company1";
     private static readonly string CompanyId2 = "Company2";
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
     }
 
     // 5 ticks on a tick size of 10, so 50 of price movement inside ten seconds is too fast.
@@ -34,7 +34,7 @@ public class InMemoryOrderBookVelocityLogicTests
                 {
                     new VelocityLimit(5, Window, pauseFor)
                 }),
-            TimeProvider);
+            Clock);
 
     [Test]
     public void StepsArrivingTooQuickly_TripTheLimit()
@@ -48,13 +48,13 @@ public class InMemoryOrderBookVelocityLogicTests
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
 
         // two seconds later, 40 from the first trade and inside the range
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+        Clock.SetCurrentTime(Now1.AddSeconds(2));
         Trade(book, 2, 140);
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
 
         // two seconds later again. This step is only 40 from the last trade, but the trade at
         // 100 is still inside the window and 80 away, which is what the limit is watching for
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+        Clock.SetCurrentTime(Now1.AddSeconds(4));
         Trade(book, 3, 180);
         Assert.AreEqual(OrderBookStatus.Paused, book.Status);
     }
@@ -69,10 +69,10 @@ public class InMemoryOrderBookVelocityLogicTests
         // act
         Trade(book, 1, 100);
 
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(20));
+        Clock.SetCurrentTime(Now1.AddSeconds(20));
         Trade(book, 2, 140);
 
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(40));
+        Clock.SetCurrentTime(Now1.AddSeconds(40));
         Trade(book, 3, 180);
 
         // assert - by the third print the first has long left the window, so nothing measures
@@ -91,14 +91,14 @@ public class InMemoryOrderBookVelocityLogicTests
                 new VolatilityBand(20),
                 new VelocityLimit(5, Window)
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act
         Trade(book, 1, 100);
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+        Clock.SetCurrentTime(Now1.AddSeconds(2));
         Trade(book, 2, 140);
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+        Clock.SetCurrentTime(Now1.AddSeconds(4));
         Trade(book, 3, 180);
 
         // assert - every step was 40, well inside the band's 200, so the band never had an
@@ -115,14 +115,14 @@ public class InMemoryOrderBookVelocityLogicTests
         book.UpdateStatus(OrderBookStatus.Open);
 
         Trade(book, 1, 100);
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(2));
+        Clock.SetCurrentTime(Now1.AddSeconds(2));
         Trade(book, 2, 140);
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(4));
+        Clock.SetCurrentTime(Now1.AddSeconds(4));
         Trade(book, 3, 180);
         Assert.AreEqual(OrderBookStatus.Paused, book.Status);
 
         // act - the orders that tripped it are still crossed, so ending the pause prints them
-        TimeProvider.SetCurrentTime(Now1.AddSeconds(4) + pauseFor);
+        Clock.SetCurrentTime(Now1.AddSeconds(4) + pauseFor);
         var events = book.AdvanceTime();
 
         // assert

--- a/tests/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
+++ b/tests/Circus.Tests/OrderBook/InMemoryOrderBookVolatilityInterruptionTests.cs
@@ -1,7 +1,7 @@
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.OrderBook;
@@ -21,12 +21,12 @@ public class InMemoryOrderBookVolatilityInterruptionTests
     private static readonly string OrderId1 = "Order1";
     private static readonly string OrderId2 = "Order2";
 
-    private TestTimeProvider TimeProvider;
+    private ManualClock Clock;
 
     [SetUp]
     public void SetUp()
     {
-        TimeProvider = new TestTimeProvider(Now1);
+        Clock = new ManualClock(Now1);
     }
 
     // Ordinary range 5 ticks, extended range 8, pausing for two minutes. On a tick size of 10
@@ -43,7 +43,7 @@ public class InMemoryOrderBookVolatilityInterruptionTests
     {
         // arrange - referenced at 100, then a trade at 200 breaches the ordinary range and
         // pauses the book, leaving the two orders crossed and unfilled
-        var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
+        var book = new InMemoryOrderBook(ExtendingSecurity(), Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
@@ -51,7 +51,7 @@ public class InMemoryOrderBookVolatilityInterruptionTests
 
         // act - the pause runs out, but the auction would still print at 200, which is 100 from
         // the reference and so outside the extended range of 80
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         var events = book.AdvanceTime();
 
         // assert - the interruption keeps running rather than resolving out there
@@ -67,12 +67,12 @@ public class InMemoryOrderBookVolatilityInterruptionTests
     public void InterruptionEnds_OnceItWouldPrintInsideTheExtendedRange()
     {
         // arrange - as above, paused with a would-be print at 200
-        var book = new InMemoryOrderBook(ExtendingSecurity(), TimeProvider);
+        var book = new InMemoryOrderBook(ExtendingSecurity(), Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
 
-        TimeProvider.SetCurrentTime(Now1 + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor);
         book.AdvanceTime();
         Assert.AreEqual(OrderBookStatus.Paused, book.Status, "extended once");
 
@@ -84,7 +84,7 @@ public class InMemoryOrderBookVolatilityInterruptionTests
         book.CreateLimitOrder(CompanyId1, "Order3", new OrderValidity.Day(), Side.Sell, 5, 180);
         book.CreateLimitOrder(CompanyId2, "Order4", new OrderValidity.Day(), Side.Buy, 5, 180);
 
-        TimeProvider.SetCurrentTime(Now1 + PauseFor + PauseFor);
+        Clock.SetCurrentTime(Now1 + PauseFor + PauseFor);
         var events = book.AdvanceTime();
 
         // assert - the interruption resolves, printing at a price the ordinary range would
@@ -107,7 +107,7 @@ public class InMemoryOrderBookVolatilityInterruptionTests
                 new VolatilityBand(3),
                 new StaticPriceRange(5)
             });
-        var book = new InMemoryOrderBook(security, TimeProvider);
+        var book = new InMemoryOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // act + assert - 120 is 2 ticks from the reference, inside both

--- a/tests/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
+++ b/tests/Circus.Tests/OrderBook/LevelTrackingOrderBook.cs
@@ -1,8 +1,8 @@
-using Circus.DataProducers;
+using Circus.MarketData;
 using Circus.OrderBook;
 using Circus.OrderBook.Actions;
 using Circus.OrderBook.Events;
-using Circus.TimeProviders;
+using Circus.Time;
 
 namespace Circus.Tests.OrderBook;
 
@@ -20,9 +20,9 @@ internal sealed class LevelTrackingOrderBook : IOrderBook
     private readonly LevelDataProducer _levelDataProducer = new(MaxLevels);
     private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
 
-    public LevelTrackingOrderBook(Security security, ITimeProvider timeProvider)
+    public LevelTrackingOrderBook(Security security, IClock clock)
     {
-        _book = new InMemoryOrderBook(security, timeProvider);
+        _book = new InMemoryOrderBook(security, clock);
     }
 
     public Security Security => _book.Security;

--- a/tests/Circus.Tests/SessionProviderTests.cs
+++ b/tests/Circus.Tests/SessionProviderTests.cs
@@ -1,5 +1,5 @@
 using Circus.OrderBook;
-using Circus.SessionProviders;
+using Circus.Sessions;
 using NUnit.Framework;
 
 namespace Circus.Tests;


### PR DESCRIPTION
Step 7 of the organisation review, following #55–#60. **54 files changed, +398 / −398.** Also carries the **0.7.0 version bump** that's been owed since #58.

## Namespaces named for their subject

Three folders were named for the *shape* of what they contain rather than the subject. `Level`, `TradingSession` and `TradedDataEvent` are domain types that happen to sit near a producer or a provider, and the folder names made that look accidental.

| Was | Now | Public types moved |
|---|---|---|
| `Circus.DataProducers` | `Circus.MarketData` | 13 |
| `Circus.SessionProviders` | `Circus.Sessions` | 4 |
| `Circus.TimeProviders` | `Circus.Time` | 3 (also renamed, below) |

The test project's `DataProducers/` folder follows, so the mirror still holds.

## Clock vocabulary

`ITimeProvider` has been a near-homonym of `System.TimeProvider` since .NET 8 shipped one, and they are not the same abstraction — a reader has to check which is meant.

| Was | Now |
|---|---|
| `ITimeProvider` | `IClock` |
| `UtcTimeProvider` | `SystemClock` |
| `TestTimeProvider` | `ManualClock` |

**`ManualClock` is the rename that was overdue, and it corrects advice I gave in the original review.** I'd suggested moving `TestTimeProvider` into the test project or splitting it into a `Circus.Testing` package, on the assumption it was test-only. It isn't: `Circus.Simulator`, `Circus.Benchmarks` and `Circus.Examples` all use it. Moving it — which is exactly what the `Test` prefix invites — would have broken three non-test projects. It's a controllable clock that happens to be useful in tests, so it stays in the package and now says what it is.

Method names are unchanged (`GetCurrentTime`, `SetCurrentTime`), keeping the diff to naming rather than shape. Adopting `System.TimeProvider` outright remains available later; it's a redesign rather than a rename, since `GetUtcNow()` returns `DateTimeOffset` and that ripples into `InMemoryOrderBook`'s public constructor.

## Version

`PackageVersion` → **0.7.0**. It has been `0.6.0` since #58 relocated 35 public types, and `publish.yml` releases on every push to `main`, so this was already owed before this PR added to the total.

Cumulative public API of the shipped package, versus 0.6.0:

| | count |
|---|---|
| Public types | 76 → 76 |
| Added / removed | 0 / 0 |
| Namespace changed | 52 |
| Renamed | 3 |
| **Unaffected** | **21** |

No type was added or removed across the whole series — every public type that existed at 0.6.0 still exists at 0.7.0, 55 of them under a new name or namespace.

## How this was verified

Same static approach as #58–#60, since there's still no dotnet in the sandbox:

- **Every type reference resolves** — 136 types mapped, all files checked against their visible namespace set. 0 unresolvable. Namespace/folder match holds for every file; extension-method safety re-checked.
- **Substitutions were guarded against clobbering each other.** The script asserts up-front that no replacement *target* contains any other replacement *pattern*, so e.g. rewriting `Circus.TimeProviders` could not later be re-hit by the `ITimeProvider` rule. All patterns are `\b`-anchored with a `(?<[\w.])` lookbehind, which is what kept `Circus.Tests.DataProducers` and any `System.TimeProvider` out of scope.
- **Two things that lookbehind deliberately spared, then handled explicitly.** The test namespace `Circus.Tests.DataProducers` isn't a substring of `Circus.DataProducers`, so it survived the first pass and would have left a namespace/folder mismatch — caught by the folder-match check and fixed. Separately, 299 PascalCase `TimeProvider` field references in the test project were invisible to the camelCase `timeProvider` rule; renamed to `Clock` in a second pass.
- **Public API diffed against the pre-review baseline** (`eaaa7ae`) to produce the table above, scoped to the shipped project so test classes don't inflate the numbers.
- **No stale references** to the old names anywhere in `.cs`, `.csproj`, `.sln`, `.yml` or `.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEKDDgTNbJM6jE8gRcQbZn)_