### PR TITLE
Put the time on the action, and take the clock out of the book

### DIFF
--- a/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
+++ b/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
@@ -1,7 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Circus.Actions;
 using Circus.Simulator;
-using Circus.Time;
 
 namespace Circus.Benchmarks;
 
@@ -28,8 +27,11 @@ public class OrderBookThroughputBenchmarks
     [Benchmark]
     public int ReplayTrace()
     {
-        var book = new OrderBook(_security, new ManualClock(DateTime.UtcNow));
-        book.UpdateStatus(OrderBookStatus.Open);
+        // No clock: the trace carries the time each action happened, so replaying it is the
+        // whole job. Opening is stamped at the first action's instant - the book refuses time
+        // running backwards, and equal stamps are fine.
+        var book = new OrderBook(_security);
+        book.Process(new OpenTrading {Security = _security, Time = _trace[0].Time});
 
         var eventCount = 0;
         foreach (var action in _trace)

--- a/samples/Circus.Examples/MarketDataProducerExample.cs
+++ b/samples/Circus.Examples/MarketDataProducerExample.cs
@@ -14,8 +14,8 @@ public class MarketDataProducerExample
         var sec1 = new Security("GCZ6", SecurityType.Future, 10, 10);
         var sec2 = new Security("SIZ6", SecurityType.Future, 10, 10);
 
-        IOrderBook book1 = new OrderBook(sec1, time);
-        IOrderBook book2 = new OrderBook(sec2, time);
+        IOrderBook book1 = new TimestampingOrderBook(sec1, time);
+        IOrderBook book2 = new TimestampingOrderBook(sec2, time);
 
         var feed1 = new BookFeed();
         var feed2 = new BookFeed();

--- a/samples/Circus.Examples/OrderBookExample.cs
+++ b/samples/Circus.Examples/OrderBookExample.cs
@@ -12,7 +12,7 @@ public static class OrderBookExample
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
 
         var clock = new ManualClock(DateTime.Now);
-        IOrderBook book = new OrderBook(sec, clock);
+        IOrderBook book = new TimestampingOrderBook(sec, clock);
 
         var preOpen = new TimeSpan(1, 0, 0);
         var open = new TimeSpan(1, 10, 0);
@@ -30,31 +30,34 @@ public static class OrderBookExample
     {
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
 
-        var clock = new ManualClock(DateTime.Now);
-        IOrderBook book = new OrderBook(sec, clock);
+        // No clock anywhere: a backtest already knows when everything happened, so it stamps
+        // each action with the data's own time rather than moving a clock the book would read.
+        IOrderBook book = new OrderBook(sec);
 
         var preOpen = new TimeSpan(1, 0, 0);
         var open = new TimeSpan(1, 10, 0);
         var close = new TimeSpan(22, 10, 0);
         var sessionProvider = new SessionProvider(preOpen, open, close);
+
+        // Stamped at the data's time rather than args.Time. A provider catching up reports
+        // boundaries it has already passed, so args.Time can run behind the data being fed -
+        // and the book refuses actions that move time backwards.
+        var dataTime = new DateTime(2020, 1, 1, 1, 30, 0);
         sessionProvider.Changed += (_, args) =>
-        {
-            clock.SetCurrentTime(args.Time);
-            book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay);
-        };
+            book.UpdateStatus(args.Status, endsTradingDay: args.EndsTradingDay, time: dataTime);
 
         // loop through data
         for (var i = 0; i < 100; i++)
         {
-            var time = new DateTime(2020, 1, 1, 1, 30, 0);
+            var time = dataTime;
 
-            // update status with correct time
+            // fires any session boundary the data has passed
             sessionProvider.Update(time);
-            // set data time
-            clock.SetCurrentTime(time);
+
             // pass in data - each order needs its own ClientOrderId, since Buyer's ids are
             // permanently reserved once used
-            Print(book.CreateLimitOrder("Buyer", $"Order{i}", new OrderValidity.Day(), Side.Buy, 3, 100));
+            Print(book.CreateLimitOrder("Buyer", $"Order{i}", new OrderValidity.Day(), Side.Buy, 3, 100,
+                time: time));
         }
     }
 
@@ -63,7 +66,7 @@ public static class OrderBookExample
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10);
 
         var clock = new SystemClock();
-        IOrderBook book = new OrderBook(sec, clock);
+        IOrderBook book = new TimestampingOrderBook(sec, clock);
 
         var preOpen = new TimeSpan(1, 0, 0);
         var open = new TimeSpan(1, 10, 0);

--- a/src/Circus.Simulator/OrderFlowSimulator.cs
+++ b/src/Circus.Simulator/OrderFlowSimulator.cs
@@ -1,7 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
 using Circus.MarketData;
-using Circus.Time;
 
 namespace Circus.Simulator;
 
@@ -40,6 +39,14 @@ public sealed class OrderFlowSimulator
     // stay reproducible for a given seed
     private long _nextId;
 
+    // A fixed epoch rather than DateTime.UtcNow, and a fixed step per action: a trace is
+    // supposed to be reproducible from its seed alone, and stamping it from the wall clock
+    // would have made the times - and so any GTD or rolling-window behaviour reading them -
+    // differ on every run of the same seed.
+    private static readonly DateTime Epoch = new(2000, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Step = TimeSpan.FromMilliseconds(1);
+    private DateTime _time = Epoch;
+
     public OrderFlowSimulator(Security security, SimulatorOptions? options = null, int? seed = null)
     {
         _security = security;
@@ -47,8 +54,8 @@ public sealed class OrderFlowSimulator
         _seed = seed ?? Random.Shared.Next();
         _random = new Random(_seed);
 
-        _shadowBook = new OrderBook(_security, new ManualClock(DateTime.UtcNow));
-        _shadowBook.UpdateStatus(OrderBookStatus.Open);
+        _shadowBook = new OrderBook(_security);
+        _shadowBook.Process(new OpenTrading {Security = _security, Time = _time});
     }
 
     public int Seed => _seed;
@@ -63,7 +70,10 @@ public sealed class OrderFlowSimulator
 
         for (var i = 0; i < actionCount; i++)
         {
-            var action = NextAction();
+            // Stamped here rather than in each Build* method, so every action gets one and the
+            // trace a caller receives is self-contained - replayable without a clock beside it.
+            _time += Step;
+            var action = NextAction() with {Time = _time};
             actions.Add(action);
             Apply(action);
         }

--- a/src/Circus/Actions/OrderBookAction.cs
+++ b/src/Circus/Actions/OrderBookAction.cs
@@ -3,6 +3,16 @@ namespace Circus.Actions;
 public abstract record OrderBookAction
 {
     public required Security Security { get; init; }
+
+    // When the exchange accepted this action, stamped on the way in by whatever owns the clock
+    // - a gateway, a session driver, TimestampingOrderBook. The book reads no clock of its own,
+    // so this is the only time it knows: every event one action produces carries this instant,
+    // and a book fed the same actions twice behaves identically both times. That is what makes
+    // the action stream a complete record, replayable without a recorded clock beside it.
+    //
+    // Not the time the client sent it. An action is the book's input language, not a wire
+    // protocol, and a participant does not get to say when their order arrived.
+    public DateTime Time { get; init; }
 }
 
 public sealed record PreOpenTrading : OrderBookAction
@@ -31,10 +41,10 @@ public sealed record PauseTrading : OrderBookAction;
 // breach calls for a halt; as an action it is the operator-driven equivalent.
 public sealed record HaltTrading : OrderBookAction;
 
-// Nothing to do but let the clock be noticed. A timed interruption ends on its own, and a book
-// with no order flow to carry it there needs something to ask - so a caller driving the book
-// off a clock sends this as it ticks. Carries no time of its own: the book's time provider is
-// the one authority on what time it is.
+// Nothing to report but the time itself. A timed interruption ends on its own, and a book with
+// no order flow to carry it there needs something to ask - so a caller driving the book off a
+// clock sends this as it ticks. Its whole payload is the Time every action carries, which is
+// why it declares no members of its own.
 public sealed record AdvanceTime : OrderBookAction;
 
 public abstract record OrderAction : OrderBookAction

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -2,7 +2,6 @@ using Circus.Actions;
 using Circus.Events;
 using Circus.Matching;
 using Circus.Restrictions;
-using Circus.Time;
 
 namespace Circus;
 
@@ -10,12 +9,19 @@ namespace Circus;
 // does and writes nothing down, which is what a book is rather than a limitation of this one:
 // durability belongs to whatever journals the action stream on the way in, and rebuilds a book
 // by replaying it rather than by asking this one what it holds.
+//
+// A pure function of the actions it is given: it reads no clock and consults nothing ambient,
+// so the same actions always produce the same events. Time arrives stamped on each action -
+// see TimestampingOrderBook for the boundary that does the stamping.
 public class OrderBook : IOrderBook
 {
     private readonly Security _security;
-    private readonly IClock _clock;
 
     private OrderBookStatus _status = OrderBookStatus.Closed;
+
+    // The last action's stamp, kept only to refuse one that moves time backwards. Set from the
+    // first action, so a book has no opinion about what time it is until something tells it.
+    private DateTime _lastActionTime;
     private long _nextSequenceNumber;
     private long? _lastTradedPrice;
 
@@ -94,8 +100,8 @@ public class OrderBook : IOrderBook
 
     private const int MaxClientOrderIdLength = 20;
 
-    public OrderBook(Security security, IClock clock)
-        : this(security, clock, Adapt(security.PriceRestrictions))
+    public OrderBook(Security security)
+        : this(security, Adapt(security.PriceRestrictions))
     {
     }
 
@@ -124,11 +130,9 @@ public class OrderBook : IOrderBook
     // Restrictions supplied outright rather than derived from the security. Internal because it
     // is a seam, not an API: it exists so combinations a Security cannot yet describe - two
     // trade-scoped restrictions disagreeing about severity, say - can still be exercised.
-    internal OrderBook(Security security, IClock clock,
-        IReadOnlyList<IPriceRestriction> priceRestrictions)
+    internal OrderBook(Security security, IReadOnlyList<IPriceRestriction> priceRestrictions)
     {
         _security = security;
-        _clock = clock;
         _priceRestrictions = priceRestrictions;
     }
 
@@ -137,10 +141,27 @@ public class OrderBook : IOrderBook
 
     public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
     {
-        // Read the clock once so all events from this action carry the same timestamp, making
-        // the sequence deterministic and reproducible regardless of when each operation
-        // individually reads system time.
-        var time = _clock.GetCurrentTime();
+        // The action's own stamp is the only time this book has, and every event below carries
+        // it. An unstamped action is a caller that has not decided when its action happened,
+        // which would otherwise land silently at DateTime.MinValue and expire every GTD order
+        // in the book.
+        var time = action.Time;
+        if (time == default)
+            throw new ArgumentException(
+                $"{action.GetType().Name} has no Time. Set it when constructing the action, or " +
+                "drive the book through a TimestampingOrderBook to have a clock stamp it.",
+                nameof(action));
+
+        // Refused rather than clamped: time running backwards means the caller has misordered
+        // its stream, and quietly carrying on would leave a book whose state no replay of those
+        // same actions could reproduce. Equal stamps are fine - a burst can share an instant.
+        if (time < _lastActionTime)
+            throw new ArgumentException(
+                $"{action.GetType().Name} is stamped {time:O}, behind the previous action's " +
+                $"{_lastActionTime:O}. Actions must arrive in time order.",
+                nameof(action));
+
+        _lastActionTime = time;
 
         // Before the action rather than after: an order arriving once the interruption has
         // elapsed should meet a resumed book, not the paused one it would otherwise land in.
@@ -638,7 +659,11 @@ public class OrderBook : IOrderBook
             throw new InvalidOperationException("a phase that matches continuously needs an algorithm");
         var pendingImmediateOrCancelStops = new List<InternalOrder>();
 
-        foreach (var outcome in _matcher.Run(algorithm ?? continuous, continuous, CheckTradeRestrictionBreach))
+        // Closed over the action's instant rather than passed as a method group, so a sweep
+        // judges every price it touches against the same moment the events it emits are stamped
+        // with. A restriction reading a clock here instead would drift within a single action.
+        foreach (var outcome in _matcher.Run(algorithm ?? continuous, continuous,
+                     priceTicks => CheckTradeRestrictionBreach(priceTicks, time)))
             Apply(outcome, events, time, pendingImmediateOrCancelStops);
 
         // Deferred until the sweep is done: the loop only exits once nothing crosses anywhere,
@@ -654,9 +679,8 @@ public class OrderBook : IOrderBook
     // pure query, consulted by Matcher.Run only outside an auction uncrossing pass. Severest
     // rather than first, so the order these are declared in cannot decide whether a breach that
     // halts is served or shadowed by one that merely pauses.
-    private RestrictionBreach? CheckTradeRestrictionBreach(long priceTicks)
+    private RestrictionBreach? CheckTradeRestrictionBreach(long priceTicks, DateTime time)
     {
-        var time = _clock.GetCurrentTime();
         RestrictionBreach? worst = null;
 
         foreach (var restriction in _priceRestrictions)

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -132,52 +132,55 @@ public class OrderBook : IOrderBook
         _priceRestrictions = priceRestrictions;
     }
 
-    private DateTime Now() => _clock.GetCurrentTime();
-
     public Security Security => _security;
     public OrderBookStatus Status => _status;
 
     public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action)
     {
+        // Read the clock once so all events from this action carry the same timestamp, making
+        // the sequence deterministic and reproducible regardless of when each operation
+        // individually reads system time.
+        var time = _clock.GetCurrentTime();
+
         // Before the action rather than after: an order arriving once the interruption has
         // elapsed should meet a resumed book, not the paused one it would otherwise land in.
         // Doing it here rather than only on AdvanceTime means a book being fed order flow
         // resumes on its own, without needing anything to poke it.
-        var events = ResumeIfDue();
-        events.AddRange(Handle(action));
+        var events = ResumeIfDue(time);
+        events.AddRange(Handle(action, time));
 
         // Last, so it reports where the action left the book rather than any state it passed
         // through - a pre-open cancel that uncrosses the book withdraws the quote, and the
         // opening print withdraws it after the trades it produced.
-        var quoteChange = TakeIndicativeQuoteChange();
+        var quoteChange = TakeIndicativeQuoteChange(time);
         if (quoteChange != null)
             events.Add(quoteChange);
 
         return events;
     }
 
-    private List<OrderBookEvent> Handle(OrderBookAction action)
+    private List<OrderBookEvent> Handle(OrderBookAction action, DateTime time)
     {
         return action switch
         {
             CreateLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
-                OrderType.Limit, o.Price, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+                OrderType.Limit, o.Price, null, o.SelfMatchPrevention, o.MaxVisibleQuantity, time),
             CreateMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side, o.Quantity,
-                OrderType.Market, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+                OrderType.Market, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity, time),
             CreateMarketLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                o.Quantity, OrderType.MarketLimit, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+                o.Quantity, OrderType.MarketLimit, null, null, o.SelfMatchPrevention, o.MaxVisibleQuantity, time),
             CreateStopLimitOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                o.Quantity, OrderType.StopLimit, o.Price, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+                o.Quantity, OrderType.StopLimit, o.Price, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity, time),
             CreateStopMarketOrder o => CreateOrder(o.CompanyId, o.ClientOrderId, o.OrderValidity, o.Side,
-                o.Quantity, OrderType.StopMarket, null, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity),
+                o.Quantity, OrderType.StopMarket, null, o.TriggerPrice, o.SelfMatchPrevention, o.MaxVisibleQuantity, time),
             UpdateOrder update => UpdateOrder(update.CompanyId, update.ClientOrderId,
-                update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice),
-            CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId),
-            PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice),
-            OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice),
-            CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay),
-            PauseTrading => UpdateStatus(OrderBookStatus.Paused),
-            HaltTrading => UpdateStatus(OrderBookStatus.Halted),
+                update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice, time),
+            CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId, time),
+            PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice, true, StatusChangeReason.Requested, time),
+            OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice, true, StatusChangeReason.Requested, time),
+            CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay, StatusChangeReason.Requested, time),
+            PauseTrading => UpdateStatus(OrderBookStatus.Paused, null, true, StatusChangeReason.Requested, time),
+            HaltTrading => UpdateStatus(OrderBookStatus.Halted, null, true, StatusChangeReason.Requested, time),
 
             // Carries nothing and does nothing: the work is the due-interruption check every
             // Process already runs, and this is how a caller with no order flow reaches it.
@@ -188,20 +191,20 @@ public class OrderBook : IOrderBook
 
     // A timed interruption returns the book to whatever it interrupted. Cleared by any explicit
     // status change, so a session closing over a pause ends it rather than being undone by it.
-    private List<OrderBookEvent> ResumeIfDue()
+    private List<OrderBookEvent> ResumeIfDue(DateTime time)
     {
-        if (_resumeAt == null || Now() < _resumeAt.Value)
+        if (_resumeAt == null || time < _resumeAt.Value)
             return new List<OrderBookEvent>();
 
         _resumeAt = null;
-        return UpdateStatus(_resumeTo, reason: StatusChangeReason.InterruptionElapsed);
+        return UpdateStatus(_resumeTo, null, true, StatusChangeReason.InterruptionElapsed, time);
     }
 
     // Asked of the phase's own algorithm, so a quote exists exactly when there is an auction
     // to report one for - the start-of-day session or a volatility pause. Continuous trading
     // declines (price-time prints at as many prices as a sweep touches, not one), as does an
     // uncrossed book and a phase with no algorithm at all.
-    private OrderBookEvent? TakeIndicativeQuoteChange()
+    private OrderBookEvent? TakeIndicativeQuoteChange(DateTime time)
     {
         var algorithm = CurrentPhase.Algorithm;
 
@@ -222,80 +225,80 @@ public class OrderBook : IOrderBook
         foreach (var restriction in _priceRestrictions)
             restriction.OnIndicativePrice(quote?.PriceTicks);
 
-        return new IndicativePriceChanged(_security, Now(),
+        return new IndicativePriceChanged(_security, time,
             quote.HasValue ? (decimal?) ToDecimal(quote.Value.PriceTicks) : null, quote?.Quantity ?? 0);
     }
 
     private List<OrderBookEvent> CreateOrder(string companyId, string clientOrderId, OrderValidity validity,
         Side side, int quantity, OrderType type, decimal? price = null, decimal? triggerPrice = null,
-        SelfMatchPrevention? selfMatchPrevention = null, int? maxVisibleQuantity = null)
+        SelfMatchPrevention? selfMatchPrevention = null, int? maxVisibleQuantity = null, DateTime time = default)
     {
         var selfMatchPreventionId = selfMatchPrevention?.Id;
         var selfMatchPreventionInstruction = selfMatchPrevention?.Instruction;
         var status = triggerPrice.HasValue ? OrderStatus.Hidden : OrderStatus.Working;
 
         if (!CurrentPhase.AcceptsOrderActions)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketClosed);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketClosed, time);
         if (type == OrderType.Market && !CurrentPhase.AcceptsMarketOrders)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketOrdersNotAccepted);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MarketOrdersNotAccepted, time);
         if (string.IsNullOrEmpty(clientOrderId))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdRequired);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdRequired, time);
         if (clientOrderId.Length > MaxClientOrderIdLength)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.ClientOrderIdTooLong, time);
         if (string.IsNullOrEmpty(companyId))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdRequired);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdRequired, time);
         if (companyId.Length > MaxClientOrderIdLength)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdTooLong);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.CompanyIdTooLong, time);
         if (selfMatchPreventionId != null && selfMatchPreventionId.Length > MaxClientOrderIdLength)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.SelfMatchPreventionIdTooLong);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.SelfMatchPreventionIdTooLong, time);
         if (quantity < 1)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidQuantity);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidQuantity, time);
         if (!TryConvertToTicks(price, out var priceTicks))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement, time);
         if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidPriceIncrement, time);
         if (triggerTicks != null && priceTicks != null && side == Side.Buy && priceTicks < triggerTicks)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanPrice);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanPrice, time);
         if (triggerTicks != null && priceTicks != null && side == Side.Sell && priceTicks > triggerTicks)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, time);
         if (triggerTicks != null && priceTicks != null &&
             !AllowsStopSpread(triggerTicks.Value, priceTicks.Value))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceTooFarFromPrice);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceTooFarFromPrice, time);
         if (triggerTicks != null && !_lastTradedPrice.HasValue)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoLastTradedPrice);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoLastTradedPrice, time);
         if (triggerTicks != null && side == Side.Buy && triggerTicks <= _lastTradedPrice)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, time);
         if (triggerTicks != null && side == Side.Sell && triggerTicks >= _lastTradedPrice)
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice);
-        if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
-            return RejectCreate(companyId, clientOrderId, entryRefusal);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, time);
+        if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value, time) is { } entryRefusal)
+            return RejectCreate(companyId, clientOrderId, entryRefusal, time);
         if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int minQty } && (minQty < 1 || minQty > quantity))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MinQuantityOutOfRange);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MinQuantityOutOfRange, time);
         if (maxVisibleQuantity.HasValue && (maxVisibleQuantity < 1 || maxVisibleQuantity > quantity))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MaxVisibleQuantityOutOfRange);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.MaxVisibleQuantityOutOfRange, time);
         if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var existingOrder))
         {
             return existingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
-                ? RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderInBook)
-                : RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderIdAlreadyUsed);
+                ? RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderInBook, time)
+                : RejectCreate(companyId, clientOrderId, OrderRejectedReason.OrderIdAlreadyUsed, time);
         }
 
         if (type == OrderType.Market || type == OrderType.MarketLimit)
         {
             var protectionTicks = type == OrderType.MarketLimit ? 0 : _security.MarketOrderProtectionTicks;
             if(!TryGetLimitPrice(side, protectionTicks, out priceTicks))
-                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoOrdersToMatchMarketOrder);
+                return RejectCreate(companyId, clientOrderId, OrderRejectedReason.NoOrdersToMatchMarketOrder, time);
         }
 
         if (validity is OrderValidity.ImmediateOrCancel { MinQuantity: int gateMinQty } && !triggerTicks.HasValue &&
             !_matcher.HasSufficientLiquidity(side, priceTicks!.Value, gateMinQty, selfMatchPreventionId,
                 selfMatchPreventionInstruction))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InsufficientLiquidityForMinQuantity);
-        if (validity is OrderValidity.GoodTilDate { Date: var goodTilDate } && goodTilDate < DateOnly.FromDateTime(Now()))
-            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidExpireDate);
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InsufficientLiquidityForMinQuantity, time);
+        if (validity is OrderValidity.GoodTilDate { Date: var goodTilDate } && goodTilDate < DateOnly.FromDateTime(time))
+            return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidExpireDate, time);
 
         _nextSequenceNumber++;
-        var order = new InternalOrder(_nextSequenceNumber, companyId, clientOrderId, _security, Now(), status,
+        var order = new InternalOrder(_nextSequenceNumber, companyId, clientOrderId, _security, time, status,
             type, validity, side, quantity, priceTicks, triggerTicks, selfMatchPreventionId,
             selfMatchPreventionInstruction, maxVisibleQuantity);
 
@@ -304,11 +307,11 @@ public class OrderBook : IOrderBook
         _matcher.Rest(order);
 
         List<OrderBookEvent> events = new();
-        events.Add(new CreateOrderConfirmed(_security, Now(), companyId, order.ToOrder()));
-        Match(events);
+        events.Add(new CreateOrderConfirmed(_security, time, companyId, order.ToOrder()));
+        Match(events, time: time);
 
         if (order.Validity is OrderValidity.ImmediateOrCancel && order.Status == OrderStatus.Working)
-            events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
+            events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled, time));
 
         return events;
     }
@@ -354,9 +357,8 @@ public class OrderBook : IOrderBook
     // Null when every entry-scoped restriction allows the price, otherwise the rejection the
     // first refusing one asks for - a band and a daily limit turn an order away for reasons
     // that read differently to whoever sent it.
-    private OrderRejectedReason? FindOrderEntryRefusal(long priceTicks)
+    private OrderRejectedReason? FindOrderEntryRefusal(long priceTicks, DateTime time)
     {
-        var time = Now();
         foreach (var restriction in _priceRestrictions)
         {
             if (restriction.Scope.HasFlag(RestrictionScope.OrderEntry) &&
@@ -376,53 +378,53 @@ public class OrderBook : IOrderBook
 
     // Only ever called on an order currently resting in the working book (a FAK remainder or
     // a self-match-prevention cancel during Match()) - never a still-Hidden stop order.
-    private OrderBookEvent CancelRemainder(InternalOrder order, OrderCancelledReason reason)
+    private OrderBookEvent CancelRemainder(InternalOrder order, OrderCancelledReason reason, DateTime time)
     {
         var previousClientOrderId = order.ClientOrderId;
         var previousPrice = ToDecimal(order.Price!.Value);
         var previousQuantity = order.DisplayedQuantity;
-        order.Cancel(Now());
+        order.Cancel(time);
         CompleteOrder(order);
-        return new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
+        return new CancelOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(), previousClientOrderId,
             reason, previousPrice, previousQuantity);
     }
 
     private List<OrderBookEvent> UpdateOrder(string companyId, string clientOrderId, string previousClientOrderId,
-        int? newTotalQuantity = null, decimal? price = null, decimal? triggerPrice = null)
+        int? newTotalQuantity = null, decimal? price = null, decimal? triggerPrice = null, DateTime time = default)
     {
         if (!CurrentPhase.AcceptsOrderActions)
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed, time: time);
         if (string.IsNullOrEmpty(clientOrderId))
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired, time: time);
         if (clientOrderId.Length > MaxClientOrderIdLength)
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong, time: time);
         if (string.IsNullOrEmpty(companyId))
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired, time: time);
         if (companyId.Length > MaxClientOrderIdLength)
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong, time: time);
         if (newTotalQuantity == null && price == null && triggerPrice == null)
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.NoChange);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.NoChange, time: time);
         if (newTotalQuantity != null && newTotalQuantity < 1)
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidQuantity);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidQuantity, time: time);
         if (!TryConvertToTicks(price, out var priceTicks))
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement, time: time);
         if (!TryConvertToTicks(triggerPrice, out var triggerTicks))
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement);
-        if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value) is { } entryRefusal)
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, entryRefusal);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.InvalidPriceIncrement, time: time);
+        if (priceTicks.HasValue && FindOrderEntryRefusal(priceTicks.Value, time) is { } entryRefusal)
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, entryRefusal, time: time);
         if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
             order.ClientOrderId != previousClientOrderId)
-            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
+            return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook, time: time);
         if (order.Status is not (OrderStatus.Working or OrderStatus.Hidden))
             return RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.TooLateToCancel,
-                order.ExchangeOrderId);
+                order.ExchangeOrderId, time);
         if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var conflictingOrder))
         {
             return conflictingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
                 ? RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderInBook,
-                    order.ExchangeOrderId)
+                    order.ExchangeOrderId, time)
                 : RejectUpdate(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderIdAlreadyUsed,
-                    order.ExchangeOrderId);
+                    order.ExchangeOrderId, time);
         }
 
         if (order.Status == OrderStatus.Hidden)
@@ -432,21 +434,21 @@ public class OrderBook : IOrderBook
 
             if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Buy && newPriceTicks < newTriggerTicks)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                    OrderRejectedReason.TriggerPriceMustBeLessThanPrice, order.ExchangeOrderId);
+                    OrderRejectedReason.TriggerPriceMustBeLessThanPrice, order.ExchangeOrderId, time);
             if (newTriggerTicks != null && newPriceTicks != null && order.Side == Side.Sell && newPriceTicks > newTriggerTicks)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                    OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, order.ExchangeOrderId);
+                    OrderRejectedReason.TriggerPriceMustBeGreaterThanPrice, order.ExchangeOrderId, time);
             if (newTriggerTicks != null && newPriceTicks != null &&
                 !AllowsStopSpread(newTriggerTicks.Value, newPriceTicks.Value))
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                    OrderRejectedReason.TriggerPriceTooFarFromPrice, order.ExchangeOrderId);
+                    OrderRejectedReason.TriggerPriceTooFarFromPrice, order.ExchangeOrderId, time);
 
             if (triggerTicks != null && order.Side == Side.Buy && triggerTicks <= _lastTradedPrice)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                    OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, order.ExchangeOrderId);
+                    OrderRejectedReason.TriggerPriceMustBeGreaterThanLastTradedPrice, order.ExchangeOrderId, time);
             if (triggerTicks != null && order.Side == Side.Sell && triggerTicks >= _lastTradedPrice)
                 return RejectUpdate(companyId, clientOrderId, previousClientOrderId,
-                    OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, order.ExchangeOrderId);
+                    OrderRejectedReason.TriggerPriceMustBeLessThanLastTradedPrice, order.ExchangeOrderId, time);
         }
         else
         {
@@ -464,13 +466,13 @@ public class OrderBook : IOrderBook
 
         if (newTotalQuantity <= order.FilledQuantity)
         {
-            order.Cancel(Now(), clientOrderId);
+            order.Cancel(time, clientOrderId);
             _clientOrderIndex[(companyId, clientOrderId)] = order;
             CompleteOrder(order);
 
             return new List<OrderBookEvent>
             {
-                new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
+                new CancelOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(), previousClientOrderId,
                     OrderCancelledReason.UpdatedQuantityLowerThanFilledQuantity, previousPrice, previousQuantity)
             };
         }
@@ -500,83 +502,83 @@ public class OrderBook : IOrderBook
         // captured before Update() below, which - since sequenceNumber may have just been
         // bumped above - is where ExchangeOrderId (derived from SequenceNumber) actually changes.
         var previousExchangeOrderId = order.ExchangeOrderId;
-        order.Update(sequenceNumber, Now(), newTotalQuantity, triggerTicks, priceTicks, clientOrderId);
+        order.Update(sequenceNumber, time, newTotalQuantity, triggerTicks, priceTicks, clientOrderId);
         _clientOrderIndex[(companyId, clientOrderId)] = order;
 
         List<OrderBookEvent> events = new();
-        events.Add(new UpdateOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
+        events.Add(new UpdateOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(), previousClientOrderId,
             previousExchangeOrderId, previousPrice, previousQuantity));
-        Match(events);
+        Match(events, time: time);
         return events;
     }
 
-    private List<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId)
+    private List<OrderBookEvent> CancelOrder(string companyId, string clientOrderId, string previousClientOrderId, DateTime time)
     {
         if (!CurrentPhase.AcceptsOrderActions)
-            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed);
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.MarketClosed, time: time);
         if (string.IsNullOrEmpty(clientOrderId))
-            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired);
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdRequired, time: time);
         if (clientOrderId.Length > MaxClientOrderIdLength)
-            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong);
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.ClientOrderIdTooLong, time: time);
         if (string.IsNullOrEmpty(companyId))
-            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired);
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdRequired, time: time);
         if (companyId.Length > MaxClientOrderIdLength)
-            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong);
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.CompanyIdTooLong, time: time);
         if (!_clientOrderIndex.TryGetValue((companyId, previousClientOrderId), out var order) ||
             order.ClientOrderId != previousClientOrderId)
-            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook);
+            return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderNotInBook, time: time);
         if (order.Status is not (OrderStatus.Working or OrderStatus.Hidden))
             return RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.TooLateToCancel,
-                order.ExchangeOrderId);
+                order.ExchangeOrderId, time);
         if (_clientOrderIndex.TryGetValue((companyId, clientOrderId), out var conflictingOrder))
         {
             return conflictingOrder.Status is OrderStatus.Working or OrderStatus.Hidden
                 ? RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderInBook,
-                    order.ExchangeOrderId)
+                    order.ExchangeOrderId, time)
                 : RejectCancel(companyId, clientOrderId, previousClientOrderId, OrderRejectedReason.OrderIdAlreadyUsed,
-                    order.ExchangeOrderId);
+                    order.ExchangeOrderId, time);
         }
 
         var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
         var previousQuantity = order.DisplayedQuantity;
-        order.Cancel(Now(), clientOrderId);
+        order.Cancel(time, clientOrderId);
         _clientOrderIndex[(companyId, clientOrderId)] = order;
         CompleteOrder(order);
 
         return new List<OrderBookEvent>
         {
-            new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousClientOrderId,
+            new CancelOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(), previousClientOrderId,
                 OrderCancelledReason.Cancelled, previousPrice, previousQuantity)
         };
     }
 
-    private List<OrderBookEvent> RejectCreate(string companyId, string clientOrderId, OrderRejectedReason reason) =>
-        new() {new CreateOrderRejected(_security, Now(), companyId, clientOrderId, reason)};
+    private List<OrderBookEvent> RejectCreate(string companyId, string clientOrderId, OrderRejectedReason reason, DateTime time) =>
+        new() {new CreateOrderRejected(_security, time, companyId, clientOrderId, reason)};
 
     private List<OrderBookEvent> RejectUpdate(string companyId, string clientOrderId, string previousClientOrderId,
-            OrderRejectedReason reason, string? exchangeOrderId = null) =>
+            OrderRejectedReason reason, string? exchangeOrderId = null, DateTime time = default) =>
         new()
         {
-            new UpdateOrderRejected(_security, Now(), companyId, clientOrderId, previousClientOrderId,
+            new UpdateOrderRejected(_security, time, companyId, clientOrderId, previousClientOrderId,
                 exchangeOrderId, reason)
         };
 
     private List<OrderBookEvent> RejectCancel(string companyId, string clientOrderId, string previousClientOrderId,
-            OrderRejectedReason reason, string? exchangeOrderId = null) =>
+            OrderRejectedReason reason, string? exchangeOrderId = null, DateTime time = default) =>
         new()
         {
-            new CancelOrderRejected(_security, Now(), companyId, clientOrderId, previousClientOrderId,
+            new CancelOrderRejected(_security, time, companyId, clientOrderId, previousClientOrderId,
                 exchangeOrderId, reason)
         };
 
-    private OrderBookEvent ExpireOrder(InternalOrder order)
+    private OrderBookEvent ExpireOrder(InternalOrder order, DateTime time)
     {
         var previousPrice = order.Status == OrderStatus.Hidden ? (decimal?) null : ToDecimal(order.Price!.Value);
         var previousQuantity = order.DisplayedQuantity;
-        order.Expire(Now());
+        order.Expire(time);
         CompleteOrder(order);
 
-        return new ExpireOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(), previousPrice,
+        return new ExpireOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(), previousPrice,
             previousQuantity);
     }
 
@@ -624,7 +626,7 @@ public class OrderBook : IOrderBook
     // The single gate on whether trading may happen right now, which is why an exiting
     // auction's print goes through it too: a phase left for one that does not trade abandons
     // the orders it accumulated rather than crossing them.
-    private void Match(List<OrderBookEvent> events, IMatchingAlgorithm? algorithm = null)
+    private void Match(List<OrderBookEvent> events, IMatchingAlgorithm? algorithm = null, DateTime time = default)
     {
         var phase = CurrentPhase;
         if (!phase.MatchesContinuously)
@@ -634,7 +636,6 @@ public class OrderBook : IOrderBook
 
         var continuous = phase.Algorithm ??
             throw new InvalidOperationException("a phase that matches continuously needs an algorithm");
-        var time = Now();
         var pendingImmediateOrCancelStops = new List<InternalOrder>();
 
         foreach (var outcome in _matcher.Run(algorithm ?? continuous, continuous, CheckTradeRestrictionBreach))
@@ -645,7 +646,7 @@ public class OrderBook : IOrderBook
         foreach (var order in pendingImmediateOrCancelStops)
         {
             if (order.RemainingQuantity > 0)
-                events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled));
+                events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled, time));
         }
     }
 
@@ -655,7 +656,7 @@ public class OrderBook : IOrderBook
     // halts is served or shadowed by one that merely pauses.
     private RestrictionBreach? CheckTradeRestrictionBreach(long priceTicks)
     {
-        var time = Now();
+        var time = _clock.GetCurrentTime();
         RestrictionBreach? worst = null;
 
         foreach (var restriction in _priceRestrictions)
@@ -694,7 +695,7 @@ public class OrderBook : IOrderBook
     // Only where a print is what would end it: a phase leaving for one that does not trade
     // abandons its orders rather than crossing them, so there is no price to hold to anything -
     // and a close must never be blocked by a price range.
-    private RestrictionBreach? CheckResumptionRefusal(OrderBookStatus arrivingStatus)
+    private RestrictionBreach? CheckResumptionRefusal(OrderBookStatus arrivingStatus, DateTime time)
     {
         var departing = CurrentPhase;
         if (!departing.PrintsOnExit || !_phases[arrivingStatus].MatchesContinuously)
@@ -703,7 +704,6 @@ public class OrderBook : IOrderBook
         if (!departing.Algorithm!.TryQuoteIndicative(_matcher.Working, out var priceTicks, out _))
             return null;
 
-        var time = Now();
         foreach (var restriction in _priceRestrictions)
         {
             // First refusal rather than the severest: every restriction refusing here is asking
@@ -736,9 +736,9 @@ public class OrderBook : IOrderBook
         {
             case SelfMatchDetected(var resting, var aggressor, var instruction):
                 if (instruction != SelfMatchPreventionInstruction.CancelAggressor)
-                    events.Add(CancelRemainder(resting, OrderCancelledReason.SelfMatchPrevention));
+                    events.Add(CancelRemainder(resting, OrderCancelledReason.SelfMatchPrevention, time));
                 if (instruction != SelfMatchPreventionInstruction.CancelResting)
-                    events.Add(CancelRemainder(aggressor, OrderCancelledReason.SelfMatchPrevention));
+                    events.Add(CancelRemainder(aggressor, OrderCancelledReason.SelfMatchPrevention, time));
                 break;
 
             case TradeExecuted(var resting, var aggressor, var priceTicks, var quantity, var usesFullRemainingQuantity):
@@ -749,7 +749,7 @@ public class OrderBook : IOrderBook
             // trade at the limit and back inside it. Only the status is spared - the run has
             // already ended, since Matcher.Run stops on any breach.
             case TradeRestrictionBreached(var blockedTicks, {Action: RestrictionBreachAction.Block}):
-                TakeLimitStateChange(blockedTicks, events);
+                TakeLimitStateChange(blockedTicks, events, time);
                 break;
 
             // Assigned directly rather than routed through UpdateStatus: this runs inside the
@@ -763,8 +763,8 @@ public class OrderBook : IOrderBook
                 _status = breach.Action == RestrictionBreachAction.Halt
                     ? OrderBookStatus.Halted
                     : OrderBookStatus.Paused;
-                _resumeAt = breach.ResumeAfter.HasValue ? Now() + breach.ResumeAfter.Value : null;
-                events.Add(new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction,
+                _resumeAt = breach.ResumeAfter.HasValue ? time + breach.ResumeAfter.Value : null;
+                events.Add(new StatusChanged(_security, time, _status, StatusChangeReason.PriceRestriction,
                     _resumeAt));
                 break;
 
@@ -778,7 +778,7 @@ public class OrderBook : IOrderBook
     // every sweep that follows, and saying so once is enough. Direction comes from where the
     // blocked price sits against the last one that traded; with nothing traded yet there is
     // nothing to compare it to, and the price alone says where the limit is.
-    private void TakeLimitStateChange(long blockedTicks, List<OrderBookEvent> events)
+    private void TakeLimitStateChange(long blockedTicks, List<OrderBookEvent> events, DateTime time)
     {
         var side = _lastTradedPrice switch
         {
@@ -792,19 +792,19 @@ public class OrderBook : IOrderBook
             return;
 
         _limitState = side;
-        events.Add(new LimitStateChanged(_security, Now(), side, ToDecimal(blockedTicks)));
+        events.Add(new LimitStateChanged(_security, time, side, ToDecimal(blockedTicks)));
     }
 
     // A print means the market is trading again, wherever it is trading. Releasing on any trade
     // rather than on one strictly inside the limits is deliberate: trading at the limit is the
     // market working, not the market stuck.
-    private void ReleaseLimitState(List<OrderBookEvent> events)
+    private void ReleaseLimitState(List<OrderBookEvent> events, DateTime time)
     {
         if (_limitState == null)
             return;
 
         _limitState = null;
-        events.Add(new LimitStateChanged(_security, Now(), null, null));
+        events.Add(new LimitStateChanged(_security, time, null, null));
     }
 
     private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
@@ -845,7 +845,7 @@ public class OrderBook : IOrderBook
         if (aggressorReplenish != null)
             events.Add(aggressorReplenish);
 
-        ReleaseLimitState(events);
+        ReleaseLimitState(events, time);
 
         if (_lastTradedPrice != priceTicks)
         {
@@ -875,12 +875,12 @@ public class OrderBook : IOrderBook
             {
                 var previousClientOrderId = order.ClientOrderId;
                 var previousQuantity = order.DisplayedQuantity;
-                order.Cancel(Now());
+                order.Cancel(time);
                 FinishOrder(order);
 
                 // FinishOrder, not CompleteOrder: already unrested above and never reached the
                 // working book, which is also why previousPrice is null.
-                events.Add(new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(),
+                events.Add(new CancelOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
                     previousClientOrderId, OrderCancelledReason.NoOrdersToMatchMarketOrder, null,
                     previousQuantity));
                 continue;
@@ -892,10 +892,10 @@ public class OrderBook : IOrderBook
             {
                 var previousClientOrderId = order.ClientOrderId;
                 var previousQuantity = order.DisplayedQuantity;
-                order.Cancel(Now());
+                order.Cancel(time);
                 FinishOrder(order);
 
-                events.Add(new CancelOrderConfirmed(_security, Now(), order.CompanyId, order.ToOrder(),
+                events.Add(new CancelOrderConfirmed(_security, time, order.CompanyId, order.ToOrder(),
                     previousClientOrderId, OrderCancelledReason.ImmediateOrCancelNotFilled, null,
                     previousQuantity));
                 continue;
@@ -918,7 +918,7 @@ public class OrderBook : IOrderBook
     // last of them ends it. The phase table stays the authority on whether a phase expires day
     // orders at all - this only says whether this particular close is that day's last.
     private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null,
-        bool endsTradingDay = true, StatusChangeReason reason = StatusChangeReason.Requested)
+        bool endsTradingDay = true, StatusChangeReason reason = StatusChangeReason.Requested, DateTime time = default)
     {
         if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
         {
@@ -931,15 +931,15 @@ public class OrderBook : IOrderBook
         if (!_phases.ContainsKey(status))
             throw new ArgumentOutOfRangeException(nameof(status), status, "no phase configured for this status");
 
-        var extension = CheckResumptionRefusal(status);
+        var extension = CheckResumptionRefusal(status, time);
         if (extension != null)
         {
             // Nothing has moved yet, so refusing simply leaves the book where it was. The status
             // is unchanged and re-reported: what a subscriber needs to know is that the
             // interruption is still running and why, which is the same thing a fresh one says.
-            _resumeAt = extension.Value.ResumeAfter.HasValue ? Now() + extension.Value.ResumeAfter.Value : null;
+            _resumeAt = extension.Value.ResumeAfter.HasValue ? time + extension.Value.ResumeAfter.Value : null;
             return new List<OrderBookEvent>
-                {new StatusChanged(_security, Now(), _status, StatusChangeReason.PriceRestriction, _resumeAt)};
+                {new StatusChanged(_security, time, _status, StatusChangeReason.PriceRestriction, _resumeAt)};
         }
 
         // Any transition supersedes a pending one, so a session closing over a running pause
@@ -959,37 +959,38 @@ public class OrderBook : IOrderBook
             // hold, and _orders/_completedOrders are keyed on exactly that. Math.Max is also
             // what keeps a replay whose clock moves backwards from colliding - a run of ids
             // that no longer encodes its date beats one that repeats itself.
-            var date = Now();
-            var seed = ((date.Year * 10000) + (date.Month * 100) + date.Day) * 10000000000L;
+            var seed = ((time.Year * 10000) + (time.Month * 100) + time.Day) * 10000000000L;
             _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
         }
 
         // _resumeAt was cleared above, so this reports nothing pending - which is what an
         // explicit transition means, having just superseded whatever was.
-        var events = new List<OrderBookEvent> {new StatusChanged(_security, Now(), _status, reason, _resumeAt)};
+        var events = new List<OrderBookEvent> {new StatusChanged(_security, time, _status, reason, _resumeAt)};
 
         // A quoting phase has been accumulating orders for a print, and leaving it is where
         // that print happens - so a second auction phase would need nothing changed here.
         // Match declines it if the phase just entered does not trade.
         if (departing.PrintsOnExit)
-            Match(events, departing.Algorithm);
+            Match(events, departing.Algorithm, time);
 
         // Then trading continues under whatever governs the phase just entered.
-        Match(events);
+        Match(events, time: time);
 
         if (arriving.ExpiresDayOrders && endsTradingDay)
-            events.AddRange(ExpireOrders());
+            events.AddRange(ExpireOrders(time));
 
         return events;
     }
 
-    private IEnumerable<OrderBookEvent> ExpireOrders()
+    private IEnumerable<OrderBookEvent> ExpireOrders(DateTime time)
     {
-        var today = DateOnly.FromDateTime(Now());
+        var today = DateOnly.FromDateTime(time);
         var orders = _orders.Values.Where(o =>
             o.Validity is OrderValidity.Day ||
-            (o.Validity is OrderValidity.GoodTilDate { Date: var date } && date <= today)).ToList();
+            (o.Validity is OrderValidity.GoodTilDate { Date: var date } && date <= today))
+            .OrderBy(o => o.InternalId)
+            .ToList();
 
-        return orders.Select(ExpireOrder).ToList();
+        return orders.Select(o => ExpireOrder(o, time)).ToList();
     }
 }

--- a/src/Circus/OrderBookExtensions.cs
+++ b/src/Circus/OrderBookExtensions.cs
@@ -3,6 +3,14 @@ using Circus.Events;
 
 namespace Circus;
 
+// Convenience over Process(action) for callers building one action at a time.
+//
+// Each takes an optional time. Left out, the action goes unstamped and wants a book that stamps
+// - TimestampingOrderBook, or anything else wrapping one; a bare OrderBook refuses it and says
+// so, rather than treating the missing stamp as the start of time. Passed, it is the instant the
+// action happened, which is what a caller owning a schedule should do: a session provider knows
+// the boundary time it is firing on, and that is more truthful than whatever a clock reads by
+// the time the event handler runs.
 public static class OrderBookExtensions
 {
     private static SelfMatchPrevention? BuildSelfMatchPrevention(string? id,
@@ -13,10 +21,10 @@ public static class OrderBookExtensions
         string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
         string? selfMatchPreventionId = null,
         SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-        int? maxVisibleQuantity = null) =>
+        int? maxVisibleQuantity = null, DateTime time = default) =>
         book.Process(new CreateLimitOrder
         {
-            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            Security = book.Security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
             OrderValidity = orderValidity, Side = side, Quantity = quantity, Price = price,
             SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
             MaxVisibleQuantity = maxVisibleQuantity
@@ -26,10 +34,10 @@ public static class OrderBookExtensions
         string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
         string? selfMatchPreventionId = null,
         SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-        int? maxVisibleQuantity = null) =>
+        int? maxVisibleQuantity = null, DateTime time = default) =>
         book.Process(new CreateMarketOrder
         {
-            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            Security = book.Security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
             OrderValidity = orderValidity, Side = side, Quantity = quantity,
             SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
             MaxVisibleQuantity = maxVisibleQuantity
@@ -39,10 +47,10 @@ public static class OrderBookExtensions
         string clientOrderId, OrderValidity orderValidity, Side side, int quantity,
         string? selfMatchPreventionId = null,
         SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-        int? maxVisibleQuantity = null) =>
+        int? maxVisibleQuantity = null, DateTime time = default) =>
         book.Process(new CreateMarketLimitOrder
         {
-            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            Security = book.Security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
             OrderValidity = orderValidity, Side = side, Quantity = quantity,
             SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
             MaxVisibleQuantity = maxVisibleQuantity
@@ -52,10 +60,10 @@ public static class OrderBookExtensions
         string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal price,
         decimal triggerPrice, string? selfMatchPreventionId = null,
         SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-        int? maxVisibleQuantity = null) =>
+        int? maxVisibleQuantity = null, DateTime time = default) =>
         book.Process(new CreateStopLimitOrder
         {
-            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            Security = book.Security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
             OrderValidity = orderValidity, Side = side, Quantity = quantity,
             Price = price, TriggerPrice = triggerPrice,
             SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
@@ -66,10 +74,10 @@ public static class OrderBookExtensions
         string clientOrderId, OrderValidity orderValidity, Side side, int quantity, decimal triggerPrice,
         string? selfMatchPreventionId = null,
         SelfMatchPreventionInstruction? selfMatchPreventionInstruction = null,
-        int? maxVisibleQuantity = null) =>
+        int? maxVisibleQuantity = null, DateTime time = default) =>
         book.Process(new CreateStopMarketOrder
         {
-            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            Security = book.Security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
             OrderValidity = orderValidity, Side = side, Quantity = quantity,
             TriggerPrice = triggerPrice,
             SelfMatchPrevention = BuildSelfMatchPrevention(selfMatchPreventionId, selfMatchPreventionInstruction),
@@ -78,43 +86,47 @@ public static class OrderBookExtensions
 
     public static IReadOnlyList<OrderBookEvent> UpdateOrder(this IOrderBook book, string companyId,
         string clientOrderId, string previousClientOrderId, int? newTotalQuantity = null, decimal? price = null,
-        decimal? triggerPrice = null) =>
+        decimal? triggerPrice = null, DateTime time = default) =>
         book.Process(new UpdateOrder
         {
-            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            Security = book.Security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
             PreviousClientOrderId = previousClientOrderId, NewTotalQuantity = newTotalQuantity, Price = price,
             TriggerPrice = triggerPrice
         });
 
     public static IReadOnlyList<OrderBookEvent> CancelOrder(this IOrderBook book, string companyId,
-        string clientOrderId, string previousClientOrderId) =>
+        string clientOrderId, string previousClientOrderId, DateTime time = default) =>
         book.Process(new CancelOrder
         {
-            Security = book.Security, CompanyId = companyId, ClientOrderId = clientOrderId,
+            Security = book.Security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
             PreviousClientOrderId = previousClientOrderId
         });
 
     public static IReadOnlyList<OrderBookEvent> PreOpenTrading(this IOrderBook book,
-        decimal? referencePrice = null) =>
-        book.Process(new PreOpenTrading { Security = book.Security, ReferencePrice = referencePrice });
+        decimal? referencePrice = null, DateTime time = default) =>
+        book.Process(new PreOpenTrading
+            { Security = book.Security, Time = time, ReferencePrice = referencePrice });
 
     public static IReadOnlyList<OrderBookEvent> OpenTrading(this IOrderBook book,
-        decimal? referencePrice = null) =>
-        book.Process(new OpenTrading { Security = book.Security, ReferencePrice = referencePrice });
+        decimal? referencePrice = null, DateTime time = default) =>
+        book.Process(new OpenTrading
+            { Security = book.Security, Time = time, ReferencePrice = referencePrice });
 
-    public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book, bool endsTradingDay = true) =>
-        book.Process(new CloseTrading { Security = book.Security, EndsTradingDay = endsTradingDay });
+    public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book, bool endsTradingDay = true,
+        DateTime time = default) =>
+        book.Process(new CloseTrading
+            { Security = book.Security, Time = time, EndsTradingDay = endsTradingDay });
 
-    public static IReadOnlyList<OrderBookEvent> PauseTrading(this IOrderBook book) =>
-        book.Process(new PauseTrading { Security = book.Security });
+    public static IReadOnlyList<OrderBookEvent> PauseTrading(this IOrderBook book, DateTime time = default) =>
+        book.Process(new PauseTrading { Security = book.Security, Time = time });
 
-    public static IReadOnlyList<OrderBookEvent> HaltTrading(this IOrderBook book) =>
-        book.Process(new HaltTrading { Security = book.Security });
+    public static IReadOnlyList<OrderBookEvent> HaltTrading(this IOrderBook book, DateTime time = default) =>
+        book.Process(new HaltTrading { Security = book.Security, Time = time });
 
     // Returns whatever the elapsed time turned out to imply - a resumption and its print, or
     // nothing at all.
-    public static IReadOnlyList<OrderBookEvent> AdvanceTime(this IOrderBook book) =>
-        book.Process(new AdvanceTime { Security = book.Security });
+    public static IReadOnlyList<OrderBookEvent> AdvanceTime(this IOrderBook book, DateTime time = default) =>
+        book.Process(new AdvanceTime { Security = book.Security, Time = time });
 
     // Bridge for callers that only know the target status at runtime (e.g. a session/schedule
     // provider driving the book off a clock) and so can't pick PreOpenTrading/OpenTrading/
@@ -122,14 +134,14 @@ public static class OrderBookExtensions
     // ones - a reference price is meaningless once the book stops trading - and endsTradingDay
     // applies only to closing, since nothing else ends a day.
     public static IReadOnlyList<OrderBookEvent> UpdateStatus(this IOrderBook book, OrderBookStatus status,
-        decimal? referencePrice = null, bool endsTradingDay = true) =>
+        decimal? referencePrice = null, bool endsTradingDay = true, DateTime time = default) =>
         status switch
         {
-            OrderBookStatus.PreOpen => book.PreOpenTrading(referencePrice),
-            OrderBookStatus.Open => book.OpenTrading(referencePrice),
-            OrderBookStatus.Closed => book.CloseTrading(endsTradingDay),
-            OrderBookStatus.Paused => book.PauseTrading(),
-            OrderBookStatus.Halted => book.HaltTrading(),
+            OrderBookStatus.PreOpen => book.PreOpenTrading(referencePrice, time),
+            OrderBookStatus.Open => book.OpenTrading(referencePrice, time),
+            OrderBookStatus.Closed => book.CloseTrading(endsTradingDay, time),
+            OrderBookStatus.Paused => book.PauseTrading(time),
+            OrderBookStatus.Halted => book.HaltTrading(time),
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
         };
 }

--- a/src/Circus/TimestampingOrderBook.cs
+++ b/src/Circus/TimestampingOrderBook.cs
@@ -1,0 +1,43 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.Time;
+
+namespace Circus;
+
+// The boundary where wall-clock time enters. An OrderBook reads no clock, so something has to
+// say when each action happened; this stamps every action on the way in and is the only part of
+// the pipeline allowed to be nondeterministic.
+//
+// Wrapping a book is what a gateway does at a real venue: the exchange stamps its own arrival
+// time on an inbound message and the matching engine works off that stamp, never off whatever
+// the clock says at the moment it gets round to the message. Everything downstream of here is a
+// pure function of the actions it is handed, which is what lets a journal of those actions
+// rebuild a book by replaying them with no clock involved at all.
+//
+// An action that already carries a Time is stamped over, not honoured: a book driven off a
+// clock has one source of truth for what time it is, and it is this one. Feed pre-stamped
+// actions - a replay, or a driver with its own schedule - straight to the book instead.
+public sealed class TimestampingOrderBook : IOrderBook
+{
+    private readonly IOrderBook _book;
+    private readonly IClock _clock;
+
+    public TimestampingOrderBook(IOrderBook book, IClock clock)
+    {
+        _book = book;
+        _clock = clock;
+    }
+
+    public TimestampingOrderBook(Security security, IClock clock)
+        : this(new OrderBook(security), clock)
+    {
+    }
+
+    public Security Security => _book.Security;
+
+    public OrderBookStatus Status => _book.Status;
+
+    // One reading per action, so every event the action produces shares an instant.
+    public IReadOnlyList<OrderBookEvent> Process(OrderBookAction action) =>
+        _book.Process(action with {Time = _clock.GetCurrentTime()});
+}

--- a/tests/Circus.Tests/Helpers/LevelTrackingOrderBook.cs
+++ b/tests/Circus.Tests/Helpers/LevelTrackingOrderBook.cs
@@ -21,7 +21,7 @@ internal sealed class LevelTrackingOrderBook : IOrderBook
 
     public LevelTrackingOrderBook(Security security, IClock clock)
     {
-        _book = new OrderBook(security, clock);
+        _book = new TimestampingOrderBook(security, clock);
     }
 
     public Security Security => _book.Security;

--- a/tests/Circus.Tests/MarketData/FullBookDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/FullBookDataProducerTests.cs
@@ -38,7 +38,7 @@ public class FullBookDataProducerTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     [Test]

--- a/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
@@ -20,7 +20,7 @@ public class IndicativePriceDataProducerTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     private static IList<IndicativePriceDataEvent> Publish(IndicativePriceDataProducer producer,

--- a/tests/Circus.Tests/MarketData/LevelDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/LevelDataProducerTests.cs
@@ -42,7 +42,7 @@ public class LevelDataProducerTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     private static LevelsDataEvent Publish(LevelDataProducer producer, IReadOnlyList<OrderBookEvent> bookEvents)

--- a/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
@@ -25,11 +25,11 @@ public class SecurityStatusDataProducerTests
         Producer.Process(book, bookEvents);
 
     private IOrderBook PlainBook() =>
-        new OrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), Clock);
+        new TimestampingOrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), Clock);
 
     // A 5-tick volatility range on a reference of 100, pausing for two minutes.
     private IOrderBook PausingBook() =>
-        new OrderBook(
+        new TimestampingOrderBook(
             new Security("GCZ6", SecurityType.Future, 10, 10,
                 PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)}),
             Clock);
@@ -111,7 +111,7 @@ public class SecurityStatusDataProducerTests
     public void OpenEndedInterruption_PublishesNoResumeTime()
     {
         // arrange - a range with no duration configured stands until something ends it
-        var book = new OrderBook(
+        var book = new TimestampingOrderBook(
             new Security("GCZ6", SecurityType.Future, 10, 10,
                 PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)}),
             Clock);
@@ -133,7 +133,7 @@ public class SecurityStatusDataProducerTests
         // arrange - a book holding a buy above the ceiling, reached by resting it while the
         // limit was wider and then moving the reference so the limit narrows under it. The
         // clock moves on so that buy is genuinely the older order when the sell arrives.
-        var book = new OrderBook(
+        var book = new TimestampingOrderBook(
             new Security("GCZ6", SecurityType.Future, 10, 10,
                 PriceRestrictions: new PriceRestrictionConfig[]
                 {

--- a/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
@@ -16,7 +16,7 @@ public class TradeDataProducerTests
         var clock = new ManualClock(now);
         var producer = new TradeDataProducer();
 
-        var book = new OrderBook(sec, clock);
+        var book = new TimestampingOrderBook(sec, clock);
         book.UpdateStatus(OrderBookStatus.Open);
         book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100);
         var bookEvents =

--- a/tests/Circus.Tests/Orders/CancelOrderTests.cs
+++ b/tests/Circus.Tests/Orders/CancelOrderTests.cs
@@ -30,7 +30,7 @@ public class CancelOrderTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     [Test]

--- a/tests/Circus.Tests/Orders/CreateOrderTests.cs
+++ b/tests/Circus.Tests/Orders/CreateOrderTests.cs
@@ -32,7 +32,7 @@ public class CreateOrderTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     [TestCase(Side.Buy)]
@@ -78,7 +78,7 @@ public class CreateOrderTests
     {
         // arrange
         var sec = new Security("GCZ6", SecurityType.Future, 10, 10, 20);
-        var book = new OrderBook(sec, Clock);
+        var book = new TimestampingOrderBook(sec, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), side == Side.Buy ? Side.Sell : Side.Buy, 3, 500);
         Clock.SetCurrentTime(Now2);

--- a/tests/Circus.Tests/Orders/StopTriggerTests.cs
+++ b/tests/Circus.Tests/Orders/StopTriggerTests.cs
@@ -39,7 +39,7 @@ public class StopTriggerTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     [Test]

--- a/tests/Circus.Tests/Orders/UpdateOrderTests.cs
+++ b/tests/Circus.Tests/Orders/UpdateOrderTests.cs
@@ -33,7 +33,7 @@ public class UpdateOrderTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     [Test]

--- a/tests/Circus.Tests/Restrictions/CircuitBreakerTests.cs
+++ b/tests/Circus.Tests/Restrictions/CircuitBreakerTests.cs
@@ -36,7 +36,7 @@ public class CircuitBreakerTests
                 new CircuitBreaker(new PriceLimitWidth.Percent(13), HaltFor),
                 new CircuitBreaker(new PriceLimitWidth.Percent(20))
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 1000);
         return book;
     }
@@ -103,7 +103,7 @@ public class CircuitBreakerTests
                 new VolatilityBand(2, PauseFor: TimeSpan.FromMinutes(2)),
                 new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor)
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 1000);
 
         // act

--- a/tests/Circus.Tests/Restrictions/DailyLimitTests.cs
+++ b/tests/Circus.Tests/Restrictions/DailyLimitTests.cs
@@ -32,7 +32,7 @@ public class DailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         return book;
     }
@@ -82,7 +82,7 @@ public class DailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
 
         book.UpdateStatus(OrderBookStatus.Open, 200);
         book.CreateLimitOrder(CompanyId1, "Sell1", new OrderValidity.Day(), Side.Sell, 5, 200);
@@ -152,7 +152,7 @@ public class DailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Percent(7))
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 1000);
 
         // act + assert - 1070 is exactly on the ceiling
@@ -172,7 +172,7 @@ public class DailyLimitTests
             {
                 new DailyPriceLimit(new PriceLimitWidth.Percent(7))
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act

--- a/tests/Circus.Tests/Restrictions/VelocityLogicTests.cs
+++ b/tests/Circus.Tests/Restrictions/VelocityLogicTests.cs
@@ -27,7 +27,7 @@ public class VelocityLogicTests
 
     // 5 ticks on a tick size of 10, so 50 of price movement inside ten seconds is too fast.
     private IOrderBook VelocityBook(TimeSpan? pauseFor = null) =>
-        new OrderBook(
+        new TimestampingOrderBook(
             new Security("GCZ6", SecurityType.Future, 10, 10,
                 PriceRestrictions: new PriceRestrictionConfig[]
                 {
@@ -90,7 +90,7 @@ public class VelocityLogicTests
                 new VolatilityBand(20),
                 new VelocityLimit(5, Window)
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act

--- a/tests/Circus.Tests/Restrictions/VolatilityInterruptionTests.cs
+++ b/tests/Circus.Tests/Restrictions/VolatilityInterruptionTests.cs
@@ -42,7 +42,7 @@ public class VolatilityInterruptionTests
     {
         // arrange - referenced at 100, then a trade at 200 breaches the ordinary range and
         // pauses the book, leaving the two orders crossed and unfilled
-        var book = new OrderBook(ExtendingSecurity(), Clock);
+        var book = new TimestampingOrderBook(ExtendingSecurity(), Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
@@ -66,7 +66,7 @@ public class VolatilityInterruptionTests
     public void InterruptionEnds_OnceItWouldPrintInsideTheExtendedRange()
     {
         // arrange - as above, paused with a would-be print at 200
-        var book = new OrderBook(ExtendingSecurity(), Clock);
+        var book = new TimestampingOrderBook(ExtendingSecurity(), Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
         book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
@@ -106,7 +106,7 @@ public class VolatilityInterruptionTests
                 new VolatilityBand(3),
                 new StaticPriceRange(5)
             });
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
         // act + assert - 120 is 2 ticks from the reference, inside both

--- a/tests/Circus.Tests/Sessions/DeterminismTests.cs
+++ b/tests/Circus.Tests/Sessions/DeterminismTests.cs
@@ -1,109 +1,216 @@
+using System.Text;
 using Circus.Actions;
 using Circus.Events;
-using Circus.Simulator;
 using Circus.Time;
 using NUnit.Framework;
 
 namespace Circus.Tests.Sessions;
 
+// A book is a pure function of the actions it is handed. These pin that down, because it is
+// what lets a journal of those actions rebuild a book by replaying them - and because the two
+// ways it was not true were both invisible until something replayed a trace and compared.
 [TestFixture]
 public class DeterminismTests
 {
     private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
 
     [Test]
-    public void SameTraceProducesIdenticalEventStream()
+    public void ReplayingATraceReproducesEveryEventExactly()
     {
-        // Arrange: generate a seeded action sequence
-        const int seed = 42;
-        const int actionCount = 100;
-        var simulator = new OrderFlowSimulator(Sec, seed: seed);
-        var actions = simulator.Generate(actionCount);
+        var actions = Trace();
 
-        // Act: run the same actions through two fresh books
-        var events1 = RunTrace(actions, seed);
-        var events2 = RunTrace(actions, seed);
+        var first = Replay(actions);
+        var second = Replay(actions);
 
-        // Assert: both runs produce identical event sequences
-        Assert.AreEqual(events1.Count, events2.Count, "Event count mismatch");
-        for (int i = 0; i < events1.Count; i++)
+        // Not just the same shape - the same events, timestamps included. A clock read anywhere
+        // inside the book would break this, which is the point.
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    [Test]
+    public void OneActionStampsEveryEventItProducesWithOneInstant()
+    {
+        var book = new OrderBook(Sec);
+        book.Process(new OpenTrading {Security = Sec, Time = Now1});
+        book.Process(new CreateLimitOrder
         {
-            var e1 = events1[i];
-            var e2 = events2[i];
+            Security = Sec, Time = Now1, CompanyId = "C1", ClientOrderId = "O1",
+            OrderValidity = new OrderValidity.Day(), Side = Side.Sell, Quantity = 5, Price = 100
+        });
 
-            Assert.AreEqual(e1.GetType(), e2.GetType(), $"Event {i}: type mismatch");
+        // A crossing order: confirms, matches, prints, and fills - several events, one action.
+        var events = book.Process(new CreateLimitOrder
+        {
+            Security = Sec, Time = Now1.AddSeconds(1), CompanyId = "C2", ClientOrderId = "O2",
+            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 5, Price = 100
+        });
 
-            // Events with timestamps must be identical (H1 fix ensures this)
-            if (e1 is OrderBookEvent obe1 && e2 is OrderBookEvent obe2)
+        Assert.Greater(events.Count, 1, "expected a create plus a match");
+        CollectionAssert.AreEqual(
+            Enumerable.Repeat(Now1.AddSeconds(1), events.Count),
+            events.Select(e => e.Time));
+    }
+
+    [Test]
+    public void DayOrdersExpireInIdOrderRatherThanHashOrder()
+    {
+        var book = new OrderBook(Sec);
+        book.Process(new OpenTrading {Security = Sec, Time = Now1});
+
+        // Enough of them that a dictionary's iteration order would not plausibly match insertion
+        // order by chance, and interleaved with cancels so the table has had entries removed.
+        var ids = Enumerable.Range(1, 20).Select(i => $"O{i}").ToList();
+        foreach (var id in ids)
+            Rest(book, id, Now1);
+
+        var cancelled = new[] {"O3", "O7", "O8", "O15"};
+        foreach (var id in cancelled)
+        {
+            book.Process(new CancelOrder
             {
-                Assert.AreEqual(obe1.Security, obe2.Security, $"Event {i}: security mismatch");
-                Assert.AreEqual(obe1.Timestamp, obe2.Timestamp,
-                    $"Event {i}: timestamp mismatch (H1 fix may not be working)");
-            }
+                Security = Sec, Time = Now1, CompanyId = "C", ClientOrderId = $"{id}x",
+                PreviousClientOrderId = id
+            });
         }
+
+        var expired = book
+            .Process(new CloseTrading {Security = Sec, Time = Now1.AddHours(6), EndsTradingDay = true})
+            .OfType<ExpireOrderConfirmed>()
+            .Select(e => e.Order.ClientOrderId)
+            .ToList();
+
+        CollectionAssert.AreEqual(ids.Except(cancelled).ToList(), expired);
     }
 
     [Test]
-    public void DayOrderExpiryOrderIsDeterministic()
+    public void AnUnstampedActionIsRefusedRatherThanTreatedAsTheStartOfTime()
     {
-        // This tests H2: expiry order by InternalId
-        var clock = new ManualClock(new DateTime(2024, 1, 15, 16, 0, 0));
-        var book = new OrderBook(Sec, clock);
+        var book = new OrderBook(Sec);
 
-        // Arrange: open the book and create several day orders
-        book.UpdateStatus(OrderBookStatus.Open);
+        var ex = Assert.Throws<ArgumentException>(() =>
+            book.Process(new OpenTrading {Security = Sec}));
 
-        var order1 = book.Process(new CreateLimitOrder
-        {
-            Security = Sec, CompanyId = "C1", ClientOrderId = "O1",
-            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 1, Price = 100
-        });
-
-        var order2 = book.Process(new CreateLimitOrder
-        {
-            Security = Sec, CompanyId = "C2", ClientOrderId = "O2",
-            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 1, Price = 100
-        });
-
-        var order3 = book.Process(new CreateLimitOrder
-        {
-            Security = Sec, CompanyId = "C3", ClientOrderId = "O3",
-            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 1, Price = 100
-        });
-
-        // Act: close the book, which triggers day order expiry
-        var closeEvents = book.Process(new CloseTrading { EndsTradingDay = true });
-
-        // Assert: expiry events come out in InternalId order
-        var expireEvents = closeEvents.OfType<ExpireOrderConfirmed>().ToList();
-        Assert.AreEqual(3, expireEvents.Count, "Should have 3 expiry events");
-
-        // The orders were created in sequence, so their InternalIds will be in order
-        var expireIds = expireEvents.Select(e => e.Order.ClientOrderId).ToList();
-        Assert.AreEqual("O1", expireIds[0], "First expiry should be O1");
-        Assert.AreEqual("O2", expireIds[1], "Second expiry should be O2");
-        Assert.AreEqual("O3", expireIds[2], "Third expiry should be O3");
+        Assert.That(ex.Message, Does.Contain("Time"));
     }
 
-    private static IReadOnlyList<OrderBookEvent> RunTrace(
-        IReadOnlyList<OrderBookAction> actions, int seed)
+    [Test]
+    public void TimeRunningBackwardsIsRefused()
     {
-        var clock = new ManualClock(DateTime.UtcNow);
-        var book = new OrderBook(Sec, clock);
-        book.UpdateStatus(OrderBookStatus.Open);
+        var book = new OrderBook(Sec);
+        book.Process(new OpenTrading {Security = Sec, Time = Now1});
 
-        var allEvents = new List<OrderBookEvent>();
+        Assert.Throws<ArgumentException>(() =>
+            book.Process(new CloseTrading {Security = Sec, Time = Now1.AddSeconds(-1)}));
+
+        // The same instant twice is not backwards - a burst can share one.
+        Assert.DoesNotThrow(() =>
+            book.Process(new AdvanceTime {Security = Sec, Time = Now1}));
+    }
+
+    [Test]
+    public void AStampingBookUsesTheClockItWasGiven()
+    {
+        var clock = new ManualClock(Now1);
+        var book = new TimestampingOrderBook(Sec, clock);
+
+        var events = book.OpenTrading();
+
+        Assert.AreEqual(Now1, events.Single().Time);
+    }
+
+    // A varied but fixed action sequence: resting orders on both sides, updates, cancels, and
+    // orders that cross and print. Built here rather than by OrderFlowSimulator, which lives in
+    // a project this one does not reference.
+    private static IReadOnlyList<OrderBookAction> Trace()
+    {
+        var actions = new List<OrderBookAction>();
+        var random = new Random(42);
+        var time = Now1;
+        var live = new List<string>();
+        var n = 0;
+
+        for (var i = 0; i < 300; i++)
+        {
+            time = time.AddMilliseconds(1);
+            var roll = random.NextDouble();
+
+            if (live.Count > 0 && roll < 0.2)
+            {
+                var index = random.Next(live.Count);
+                actions.Add(new CancelOrder
+                {
+                    Security = Sec, Time = time, CompanyId = "C", ClientOrderId = $"o{n++}",
+                    PreviousClientOrderId = live[index]
+                });
+                live.RemoveAt(index);
+                continue;
+            }
+
+            if (live.Count > 0 && roll < 0.35)
+            {
+                var index = random.Next(live.Count);
+                var renamed = $"o{n++}";
+                actions.Add(new UpdateOrder
+                {
+                    Security = Sec, Time = time, CompanyId = "C", ClientOrderId = renamed,
+                    PreviousClientOrderId = live[index], NewTotalQuantity = random.Next(1, 10)
+                });
+                live[index] = renamed;
+                continue;
+            }
+
+            // Prices straddle 100 so buys and sells cross each other regularly.
+            var id = $"o{n++}";
+            actions.Add(new CreateLimitOrder
+            {
+                Security = Sec, Time = time, CompanyId = "C", ClientOrderId = id,
+                OrderValidity = new OrderValidity.Day(),
+                Side = random.Next(2) == 0 ? Side.Buy : Side.Sell,
+                Quantity = random.Next(1, 10),
+                Price = 10 * random.Next(8, 13)
+            });
+            live.Add(id);
+        }
+
+        actions.Add(new CloseTrading {Security = Sec, Time = time.AddHours(6), EndsTradingDay = true});
+        return actions;
+    }
+
+    // No clock: the trace carries the time each action happened, which is the property under
+    // test. The opening action shares the first action's instant so nothing moves backwards.
+    private static List<string> Replay(IReadOnlyList<OrderBookAction> actions)
+    {
+        var book = new OrderBook(Sec);
+        var events = new List<OrderBookEvent>(book.Process(
+            new OpenTrading {Security = Sec, Time = actions[0].Time}));
 
         foreach (var action in actions)
-        {
-            // Advance clock by a small increment to vary timestamp and
-            // simulate sequential action processing time
-            clock.SetCurrentTime(clock.GetCurrentTime().AddMilliseconds(1));
+            events.AddRange(book.Process(action));
 
-            var events = book.Process(action);
-            allEvents.AddRange(events);
-        }
-
-        return allEvents;
+        return events.Select(Describe).ToList();
     }
+
+    // Rendered rather than compared directly: OrdersMatched carries its fills in an IList, and a
+    // record's generated equality compares that by reference, so two runs producing identical
+    // trades would still come out unequal. Expanding the fills here compares what they say.
+    private static string Describe(OrderBookEvent e)
+    {
+        if (e is not OrdersMatched matched)
+            return e.ToString();
+
+        var text = new StringBuilder();
+        text.Append($"OrdersMatched {{ Time = {matched.Time:O}, Price = {matched.Price}, " +
+                    $"Quantity = {matched.Quantity}, Fills = [");
+        foreach (var fill in matched.Fills)
+            text.Append(fill).Append("; ");
+        return text.Append("] }").ToString();
+    }
+
+    private static void Rest(IOrderBook book, string clientOrderId, DateTime time) =>
+        book.Process(new CreateLimitOrder
+        {
+            Security = Sec, Time = time, CompanyId = "C", ClientOrderId = clientOrderId,
+            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 1, Price = 100
+        });
 }

--- a/tests/Circus.Tests/Sessions/DeterminismTests.cs
+++ b/tests/Circus.Tests/Sessions/DeterminismTests.cs
@@ -1,0 +1,109 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.Simulator;
+using Circus.Time;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sessions;
+
+[TestFixture]
+public class DeterminismTests
+{
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    [Test]
+    public void SameTraceProducesIdenticalEventStream()
+    {
+        // Arrange: generate a seeded action sequence
+        const int seed = 42;
+        const int actionCount = 100;
+        var simulator = new OrderFlowSimulator(Sec, seed: seed);
+        var actions = simulator.Generate(actionCount);
+
+        // Act: run the same actions through two fresh books
+        var events1 = RunTrace(actions, seed);
+        var events2 = RunTrace(actions, seed);
+
+        // Assert: both runs produce identical event sequences
+        Assert.AreEqual(events1.Count, events2.Count, "Event count mismatch");
+        for (int i = 0; i < events1.Count; i++)
+        {
+            var e1 = events1[i];
+            var e2 = events2[i];
+
+            Assert.AreEqual(e1.GetType(), e2.GetType(), $"Event {i}: type mismatch");
+
+            // Events with timestamps must be identical (H1 fix ensures this)
+            if (e1 is OrderBookEvent obe1 && e2 is OrderBookEvent obe2)
+            {
+                Assert.AreEqual(obe1.Security, obe2.Security, $"Event {i}: security mismatch");
+                Assert.AreEqual(obe1.Timestamp, obe2.Timestamp,
+                    $"Event {i}: timestamp mismatch (H1 fix may not be working)");
+            }
+        }
+    }
+
+    [Test]
+    public void DayOrderExpiryOrderIsDeterministic()
+    {
+        // This tests H2: expiry order by InternalId
+        var clock = new ManualClock(new DateTime(2024, 1, 15, 16, 0, 0));
+        var book = new OrderBook(Sec, clock);
+
+        // Arrange: open the book and create several day orders
+        book.UpdateStatus(OrderBookStatus.Open);
+
+        var order1 = book.Process(new CreateLimitOrder
+        {
+            Security = Sec, CompanyId = "C1", ClientOrderId = "O1",
+            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 1, Price = 100
+        });
+
+        var order2 = book.Process(new CreateLimitOrder
+        {
+            Security = Sec, CompanyId = "C2", ClientOrderId = "O2",
+            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 1, Price = 100
+        });
+
+        var order3 = book.Process(new CreateLimitOrder
+        {
+            Security = Sec, CompanyId = "C3", ClientOrderId = "O3",
+            OrderValidity = new OrderValidity.Day(), Side = Side.Buy, Quantity = 1, Price = 100
+        });
+
+        // Act: close the book, which triggers day order expiry
+        var closeEvents = book.Process(new CloseTrading { EndsTradingDay = true });
+
+        // Assert: expiry events come out in InternalId order
+        var expireEvents = closeEvents.OfType<ExpireOrderConfirmed>().ToList();
+        Assert.AreEqual(3, expireEvents.Count, "Should have 3 expiry events");
+
+        // The orders were created in sequence, so their InternalIds will be in order
+        var expireIds = expireEvents.Select(e => e.Order.ClientOrderId).ToList();
+        Assert.AreEqual("O1", expireIds[0], "First expiry should be O1");
+        Assert.AreEqual("O2", expireIds[1], "Second expiry should be O2");
+        Assert.AreEqual("O3", expireIds[2], "Third expiry should be O3");
+    }
+
+    private static IReadOnlyList<OrderBookEvent> RunTrace(
+        IReadOnlyList<OrderBookAction> actions, int seed)
+    {
+        var clock = new ManualClock(DateTime.UtcNow);
+        var book = new OrderBook(Sec, clock);
+        book.UpdateStatus(OrderBookStatus.Open);
+
+        var allEvents = new List<OrderBookEvent>();
+
+        foreach (var action in actions)
+        {
+            // Advance clock by a small increment to vary timestamp and
+            // simulate sequential action processing time
+            clock.SetCurrentTime(clock.GetCurrentTime().AddMilliseconds(1));
+
+            var events = book.Process(action);
+            allEvents.AddRange(events);
+        }
+
+        return allEvents;
+    }
+}

--- a/tests/Circus.Tests/Sessions/DeterminismTests.cs
+++ b/tests/Circus.Tests/Sessions/DeterminismTests.cs
@@ -25,7 +25,7 @@ public class DeterminismTests
 
         // Not just the same shape - the same events, timestamps included. A clock read anywhere
         // inside the book would break this, which is the point.
-        CollectionAssert.AreEqual(first, second);
+        Assert.That(second, Is.EqualTo(first));
     }
 
     [Test]
@@ -47,9 +47,9 @@ public class DeterminismTests
         });
 
         Assert.Greater(events.Count, 1, "expected a create plus a match");
-        CollectionAssert.AreEqual(
-            Enumerable.Repeat(Now1.AddSeconds(1), events.Count),
-            events.Select(e => e.Time));
+        Assert.That(
+            events.Select(e => e.Time),
+            Is.EqualTo(Enumerable.Repeat(Now1.AddSeconds(1), events.Count)));
     }
 
     [Test]
@@ -80,7 +80,7 @@ public class DeterminismTests
             .Select(e => e.Order.ClientOrderId)
             .ToList();
 
-        CollectionAssert.AreEqual(ids.Except(cancelled).ToList(), expired);
+        Assert.That(expired, Is.EqualTo(ids.Except(cancelled).ToList()));
     }
 
     [Test]

--- a/tests/Circus.Tests/Sessions/MultipleSessionsTests.cs
+++ b/tests/Circus.Tests/Sessions/MultipleSessionsTests.cs
@@ -33,7 +33,7 @@ public class MultipleSessionsTests
     public void SetUp()
     {
         Clock = new ManualClock(MorningSession);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     // The seed OrderBook derives from a date, so a test can say which run of ids it

--- a/tests/Circus.Tests/Sessions/PausedHaltedTests.cs
+++ b/tests/Circus.Tests/Sessions/PausedHaltedTests.cs
@@ -31,7 +31,7 @@ public class PausedHaltedTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     [TestCase(OrderBookStatus.Paused)]
@@ -201,7 +201,7 @@ public class PausedHaltedTests
         // arrange - a reference of 100 and a 5-tick volatility band
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);
 

--- a/tests/Circus.Tests/Sessions/TimedResumeTests.cs
+++ b/tests/Circus.Tests/Sessions/TimedResumeTests.cs
@@ -34,7 +34,7 @@ public class TimedResumeTests
     {
         var security = new Security("GCZ6", SecurityType.Future, 10, 10,
             PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, duration)});
-        var book = new OrderBook(security, Clock);
+        var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         return book;
     }
@@ -196,7 +196,7 @@ public class TimedResumeTests
             : new IPriceRestriction[] {pausing, halting};
 
         var security = new Security("GCZ6", SecurityType.Future, 10, 10);
-        var book = new OrderBook(security, Clock, restrictions);
+        var book = new TimestampingOrderBook(new OrderBook(security, restrictions), Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
         // act

--- a/tests/Circus.Tests/Sessions/UpdateStateTests.cs
+++ b/tests/Circus.Tests/Sessions/UpdateStateTests.cs
@@ -29,7 +29,7 @@ public class UpdateStateTests
     public void SetUp()
     {
         Clock = new ManualClock(Now1);
-        Book = new OrderBook(Sec, Clock);
+        Book = new TimestampingOrderBook(Sec, Clock);
     }
 
     [TestCase(OrderBookStatus.PreOpen)]


### PR DESCRIPTION
## Why

A book that reads a clock cannot be replayed. Feeding the same actions to a fresh book produced *similar* state, never identical events, because time arrived from the side rather than with the message. That blocked journalling, and it made "the action stream is the authoritative record" false — the stream was incomplete without a recorded clock beside it.

This makes `OrderBook` a pure function of the actions it is handed.

## What changed

**`OrderBookAction` carries `Time`** — the instant the exchange accepted the action. `AdvanceTime`'s entire payload is now that field, which is what it always meant.

**`OrderBook` drops `IClock`.** `Process` reads `action.Time` and threads it down, so every event one action produces shares one instant. Two things it now refuses rather than absorbing:

- an unstamped action, instead of silently treating `DateTime.MinValue` as the time and expiring every GTD order in the book
- an action that moves time backwards, instead of leaving state that no replay of those same actions could reproduce (equal stamps are fine — a burst can share an instant)

**`TimestampingOrderBook`** is the boundary where wall-clock time enters. It wraps a book, stamps each action from an `IClock`, and is the only part of the pipeline allowed to be nondeterministic. This is what a gateway does at a venue: the exchange stamps arrival time on an inbound message and the matching engine works off that stamp, never off whatever the clock reads by the time it gets to the message.

**The convenience extensions take an optional `time`.** A caller that owns a schedule — a session provider, a backtest, a replay — can stamp at the boundary it is firing on, which is more truthful than having a wrapper overwrite it with "now".

## Also in here

**Finishes the H1 fix.** `CheckTradeRestrictionBreach` was still reading a clock directly, because it reaches `Matcher.Run` as a method group and so couldn't take the threaded time. It now closes over the action's instant, so a sweep judges every price it touches against the same moment its events are stamped with. Without this the volatility-band and daily-limit checks still drifted within a single action.

**H2, from the earlier commit on this branch:** day-order expiry is ordered by `InternalId` rather than following `Dictionary.Values`, so a close-of-day event stream is stable.

## Two things this surfaced

- `OrderFlowSimulator` seeded its shadow book from `DateTime.UtcNow`, so a trace was never quite reproducible from its seed alone — despite that being the class's stated purpose. It now runs off a fixed epoch with a fixed step, and the trace it hands back is self-contained.
- `SessionProvider` reports boundaries it has already passed (its initial `Closed` fires at the caller's time, then past transitions replay behind it). A driver stamping from `args.Time` therefore hands the book time running backwards. The backtest sample stamps from the data's time instead. Worth fixing in the provider separately — the ordering was always odd, this just made it visible.

## Tests

`DeterminismTests` covers the properties directly: replaying a trace reproduces every event exactly, one action stamps every event it produces with one instant, day orders expire in id order, unstamped and backwards-stamped actions are refused, and a stamping book agrees with the clock it was given.

The replay comparison renders events rather than comparing them — `OrdersMatched` holds its fills in an `IList`, and a record's generated equality compares that by reference, so two runs producing identical trades would otherwise come out unequal.

## Not in here

External timer actions — a schedule or volatility resume arriving as an action rather than firing off `_resumeAt` internally. It's a reasonable direction and consistent with the scheduled transitions already being external, but it needs an epoch on the resume so a superseded interruption can't fire, and a sequencer merging timer actions into the same ordered stream as client flow. Internal `_resumeAt` is deterministic and race-free today, and now compares against `action.Time`.