### PR TITLE
Put one queue in front of the books and let it decide the order

### DIFF
--- a/src/Circus/Sequencing/DispatchKind.cs
+++ b/src/Circus/Sequencing/DispatchKind.cs
@@ -1,0 +1,21 @@
+namespace Circus.Sequencing;
+
+// What settles a tie between actions queued at the same instant. A rank, not a category: the
+// values matter only in that they are ordered.
+//
+// It has to exist. In a replay every client action is submitted up front and so carries a lower
+// submission counter than any interruption tick queued later, so a counter alone would dispatch
+// an order stamped exactly at a resume deadline before the resume - leaving it to meet a paused
+// book that should already have reopened.
+internal enum DispatchKind
+{
+    // An open at 09:00:00.000 precedes an order stamped the same instant: the venue decides what
+    // a book is doing before anyone trades into it.
+    ScheduleTransition,
+
+    // A book coming back from an interruption, for the same reason.
+    InterruptionTick,
+
+    // Last, ordered among itself by submission counter.
+    ClientFlow
+}

--- a/src/Circus/Sequencing/Dispatched.cs
+++ b/src/Circus/Sequencing/Dispatched.cs
@@ -1,0 +1,15 @@
+using Circus.Actions;
+using Circus.Events;
+
+namespace Circus.Sequencing;
+
+// One action handed to one book, and what came back. Sequence is the venue's dispatch count -
+// the order things happened in, which is the only thing that exists at venue scope rather than
+// per security.
+//
+// No book reference: Action.Security is which book this was, and every event carries its own
+// security too, so a consumer keys off that the same way the dispatch loop does. Keeping the book
+// itself out of the record is what lets this stay the same shape once one action can imply a fill
+// in another.
+public readonly record struct Dispatched(long Sequence, OrderBookAction Action,
+    IReadOnlyList<OrderBookEvent> Events);

--- a/src/Circus/Sequencing/Sequencer.cs
+++ b/src/Circus/Sequencing/Sequencer.cs
@@ -1,0 +1,198 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.Sessions;
+
+namespace Circus.Sequencing;
+
+// One queue in front of the books, and the only component that knows more than one security
+// exists. Its dispatch order is the venue's order of events.
+//
+// That is the whole reason it exists. A book must never be handed an action stamped behind the
+// last one it saw - it throws if that happens - so exactly one component may decide what reaches
+// a book first, and it is this one. Nothing else should hold a book and drive it directly while a
+// sequencer has it.
+//
+// Three sources feed the one queue. Client flow arrives already stamped, through Submit. Schedule
+// transitions come from asking each book's MarketSchedule what is next. Interruption ticks come
+// from the books' own events - a book saying when its pause is due back becomes a poke queued at
+// that instant, which is the only feedback in the system.
+//
+// Ordering is by (Time, Kind, Sequence), and per-book monotonicity is not enforced separately: it
+// follows from dispatching in global time order, which is the point of having one queue rather
+// than one per book. Every queued action carries a unique submission counter, so no two entries
+// ever compare equal and dispatch order is a function of the inputs alone - no dictionary
+// iteration, no arrival races once submitted. That is what makes the stream reproducible.
+//
+// Single-threaded by construction: one queue, one dispatch loop, one thread. The shape invites a
+// lock and a lock is the wrong answer - a gateway submitting from an I/O thread wants a handoff
+// queue into this thread, not contention on it.
+//
+// No clock of its own. AdvanceTo is the seam that makes live and replay the same code: a replay
+// submits a trace and advances to the end, a live pump advances to whatever its clock reads on a
+// tick. For the same reason the books registered here should be bare OrderBooks - a
+// TimestampingOrderBook would stamp its own clock reading over the instant the sequencer decided
+// this action happened at.
+public sealed class Sequencer
+{
+    // Priority is a plain tuple rather than a type of its own: it is compared, never handled, and
+    // ValueTuple already compares its members in order.
+    private readonly PriorityQueue<OrderBookAction, (DateTime Time, DispatchKind Kind, long Counter)>
+        _queue = new();
+
+    // Keyed on the security's name rather than on the record. A name is what identifies a
+    // contract at a venue, and it is the part an action arriving from anywhere else can be
+    // trusted to carry: two Security records describing the same contract need not be equal,
+    // since the restriction list on them compares by reference. A routing table that turned that
+    // into "no book is registered for GCZ6" while holding a book for GCZ6 would be a bad
+    // afternoon.
+    private readonly Dictionary<string, (IOrderBook Book, MarketSchedule Schedule)> _books = new();
+
+    // Never reused, so it is what makes every queue entry distinct and every tie decidable.
+    private long _counter;
+
+    private long _sequence;
+    private DateTime _now;
+
+    public Sequencer(DateTime start)
+    {
+        _now = start;
+    }
+
+    // Everything at or before this instant has been dispatched, so nothing may be inserted there
+    // any more. Starts wherever the venue was told it was starting - a replay at the beginning of
+    // its trace, a live pump at its clock.
+    public DateTime LogicalNow => _now;
+
+    // Registers a book and the schedule driving it, keyed on the book's own security, and queues
+    // its first boundary - the next one strictly after logical now.
+    //
+    // A book registered mid-session is not caught up. The schedule is asked what is next, never
+    // what was missed, so a book added between its open and its close stays as it is until that
+    // close arrives. Register before the day begins, or submit the transitions to put the book
+    // where it should be: that decision belongs to whoever starts the venue, not here.
+    public void Add(IOrderBook book, MarketSchedule schedule)
+    {
+        if (!_books.TryAdd(book.Security.Name, (book, schedule)))
+            throw new ArgumentException(
+                $"a book is already registered for {book.Security.Name}", nameof(book));
+
+        QueueNextTransition(book.Security, schedule, _now);
+    }
+
+    // Queues client flow at its own stamp.
+    //
+    // Refused if stamped behind logical now: the past has already been dispatched and cannot be
+    // inserted into. Refused for a security with no book registered, because a routing mistake is
+    // worth hearing about where it was made rather than as a lookup failure mid-dispatch.
+    public void Submit(OrderBookAction action)
+    {
+        if (action.Time == default)
+            throw new ArgumentException(
+                $"{action.GetType().Name} has no Time. A sequencer orders actions by when they " +
+                "happened, so an unstamped one has no place in the queue.", nameof(action));
+
+        if (action.Time < _now)
+            throw new ArgumentException(
+                $"{action.GetType().Name} is stamped {action.Time:O}, behind logical now " +
+                $"({_now:O}). Everything up to that instant has been dispatched already.",
+                nameof(action));
+
+        if (!_books.ContainsKey(action.Security.Name))
+            throw new ArgumentException(
+                $"no book is registered for {action.Security.Name}", nameof(action));
+
+        Enqueue(action, DispatchKind.ClientFlow);
+    }
+
+    // Dispatches everything queued at or before `time`, in order, then holds logical now there.
+    //
+    // Dispatching can queue more work at or before that same instant - the boundary after a
+    // schedule transition, a poke for an interruption that just began - so the loop drains rather
+    // than taking a snapshot of what was queued on entry.
+    public IReadOnlyList<Dispatched> AdvanceTo(DateTime time)
+    {
+        if (time < _now)
+            throw new ArgumentException(
+                $"cannot advance to {time:O}, behind logical now ({_now:O}). Time runs one way.",
+                nameof(time));
+
+        var dispatched = new List<Dispatched>();
+
+        while (_queue.TryPeek(out _, out var next) && next.Time <= time)
+        {
+            var action = _queue.Dequeue();
+
+            // Logical now moves with the action being dispatched rather than jumping to the
+            // caller's target, so anything that action queues is placed against the instant it
+            // actually happened at.
+            _now = next.Time;
+
+            var (book, schedule) = _books[action.Security.Name];
+            var events = book.Process(action);
+
+            _sequence++;
+            dispatched.Add(new Dispatched(_sequence, action, events));
+
+            // The next boundary is queued only once this one has been dispatched, so the queue
+            // holds a single pending transition per book however far ahead the schedule runs.
+            if (next.Kind == DispatchKind.ScheduleTransition)
+                QueueNextTransition(action.Security, schedule, next.Time);
+
+            QueueInterruptionTicks(events, next.Time);
+        }
+
+        _now = time;
+        return dispatched;
+    }
+
+    // A book pausing says when it is due back, and that becomes a poke at the deadline. Nothing is
+    // ever cancelled: a close landing before the deadline clears the book's own resume time, and
+    // the tick that arrives afterwards finds nothing to do. An interruption that extends emits a
+    // fresh deadline, which queues a fresh tick and leaves the earlier one inert. Self-correcting,
+    // which is what makes punctuality this cheap - no interruption epoch on the action, no
+    // cancellation bookkeeping.
+    //
+    // The book's own resume time stays the authority throughout. This only pokes it on time.
+    private void QueueInterruptionTicks(IReadOnlyList<OrderBookEvent> events, DateTime dispatchedAt)
+    {
+        foreach (var status in events.OfType<StatusChanged>())
+        {
+            // Strictly ahead: a deadline that has already arrived was served by the action that
+            // set it, and a poke queued at the instant being dispatched would only spin.
+            if (status.ResumesAt is { } resumesAt && resumesAt > dispatchedAt)
+                Enqueue(new AdvanceTime {Security = status.Security, Time = resumesAt},
+                    DispatchKind.InterruptionTick);
+        }
+    }
+
+    private void QueueNextTransition(Security security, MarketSchedule schedule, DateTime after)
+    {
+        // A schedule with nothing left to say - a holiday calendar past its end - simply stops
+        // driving its book. Whoever registered it decides what that means.
+        if (schedule.NextAfter(after) is not { } transition) return;
+
+        Enqueue(ToAction(security, transition), DispatchKind.ScheduleTransition);
+    }
+
+    private void Enqueue(OrderBookAction action, DispatchKind kind)
+    {
+        _counter++;
+        _queue.Enqueue(action, (action.Time, kind, _counter));
+    }
+
+    // No reference price on an opening this builds: where that number comes from is a decision
+    // kept outside the engine, and it reaches a book as an ordinary submitted action rather than
+    // through a lookup wired into the schedule.
+    private static OrderBookAction ToAction(Security security, ScheduledTransition transition) =>
+        transition.Status switch
+        {
+            OrderBookStatus.PreOpen => new PreOpenTrading {Security = security, Time = transition.Time},
+            OrderBookStatus.Open => new OpenTrading {Security = security, Time = transition.Time},
+            OrderBookStatus.Closed => new CloseTrading
+            {
+                Security = security, Time = transition.Time, EndsTradingDay = transition.EndsTradingDay
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(transition), transition.Status,
+                "a schedule moves a book between pre-open, open and closed, and nowhere else")
+        };
+}

--- a/tests/Circus.Tests/Sequencing/SequencerTests.cs
+++ b/tests/Circus.Tests/Sequencing/SequencerTests.cs
@@ -1,0 +1,427 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.Sequencing;
+using Circus.Sessions;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sequencing;
+
+// One book, so what is under test here is the queue rather than the routing: that three sources
+// feed one order, that ties at a single instant fall the way a venue needs them to, and that a
+// book's interruption comes back as a poke it never had to ask for. Several books are the next
+// step and change none of it.
+[TestFixture]
+public class SequencerTests
+{
+    private static readonly DateTime Day = new(2000, 1, 1);
+
+    private static readonly TimeSpan PreOpenAt = new(9, 0, 0);
+    private static readonly TimeSpan OpenAt = new(9, 30, 0);
+    private static readonly TimeSpan CloseAt = new(17, 0, 0);
+
+    private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+
+    // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it and pauses the
+    // book for two minutes.
+    private static readonly Security PausingSec = new("GCZ6", SecurityType.Future, 10, 10,
+        PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)});
+
+    private static MarketSchedule TradingDay() => new(PreOpenAt, OpenAt, CloseAt);
+
+    // A day that does not begin until late in the evening, so the schedule stays out of the way
+    // while a test drives the book itself.
+    private static MarketSchedule Quiet() =>
+        new(new TimeSpan(23, 0, 0), new TimeSpan(23, 15, 0), new TimeSpan(23, 45, 0));
+
+    private static DateTime At(TimeSpan timeOfDay) => Day.Add(timeOfDay);
+
+    private static DateTime At(int hour, int minute) => Day.Add(new TimeSpan(hour, minute, 0));
+
+    private static CreateLimitOrder Order(Security security, string companyId, string clientOrderId,
+        Side side, decimal price, DateTime time) =>
+        new()
+        {
+            Security = security, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = new OrderValidity.Day(), Side = side, Quantity = 5, Price = price
+        };
+
+    // The book paused at 12:01 and due back two minutes later, with the pair that caused it still
+    // crossed and unfilled. Everything is submitted before anything is dispatched, the way a
+    // replay feeds in a trace, so every client action carries a lower counter than the tick the
+    // pause will queue during dispatch.
+    private static (Sequencer Sequencer, OrderBook Book) PausedAtNoon()
+    {
+        var book = new OrderBook(PausingSec);
+        var sequencer = new Sequencer(At(12, 0));
+        sequencer.Add(book, Quiet());
+
+        sequencer.Submit(new OpenTrading {Security = PausingSec, Time = At(12, 0), ReferencePrice = 100});
+        sequencer.Submit(Order(PausingSec, "Company1", "Sell1", Side.Sell, 200, At(12, 1)));
+        sequencer.Submit(Order(PausingSec, "Company2", "Buy1", Side.Buy, 200, At(12, 1)));
+
+        return (sequencer, book);
+    }
+
+    private static DateTime Deadline => At(12, 1) + PauseFor;
+
+    [Test]
+    public void AdvanceTo_DrivesTheBookThroughItsScheduledDay()
+    {
+        // arrange
+        var book = new OrderBook(Sec);
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(book, TradingDay());
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(10, 0));
+
+        // assert - the schedule became actions, stamped at the boundaries rather than at the
+        // instant the caller happened to advance to
+        Assert.AreEqual(2, dispatched.Count);
+        Assert.IsInstanceOf<PreOpenTrading>(dispatched[0].Action);
+        Assert.AreEqual(At(PreOpenAt), dispatched[0].Action.Time);
+        Assert.IsInstanceOf<OpenTrading>(dispatched[1].Action);
+        Assert.AreEqual(At(OpenAt), dispatched[1].Action.Time);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void AdvanceTo_QueuesOnlyTheBoundaryAfterTheOneItDispatched()
+    {
+        // arrange - opened, so the close is the one thing pending
+        var book = new OrderBook(Sec);
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(book, TradingDay());
+        sequencer.AdvanceTo(At(10, 0));
+
+        // act - past the close, and past nothing else: tomorrow's pre-open is queued but not due
+        var dispatched = sequencer.AdvanceTo(At(18, 0));
+
+        // assert
+        Assert.AreEqual(1, dispatched.Count);
+        var close = dispatched[0].Action as CloseTrading;
+        Assert.IsNotNull(close);
+        Assert.AreEqual(At(CloseAt), close.Time);
+        Assert.IsTrue(close.EndsTradingDay, "a lone session is also the day's last");
+        Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+    }
+
+    [Test]
+    public void AdvanceTo_TheFollowingDay_OpensAgain()
+    {
+        // arrange
+        var book = new OrderBook(Sec);
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(book, TradingDay());
+        sequencer.AdvanceTo(At(18, 0));
+
+        // act
+        var dispatched = sequencer.AdvanceTo(Day.AddDays(1).Add(OpenAt));
+
+        // assert - one pending transition at a time, however far ahead the schedule runs
+        Assert.AreEqual(2, dispatched.Count);
+        Assert.IsInstanceOf<PreOpenTrading>(dispatched[0].Action);
+        Assert.AreEqual(Day.AddDays(1).Add(PreOpenAt), dispatched[0].Action.Time);
+        Assert.IsInstanceOf<OpenTrading>(dispatched[1].Action);
+        Assert.AreEqual(Day.AddDays(1).Add(OpenAt), dispatched[1].Action.Time);
+    }
+
+    [Test]
+    public void AdvanceTo_NothingDue_DispatchesNothingAndHoldsLogicalNow()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(8, 0));
+
+        // assert
+        Assert.AreEqual(0, dispatched.Count);
+        Assert.AreEqual(At(8, 0), sequencer.LogicalNow);
+    }
+
+    [Test]
+    public void AdvanceTo_ScheduleTransitionBeatsClientFlowAtTheSameInstant()
+    {
+        // arrange - an order stamped exactly at the open, submitted before the open was queued at
+        // all. Its counter is the lower one, so only the kind can put the venue's transition first
+        var book = new OrderBook(Sec);
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(book, TradingDay());
+        sequencer.Submit(Order(Sec, "Company1", "Order1", Side.Buy, 90, At(OpenAt)));
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(OpenAt));
+
+        // assert - the book decides what it is doing before anyone trades into it
+        Assert.AreEqual(3, dispatched.Count);
+        Assert.IsInstanceOf<PreOpenTrading>(dispatched[0].Action);
+        Assert.IsInstanceOf<OpenTrading>(dispatched[1].Action);
+        Assert.IsInstanceOf<CreateLimitOrder>(dispatched[2].Action);
+    }
+
+    [Test]
+    public void AdvanceTo_InterruptionTickBeatsClientFlowAtTheSameInstant()
+    {
+        // arrange - an order stamped exactly at the resume deadline, submitted up front and so
+        // carrying a lower counter than the tick the pause queues later. Without a kind to rank
+        // them it would be dispatched into a book that should already have reopened
+        var (sequencer, book) = PausedAtNoon();
+        sequencer.Submit(Order(PausingSec, "Company1", "Buy2", Side.Buy, 90, Deadline));
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(12, 30));
+
+        // assert
+        Assert.AreEqual(5, dispatched.Count);
+
+        Assert.IsInstanceOf<AdvanceTime>(dispatched[3].Action);
+        var resumed = dispatched[3].Events.OfType<StatusChanged>().Single();
+        Assert.AreEqual(OrderBookStatus.Open, resumed.Status);
+        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+
+        Assert.IsInstanceOf<CreateLimitOrder>(dispatched[4].Action);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void AdvanceTo_ClientFlowAtOneInstant_DispatchedInSubmissionOrder()
+    {
+        // arrange - a burst sharing an instant, which the counter is what orders
+        var book = new OrderBook(Sec);
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(book, TradingDay());
+        sequencer.Submit(Order(Sec, "Company1", "Order1", Side.Buy, 90, At(10, 0)));
+        sequencer.Submit(Order(Sec, "Company2", "Order2", Side.Buy, 91, At(10, 0)));
+        sequencer.Submit(Order(Sec, "Company1", "Order3", Side.Buy, 92, At(10, 0)));
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(10, 0));
+
+        // assert
+        Assert.AreEqual(new[] {"Order1", "Order2", "Order3"},
+            dispatched.Where(d => d.Action is OrderAction)
+                .Select(d => ((OrderAction) d.Action).ClientOrderId)
+                .ToArray());
+    }
+
+    [Test]
+    public void AdvanceTo_Pause_PokesTheBookAtItsDeadline()
+    {
+        // arrange - nothing else is submitted, so only the book's own event brings it back
+        var (sequencer, book) = PausedAtNoon();
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(12, 30));
+
+        // assert
+        var tick = dispatched.Single(d => d.Action is AdvanceTime);
+        Assert.AreEqual(Deadline, tick.Action.Time);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+
+        // poked punctually, the deadline and the poke are the same instant - which is what stops
+        // the resume being stamped anywhere else
+        var resumed = tick.Events.OfType<StatusChanged>().Single();
+        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+        Assert.AreEqual(Deadline, resumed.Time);
+
+        // and the pause resolves into one uncrossing print, stamped there too
+        var matched = tick.Events.OfType<OrdersMatched>().Single();
+        Assert.AreEqual(200, matched.Price);
+        Assert.AreEqual(Deadline, matched.Time);
+    }
+
+    [Test]
+    public void AdvanceTo_StoppingShortOfTheDeadline_LeavesTheBookPaused()
+    {
+        // arrange
+        var (sequencer, book) = PausedAtNoon();
+
+        // act - a minute short
+        var dispatched = sequencer.AdvanceTo(Deadline - TimeSpan.FromMinutes(1));
+
+        // assert
+        Assert.AreEqual(0, dispatched.Count(d => d.Action is AdvanceTime));
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status);
+    }
+
+    [Test]
+    public void AdvanceTo_CloseBeforeTheDeadline_LeavesTheTickInert()
+    {
+        // arrange - the session closes over the running pause, which clears the book's own resume
+        // time. Nothing cancels the poke that was queued for it
+        var (sequencer, book) = PausedAtNoon();
+        sequencer.Submit(new CloseTrading {Security = PausingSec, Time = At(12, 2)});
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(12, 30));
+
+        // assert - the tick still arrives, finds nothing to supersede, and does nothing. No
+        // interruption epoch on the action, no cancellation bookkeeping
+        var tick = dispatched.Single(d => d.Action is AdvanceTime);
+        Assert.AreEqual(Deadline, tick.Action.Time);
+        Assert.AreEqual(0, tick.Events.Count);
+        Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+    }
+
+    [Test]
+    public void AdvanceTo_Sequence_CountsEveryDispatchWhateverQueuedIt()
+    {
+        // arrange
+        var (sequencer, book) = PausedAtNoon();
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(23, 20));
+
+        // assert - client flow, the schedule's own transitions and an interruption tick all count,
+        // because the number is the venue's order of events rather than a count of client actions
+        Assert.AreEqual(6, dispatched.Count);
+        Assert.AreEqual(new long[] {1, 2, 3, 4, 5, 6}, dispatched.Select(d => d.Sequence).ToArray());
+        Assert.AreEqual(1, dispatched.Count(d => d.Action is AdvanceTime), "the interruption tick");
+        Assert.AreEqual(2, dispatched.Count(d => d.Action.Time >= At(23, 0)),
+            "the schedule's own pre-open and open");
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void AdvanceTo_SameInputs_SameDispatchOrder()
+    {
+        // arrange - the whole point of one queue with a total order on its entries: nothing about
+        // the dispatch stream depends on anything but the inputs
+        static IReadOnlyList<(long Sequence, string Action, DateTime Time)> Run()
+        {
+            var (sequencer, _) = PausedAtNoon();
+            sequencer.Submit(Order(PausingSec, "Company1", "Buy2", Side.Buy, 90, Deadline));
+            sequencer.Submit(Order(PausingSec, "Company2", "Sell2", Side.Sell, 300, At(12, 10)));
+
+            return sequencer.AdvanceTo(At(23, 20))
+                .Select(d => (d.Sequence, d.Action.GetType().Name, d.Action.Time))
+                .ToList();
+        }
+
+        // act
+        var first = Run();
+        var second = Run();
+
+        // assert
+        Assert.AreEqual(first, second);
+    }
+
+    [Test]
+    public void Add_MidSession_QueuesTheNextBoundaryAndNotTheOnesItMissed()
+    {
+        // arrange - registered at noon, with the session's pre-open and open already behind it
+        var book = new OrderBook(Sec);
+        var sequencer = new Sequencer(At(12, 0));
+        sequencer.Add(book, TradingDay());
+
+        // act
+        var dispatched = sequencer.AdvanceTo(At(18, 0));
+
+        // assert - a schedule is asked what is next, never what was missed. Bringing a book up to
+        // date is the job of whoever starts the venue
+        Assert.AreEqual(1, dispatched.Count);
+        Assert.IsInstanceOf<CloseTrading>(dispatched[0].Action);
+    }
+
+    [Test]
+    public void Add_TwiceForTheSameSecurity_ArgumentException()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+
+        // assert
+        Assert.Catch<ArgumentException>(
+            () => sequencer.Add(new OrderBook(Sec), TradingDay())
+        );
+    }
+
+    [Test]
+    public void Submit_BehindLogicalNow_ArgumentException()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+        sequencer.AdvanceTo(At(12, 0));
+
+        // assert - the past has been dispatched and cannot be inserted into
+        Assert.Catch<ArgumentException>(
+            () => sequencer.Submit(Order(Sec, "Company1", "Order1", Side.Buy, 90, At(11, 59)))
+        );
+    }
+
+    [Test]
+    public void Submit_AtLogicalNow_Accepted()
+    {
+        // arrange - the boundary case on the other side: the instant itself is still open, because
+        // a burst may share it
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+        sequencer.AdvanceTo(At(12, 0));
+
+        // act
+        sequencer.Submit(Order(Sec, "Company1", "Order1", Side.Buy, 90, At(12, 0)));
+        var dispatched = sequencer.AdvanceTo(At(12, 0));
+
+        // assert
+        Assert.AreEqual(1, dispatched.Count);
+        Assert.IsInstanceOf<CreateLimitOrder>(dispatched[0].Action);
+    }
+
+    [Test]
+    public void Submit_Unstamped_ArgumentException()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+
+        // assert - an action with no time has no place in a queue ordered by time
+        Assert.Catch<ArgumentException>(
+            () => sequencer.Submit(new AdvanceTime {Security = Sec})
+        );
+    }
+
+    [Test]
+    public void Submit_SecurityWithNoBook_ArgumentException()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+        var unregistered = new Security("SIZ6", SecurityType.Future, 10, 10);
+
+        // assert - heard about where the routing mistake was made, not mid-dispatch
+        Assert.Catch<ArgumentException>(
+            () => sequencer.Submit(Order(unregistered, "Company1", "Order1", Side.Buy, 90, At(12, 0)))
+        );
+    }
+
+    [Test]
+    public void AdvanceTo_Backwards_ArgumentException()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+        sequencer.AdvanceTo(At(12, 0));
+
+        // assert
+        Assert.Catch<ArgumentException>(() => sequencer.AdvanceTo(At(11, 0)));
+    }
+
+    [Test]
+    public void AdvanceTo_HoldsLogicalNowAtTheTargetRatherThanTheLastThingDispatched()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Sec), TradingDay());
+
+        // act - the last thing dispatched was the open at 09:30
+        sequencer.AdvanceTo(At(14, 0));
+
+        // assert
+        Assert.AreEqual(At(14, 0), sequencer.LogicalNow);
+    }
+}


### PR DESCRIPTION
Phase 2: the sequencer, one security. Builds directly on the `MarketSchedule` extracted in #65.

## What it is

A book throws if it is handed an action stamped behind the last one it saw, so something has to own the decision about what reaches a book first. `Sequencer` is that thing, and the only component that knows more than one security exists.

```csharp
public sealed class Sequencer
{
    public Sequencer(DateTime start);

    public DateTime LogicalNow { get; }

    public void Add(IOrderBook book, MarketSchedule schedule);
    public void Submit(OrderBookAction action);
    public IReadOnlyList<Dispatched> AdvanceTo(DateTime time);
}

public readonly record struct Dispatched(long Sequence, OrderBookAction Action,
    IReadOnlyList<OrderBookEvent> Events);
```

Three sources feed one queue. Client flow arrives already stamped, through `Submit`. Schedule transitions come from asking each book's `MarketSchedule` what is next — the extraction in #65 is what makes that a question the sequencer can ask rather than a walk it has to drive. Interruption ticks come from the books' own events: a book saying when its pause is due back becomes a poke queued at that instant, which is the only feedback in the system.

## Ordering, and why `Kind` earns its place

`(Time, Kind, Sequence)`, with schedule transitions first, interruption ticks next, client flow last.

The rank is not decoration. In a replay every client action is submitted up front and so carries a lower counter than any tick queued later — so a counter alone would dispatch an order stamped exactly at a resume deadline *before* the resume, leaving it to meet a paused book that should already have reopened. I checked that claim rather than asserting it: inverting the enum's order fails exactly `AdvanceTo_ScheduleTransitionBeatsClientFlowAtTheSameInstant` and `AdvanceTo_InterruptionTickBeatsClientFlowAtTheSameInstant`, and nothing else.

Per-book monotonicity is not enforced separately — it falls out of dispatching in global time order, which is the point of one queue rather than one per book. Every entry carries a unique counter, so no two ever compare equal and dispatch order is a function of the inputs alone. `AdvanceTo_SameInputs_SameDispatchOrder` pins that.

## Resumes stay punctual without an epoch

The sequencer never decides when an interruption ends. It queues a poke at the deadline the book published, and the book's own resume time stays the authority. Nothing is ever cancelled: a close landing before the deadline clears the book's resume time, and the tick that arrives afterwards finds nothing to do (`AdvanceTo_CloseBeforeTheDeadline_LeavesTheTickInert` asserts the tick dispatches and produces zero events). An interruption that extends emits a fresh deadline, which queues a fresh tick and leaves the earlier one inert.

Poked punctually, a deadline and its poke are the same instant — so #65's resume stamp and this land in the same place, which `AdvanceTo_Pause_PokesTheBookAtItsDeadline` checks on both the status change and the uncrossing print.

## Decisions worth your eye

- **`Dispatched` carries no book reference.** `Action.Security` is which book this was, and every event names its own security, so nothing downstream needs a handle — which is what lets the type survive an action that implies a fill in another.
- **The registry is keyed on the security's *name*, not the record.** Two `Security` values describing one contract need not be equal, since the restriction list on them compares by reference. Keying on the record would let "no book is registered for GCZ6" happen while a book for GCZ6 sat in the table.
- **A book registered mid-session is not caught up.** The schedule is asked what is next, never what was missed, so a book added between its open and its close stays as it is until that close arrives. Bringing it up to date belongs to whoever starts the venue. `Add_MidSession_QueuesTheNextBoundaryAndNotTheOnesItMissed` says so rather than leaving it to be found.
- **A scheduled opening carries no reference price.** §6 keeps that decision outside the engine and submitted as an ordinary action, and "what not to build" rules out a lookup wired into the schedule — so the sequencer builds `PreOpenTrading`/`OpenTrading` with none. That leaves an open question I did not want to answer on spec: an operator-supplied `OpenTrading { ReferencePrice = … }` submitted for the same instant as the schedule's own opening would be a second transition, not a merged one. Worth settling before anything relies on it.
- **`Sequencer(DateTime start)`** — the sketch had no constructor, but logical now has to begin somewhere: a replay at the start of its trace, a live pump at its clock. `Add` queues each book's first boundary relative to it.
- Books registered here should be bare `OrderBook`s. A `TimestampingOrderBook` would stamp its own clock reading over the instant the sequencer decided the action happened at. Said in the type comment; not enforced.

## Tests

20 new tests in `tests/Circus.Tests/Sequencing/SequencerTests.cs`, one book throughout — the scheduled day and the roll into the next one, one pending transition at a time, both ties, submission order within an instant, a pause poked at its deadline and one stopped short of it, the inert tick, the dispatch counter covering transitions and ticks as well as client flow, determinism, and the refusals (behind logical now, unstamped, unregistered security, duplicate registration, advancing backwards).

## Verification

Built and ran locally this time: **417 tests pass, 0 failures** on `net10.0`, plus the mutation check above. I got a working SDK by installing `dotnet-sdk-10.0` from `packages.microsoft.com`, which this environment's network policy does allow even though `builds.dotnet.microsoft.com` (the `dotnet-install.sh` path that failed on #65) is blocked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGRw4mRd2xujbSffPvTXZr)_