### PR TITLE
Give the sequencer a way in from a trace and from a clock

### DIFF
--- a/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
+++ b/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
@@ -1,5 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using Circus.Actions;
+using Circus.Sequencing;
+using Circus.Sessions;
 using Circus.Simulator;
 
 namespace Circus.Benchmarks;
@@ -16,6 +18,10 @@ public class OrderBookThroughputBenchmarks
     private Security _security = null!;
     private IReadOnlyList<OrderBookAction> _trace = null!;
 
+    // The trace runs from 09:00, so an evening session never comes due within it.
+    private static readonly MarketSchedule OutOfTheWay =
+        new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
+
     [GlobalSetup]
     public void Setup()
     {
@@ -24,7 +30,7 @@ public class OrderBookThroughputBenchmarks
         _trace = simulator.Generate(ActionCount);
     }
 
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public int ReplayTrace()
     {
         // No clock: the trace carries the time each action happened, so replaying it is the
@@ -36,6 +42,31 @@ public class OrderBookThroughputBenchmarks
         var eventCount = 0;
         foreach (var action in _trace)
             eventCount += book.Process(action).Count;
+
+        return eventCount;
+    }
+
+    // The same trace and the same book, reached through the queue that decides what order things
+    // happened in. Against the baseline above, the difference is what sequencing costs: a
+    // priority-queue insert and pop per action, a routing lookup, and a scan of each action's
+    // events for an interruption deadline.
+    //
+    // Worth having as a number rather than an assumption, since every action in a running venue
+    // pays it.
+    [Benchmark]
+    public int ReplayTraceThroughSequencer()
+    {
+        var book = new OrderBook(_security);
+        var sequencer = new Sequencer(_trace[0].Time);
+
+        // A schedule whose boundaries fall outside the trace, so what is measured is the queue
+        // rather than transitions the baseline never dispatched. Opening is submitted instead,
+        // matching the baseline action for action.
+        sequencer.Add(book, OutOfTheWay);
+        sequencer.Submit(new OpenTrading {Security = _security, Time = _trace[0].Time});
+
+        var eventCount = 0;
+        Replay.Run(sequencer, _trace, d => eventCount += d.Events.Count);
 
         return eventCount;
     }

--- a/src/Circus.Simulator/OrderFlowSimulator.cs
+++ b/src/Circus.Simulator/OrderFlowSimulator.cs
@@ -5,38 +5,28 @@ using Circus.MarketData;
 namespace Circus.Simulator;
 
 // Generates a plausible, replayable stream of order book actions (create/cancel/update,
-// limit/market) for a single security. Drives a private "shadow" order book purely to keep
-// track of which orders are currently live, so that generated cancels/updates always target
-// a real resting order instead of a random, possibly-already-filled id.
+// limit/market) across one or more securities. Drives a private "shadow" book per security
+// purely to keep track of which orders are currently live, so that generated cancels/updates
+// always target a real resting order instead of a random, possibly-already-filled id.
+//
+// Several securities produce one interleaved trace rather than one trace each: a venue's flow
+// arrives mixed, and a sequencer being fed this is exactly the thing that has to put it back in
+// order. Each security's shadow book, level view and live-order set are its own, so flow on one
+// never depends on what another was doing - the same independence the real books have.
 //
 // Pass a seed for a deterministic, reproducible trace (e.g. a committed benchmark baseline);
 // omit it to get a fresh random trace each run (e.g. fuzzing).
 public sealed class OrderFlowSimulator
 {
-    private readonly Security _security;
     private readonly SimulatorOptions _options;
     private readonly Random _random;
     private readonly int _seed;
 
-    private readonly OrderBook _shadowBook;
-
-    // The touch, rebuilt from the shadow book's events the same way any market data consumer
-    // would - the book itself answers no questions about its levels.
-    private readonly LevelDataProducer _touch = new(1);
-    private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
-
-    // Keyed by ClientOrderId, not ExchangeOrderId - the latter no longer stays constant for
-    // an order's whole life (a reprice, a quantity increase, or an iceberg peak refilling
-    // from its hidden reserve all mint a fresh one), so it can't be used as a stable tracking
-    // key here. ClientOrderId changes too (a new one is chosen on every update/cancel), but
-    // this class is itself the one choosing each new value, so it renames its own tracking
-    // entries in lockstep rather than needing a truly immutable id.
-    private readonly List<string> _liveIds = new();
-    private readonly Dictionary<string, int> _liveIndex = new();
-    private readonly Dictionary<string, LiveOrderInfo> _liveInfo = new();
+    private readonly List<BookState> _books;
 
     // deterministic (derived from the seeded action sequence, not Guid.NewGuid()) so traces
-    // stay reproducible for a given seed
+    // stay reproducible for a given seed. Shared across securities so no two orders anywhere in
+    // a trace collide on a client order id.
     private long _nextId;
 
     // A fixed epoch rather than DateTime.UtcNow, and a fixed step per action: a trace is
@@ -48,22 +38,31 @@ public sealed class OrderFlowSimulator
     private DateTime _time = Epoch;
 
     public OrderFlowSimulator(Security security, SimulatorOptions? options = null, int? seed = null)
+        : this(new[] {security}, options, seed)
     {
-        _security = security;
+    }
+
+    public OrderFlowSimulator(IReadOnlyList<Security> securities, SimulatorOptions? options = null,
+        int? seed = null)
+    {
+        if (securities.Count == 0)
+            throw new ArgumentException("at least one security is required", nameof(securities));
+
         _options = options ?? new SimulatorOptions();
         _seed = seed ?? Random.Shared.Next();
         _random = new Random(_seed);
 
-        _shadowBook = new OrderBook(_security);
-        _shadowBook.Process(new OpenTrading {Security = _security, Time = _time});
+        _books = securities.Select(s => new BookState(s, _time)).ToList();
     }
 
     public int Seed => _seed;
 
-    // Generates the next `actionCount` actions, continuing from wherever the internal
-    // shadow book currently is (i.e. calling this repeatedly extends the same session
-    // rather than restarting it). The returned list contains only the newly generated
-    // batch, not the full history.
+    public IReadOnlyList<Security> Securities => _books.Select(b => b.Security).ToList();
+
+    // Generates the next `actionCount` actions, continuing from wherever the internal shadow
+    // books currently are (i.e. calling this repeatedly extends the same session rather than
+    // restarting it). The returned list contains only the newly generated batch, not the full
+    // history.
     public IReadOnlyList<OrderBookAction> Generate(int actionCount)
     {
         var actions = new List<OrderBookAction>(actionCount);
@@ -73,165 +72,84 @@ public sealed class OrderFlowSimulator
             // Stamped here rather than in each Build* method, so every action gets one and the
             // trace a caller receives is self-contained - replayable without a clock beside it.
             _time += Step;
-            var action = NextAction() with {Time = _time};
+
+            // Not drawn at all when there is only one book to draw. A draw consumes the seeded
+            // sequence, so making it unconditionally would have shifted every trace this class
+            // has ever produced for a single security - including the committed benchmark
+            // baseline - for no reason beyond tidiness.
+            var book = _books.Count == 1 ? _books[0] : _books[_random.Next(_books.Count)];
+            var action = NextAction(book) with {Time = _time};
+
             actions.Add(action);
-            Apply(action);
+            book.Apply(action);
         }
 
         return actions;
     }
 
-    private void Apply(OrderBookAction action)
-    {
-        var events = _shadowBook.Process(action);
-
-        foreach (var levels in _touch.Process(_shadowBook, events))
-            _levels = levels;
-
-        foreach (var e in events)
-        {
-            switch (e)
-            {
-                case CreateOrderConfirmed c:
-                    Track(c.Order, previousClientOrderId: null);
-                    break;
-                case UpdateOrderConfirmed u:
-                    Track(u.Order, u.PreviousClientOrderId);
-                    break;
-                case CancelOrderConfirmed cancel:
-                    RemoveLive(cancel.PreviousClientOrderId);
-                    break;
-                case ExpireOrderConfirmed expire:
-                    RemoveLive(expire.Order.ClientOrderId);
-                    break;
-                case OrdersMatched matched:
-                    foreach (var fill in matched.Fills)
-                    {
-                        if (fill.Order.RemainingQuantity == 0)
-                            RemoveLive(fill.Order.ClientOrderId);
-                    }
-                    break;
-            }
-        }
-    }
-
-    // previousClientOrderId is null for a fresh Create, and the id being renamed from for an
-    // Update - renaming (rather than remove-then-add under whatever key happens to already
-    // be there) keeps a single live entry across the chain of client order ids one logical
-    // resting order accumulates over its life.
-    private void Track(Order order, string? previousClientOrderId)
-    {
-        if (order.RemainingQuantity == 0)
-        {
-            RemoveLive(previousClientOrderId ?? order.ClientOrderId);
-            return;
-        }
-
-        if (previousClientOrderId != null && previousClientOrderId != order.ClientOrderId)
-            RemoveLive(previousClientOrderId);
-
-        if (!_liveIndex.ContainsKey(order.ClientOrderId))
-        {
-            _liveIndex[order.ClientOrderId] = _liveIds.Count;
-            _liveIds.Add(order.ClientOrderId);
-        }
-
-        _liveInfo[order.ClientOrderId] = new LiveOrderInfo(order.CompanyId, order.ClientOrderId, order.Side,
-            order.Price, order.TriggerPrice);
-    }
-
-    private void RemoveLive(string clientOrderId)
-    {
-        if (!_liveIndex.TryGetValue(clientOrderId, out var index))
-            return;
-
-        var lastIndex = _liveIds.Count - 1;
-        var lastId = _liveIds[lastIndex];
-        _liveIds[index] = lastId;
-        _liveIndex[lastId] = index;
-        _liveIds.RemoveAt(lastIndex);
-
-        _liveIndex.Remove(clientOrderId);
-        _liveInfo.Remove(clientOrderId);
-    }
-
-    private bool TryPickLive(out string clientOrderId, out LiveOrderInfo info)
-    {
-        if (_liveIds.Count == 0)
-        {
-            clientOrderId = default!;
-            info = default!;
-            return false;
-        }
-
-        clientOrderId = _liveIds[_random.Next(_liveIds.Count)];
-        info = _liveInfo[clientOrderId];
-        return true;
-    }
-
     private string NextCompanyId() => $"c{_nextId++}";
     private string NextClientOrderId() => $"o{_nextId++}";
 
-    private OrderBookAction NextAction()
+    private OrderBookAction NextAction(BookState book)
     {
-        var hasLive = _liveIds.Count > 0;
+        var hasLive = book.HasLive;
         var roll = _random.NextDouble();
 
         if (hasLive)
         {
             if (roll < _options.CancelWeight)
-                return BuildCancel();
+                return BuildCancel(book);
             roll -= _options.CancelWeight;
 
             if (roll < _options.UpdateWeight)
-                return BuildUpdate();
+                return BuildUpdate(book);
             roll -= _options.UpdateWeight;
         }
 
         if (roll < _options.MarketOrderWeight)
-            return BuildCreateMarket();
+            return BuildCreateMarket(book);
 
-        return BuildCreateLimit();
+        return BuildCreateLimit(book);
     }
 
-    private CreateLimitOrder BuildCreateLimit()
+    private CreateLimitOrder BuildCreateLimit(BookState book)
     {
         var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
-        var price = ComputePrice(side);
+        var price = ComputePrice(book, side);
         var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
 
         return new CreateLimitOrder
         {
-            Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
+            Security = book.Security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
             OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity, Price = price
         };
     }
 
-    private CreateMarketOrder BuildCreateMarket()
+    private CreateMarketOrder BuildCreateMarket(BookState book)
     {
         var side = _random.Next(2) == 0 ? Side.Buy : Side.Sell;
         var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
 
         return new CreateMarketOrder
         {
-            Security = _security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
+            Security = book.Security, CompanyId = NextCompanyId(), ClientOrderId = NextClientOrderId(),
             OrderValidity = new OrderValidity.GoodTilCanceled(), Side = side, Quantity = quantity
         };
     }
 
-    private CancelOrder BuildCancel()
+    private CancelOrder BuildCancel(BookState book)
     {
-        TryPickLive(out _, out var info);
+        var info = book.PickLive(_random);
         return new CancelOrder
         {
-            Security = _security, CompanyId = info.CompanyId, ClientOrderId = NextClientOrderId(),
+            Security = book.Security, CompanyId = info.CompanyId, ClientOrderId = NextClientOrderId(),
             PreviousClientOrderId = info.ClientOrderId
         };
     }
 
-    private UpdateOrder BuildUpdate()
+    private UpdateOrder BuildUpdate(BookState book)
     {
-        TryPickLive(out _, out var info);
+        var info = book.PickLive(_random);
         var newClientOrderId = NextClientOrderId();
 
         // stop orders keep a Price/TriggerPrice relationship that a blind tweak could
@@ -242,31 +160,31 @@ public sealed class OrderFlowSimulator
             var quantity = _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
             return new UpdateOrder
             {
-                Security = _security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
+                Security = book.Security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
                 PreviousClientOrderId = info.ClientOrderId, NewTotalQuantity = quantity
             };
         }
 
-        var tick = _security.TickSize;
+        var tick = book.Security.TickSize;
         var direction = info.Side == Side.Buy ? -1 : 1; // move away from touch, staying passive
-        var reference = info.Price ?? AlignToTick(_options.StartingPrice);
+        var reference = info.Price ?? AlignToTick(book.Security, _options.StartingPrice);
         var newPrice = reference + direction * _random.Next(1, 4) * tick;
 
         return new UpdateOrder
         {
-            Security = _security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
+            Security = book.Security, CompanyId = info.CompanyId, ClientOrderId = newClientOrderId,
             PreviousClientOrderId = info.ClientOrderId, Price = newPrice
         };
     }
 
-    private decimal ComputePrice(Side side)
+    private decimal ComputePrice(BookState book, Side side)
     {
-        var tick = _security.TickSize;
-        var bestBuy = _levels.Bids;
-        var bestSell = _levels.Offers;
+        var tick = book.Security.TickSize;
+        var bestBuy = book.Levels.Bids;
+        var bestSell = book.Levels.Offers;
 
         if (bestBuy.Count == 0 && bestSell.Count == 0)
-            return AlignToTick(_options.StartingPrice);
+            return AlignToTick(book.Security, _options.StartingPrice);
 
         var opposite = side == Side.Buy ? bestSell : bestBuy;
         var own = side == Side.Buy ? bestBuy : bestSell;
@@ -285,10 +203,127 @@ public sealed class OrderFlowSimulator
         return side == Side.Buy ? reference - offsetTicks * tick : reference + offsetTicks * tick;
     }
 
-    private decimal AlignToTick(decimal price)
+    private static decimal AlignToTick(Security security, decimal price)
     {
-        var tick = _security.TickSize;
+        var tick = security.TickSize;
         return Math.Round(price / tick) * tick;
+    }
+
+    // One security's worth of the modelling the simulator needs to generate flow that targets
+    // real resting orders: a shadow book, the touch rebuilt from its events, and the set of
+    // orders currently live in it.
+    //
+    // Not a venue in miniature - no schedule, no sequencer. The book here is a tracking device
+    // for "what is still resting", opened once and never moved through a session again, so
+    // routing it through a sequencer would buy nothing and cost the simulator a schedule it has
+    // no opinion about.
+    private sealed class BookState
+    {
+        private readonly OrderBook _shadowBook;
+
+        // The touch, rebuilt from the shadow book's events the same way any market data consumer
+        // would - the book itself answers no questions about its levels.
+        private readonly LevelDataProducer _touch = new(1);
+
+        // Keyed by ClientOrderId, not ExchangeOrderId - the latter no longer stays constant for
+        // an order's whole life (a reprice, a quantity increase, or an iceberg peak refilling
+        // from its hidden reserve all mint a fresh one), so it can't be used as a stable tracking
+        // key here. ClientOrderId changes too (a new one is chosen on every update/cancel), but
+        // the simulator is itself the one choosing each new value, so it renames its own tracking
+        // entries in lockstep rather than needing a truly immutable id.
+        private readonly List<string> _liveIds = new();
+        private readonly Dictionary<string, int> _liveIndex = new();
+        private readonly Dictionary<string, LiveOrderInfo> _liveInfo = new();
+
+        public BookState(Security security, DateTime openedAt)
+        {
+            Security = security;
+            _shadowBook = new OrderBook(security);
+            _shadowBook.Process(new OpenTrading {Security = security, Time = openedAt});
+        }
+
+        public Security Security { get; }
+
+        public LevelsDataEvent Levels { get; private set; } =
+            new(default, Array.Empty<Level>(), Array.Empty<Level>());
+
+        public bool HasLive => _liveIds.Count > 0;
+
+        public LiveOrderInfo PickLive(Random random) => _liveInfo[_liveIds[random.Next(_liveIds.Count)]];
+
+        public void Apply(OrderBookAction action)
+        {
+            var events = _shadowBook.Process(action);
+
+            foreach (var levels in _touch.Process(_shadowBook, events))
+                Levels = levels;
+
+            foreach (var e in events)
+            {
+                switch (e)
+                {
+                    case CreateOrderConfirmed c:
+                        Track(c.Order, previousClientOrderId: null);
+                        break;
+                    case UpdateOrderConfirmed u:
+                        Track(u.Order, u.PreviousClientOrderId);
+                        break;
+                    case CancelOrderConfirmed cancel:
+                        RemoveLive(cancel.PreviousClientOrderId);
+                        break;
+                    case ExpireOrderConfirmed expire:
+                        RemoveLive(expire.Order.ClientOrderId);
+                        break;
+                    case OrdersMatched matched:
+                        foreach (var fill in matched.Fills)
+                        {
+                            if (fill.Order.RemainingQuantity == 0)
+                                RemoveLive(fill.Order.ClientOrderId);
+                        }
+                        break;
+                }
+            }
+        }
+
+        // previousClientOrderId is null for a fresh Create, and the id being renamed from for an
+        // Update - renaming (rather than remove-then-add under whatever key happens to already
+        // be there) keeps a single live entry across the chain of client order ids one logical
+        // resting order accumulates over its life.
+        private void Track(Order order, string? previousClientOrderId)
+        {
+            if (order.RemainingQuantity == 0)
+            {
+                RemoveLive(previousClientOrderId ?? order.ClientOrderId);
+                return;
+            }
+
+            if (previousClientOrderId != null && previousClientOrderId != order.ClientOrderId)
+                RemoveLive(previousClientOrderId);
+
+            if (!_liveIndex.ContainsKey(order.ClientOrderId))
+            {
+                _liveIndex[order.ClientOrderId] = _liveIds.Count;
+                _liveIds.Add(order.ClientOrderId);
+            }
+
+            _liveInfo[order.ClientOrderId] = new LiveOrderInfo(order.CompanyId, order.ClientOrderId,
+                order.Side, order.Price, order.TriggerPrice);
+        }
+
+        private void RemoveLive(string clientOrderId)
+        {
+            if (!_liveIndex.TryGetValue(clientOrderId, out var index))
+                return;
+
+            var lastIndex = _liveIds.Count - 1;
+            var lastId = _liveIds[lastIndex];
+            _liveIds[index] = lastId;
+            _liveIndex[lastId] = index;
+            _liveIds.RemoveAt(lastIndex);
+
+            _liveIndex.Remove(clientOrderId);
+            _liveInfo.Remove(clientOrderId);
+        }
     }
 
     private readonly record struct LiveOrderInfo(string CompanyId, string ClientOrderId, Side Side,

--- a/src/Circus/Sequencing/LiveDriver.cs
+++ b/src/Circus/Sequencing/LiveDriver.cs
@@ -1,0 +1,52 @@
+using Circus.Actions;
+using Circus.Time;
+
+namespace Circus.Sequencing;
+
+// Drives a sequencer off a clock, and is the only place in a running venue that reads wall-clock
+// time. Books hold no clock and the sequencer holds none either; everything downstream is a
+// function of actions that already carry their instant, and this is where that instant is
+// decided.
+//
+// Two halves of one job. Submit stamps an arriving action with the time it arrived, the way a
+// gateway stamps an inbound message and the matching engine then works off that stamp rather
+// than off whatever the clock reads by the time it reaches the message. Tick advances the
+// sequencer to whatever the clock now says, dispatching that flow along with any schedule
+// boundary or interruption deadline that has come due since the last one.
+//
+// Nothing here decides ordering - the sequencer does. This only decides what time it is, which
+// is the one thing that cannot be derived from the actions in a live venue the way it can in a
+// replay.
+//
+// Single-threaded, like the sequencer it drives: a host calls Tick on a timer from the same
+// thread it calls Submit on, and a gateway on an I/O thread hands work across to that thread
+// rather than calling in. A clock that jumps backwards - an NTP correction mid-session - will
+// be refused by the sequencer rather than quietly reordering the venue, which is the right
+// noise to make.
+public sealed class LiveDriver
+{
+    private readonly Sequencer _sequencer;
+    private readonly IClock _clock;
+
+    public LiveDriver(Sequencer sequencer, IClock clock)
+    {
+        _sequencer = sequencer ?? throw new ArgumentNullException(nameof(sequencer));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    // Queues an action at the instant it arrived, stamping over whatever it carried. A client
+    // does not get to say when its order reached the exchange, so an action arriving here is
+    // stamped rather than trusted - which is also why a pre-stamped trace goes to Replay instead
+    // of through this.
+    public void Submit(OrderBookAction action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        _sequencer.Submit(action with {Time = _clock.GetCurrentTime()});
+    }
+
+    // Dispatches everything that has come due as of now. Called on a timer by whatever hosts the
+    // venue: often enough that an interruption ends near its deadline rather than late, since
+    // nothing else is going to poke it.
+    public IReadOnlyList<Dispatched> Tick() => _sequencer.AdvanceTo(_clock.GetCurrentTime());
+}

--- a/src/Circus/Sequencing/Replay.cs
+++ b/src/Circus/Sequencing/Replay.cs
@@ -1,0 +1,53 @@
+using Circus.Actions;
+
+namespace Circus.Sequencing;
+
+// Feeds a recorded trace through a sequencer, with no clock anywhere: every instant involved
+// comes from the actions themselves. That is the whole difference between this and LiveDriver,
+// and it is what makes a replay reproduce a run rather than merely resemble it.
+//
+// Submitted and advanced action by action rather than submitted all at once. The queue then
+// holds a single action's worth of client flow plus whatever the schedules have pending, instead
+// of the entire trace, which is what lets a day's worth of it replay without being held in
+// memory twice.
+//
+// Dispatch order is unaffected by feeding it that way. Ties are settled by kind before the
+// submission counter, so client flow never reorders against a schedule transition however the
+// counters fall; and two entries of the same kind keep their relative counters however many
+// others were queued between them. Both orderings come out identical, which is asserted rather
+// than assumed.
+public static class Replay
+{
+    // Runs the trace, calling back for each dispatch in order.
+    //
+    // `until` advances once more after the last action, so a close the schedule still has pending
+    // is dispatched rather than left in the queue - a trace that stops mid-session should still
+    // be able to end its day. Ignored if it is not past where the trace already left the
+    // sequencer, since time only runs one way.
+    public static void Run(Sequencer sequencer, IEnumerable<OrderBookAction> trace,
+        Action<Dispatched>? onDispatched = null, DateTime? until = null)
+    {
+        ArgumentNullException.ThrowIfNull(sequencer);
+        ArgumentNullException.ThrowIfNull(trace);
+
+        foreach (var action in trace)
+        {
+            sequencer.Submit(action);
+
+            // To the action's own instant rather than to the end of the trace: anything the
+            // schedule or an interruption has due before it is dispatched first, in its place.
+            Report(sequencer.AdvanceTo(action.Time), onDispatched);
+        }
+
+        if (until is { } end && end > sequencer.LogicalNow)
+            Report(sequencer.AdvanceTo(end), onDispatched);
+    }
+
+    private static void Report(IReadOnlyList<Dispatched> dispatched, Action<Dispatched>? onDispatched)
+    {
+        if (onDispatched == null) return;
+
+        foreach (var d in dispatched)
+            onDispatched(d);
+    }
+}

--- a/tests/Circus.Tests/Circus.Tests.csproj
+++ b/tests/Circus.Tests/Circus.Tests.csproj
@@ -24,6 +24,10 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Circus\Circus.csproj" />
+
+      <!-- The simulator generates the traces the replay tests feed through a sequencer, and has
+           behaviour of its own worth pinning now that it covers several securities. -->
+      <ProjectReference Include="..\..\src\Circus.Simulator\Circus.Simulator.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/Circus.Tests/Sequencing/LiveDriverTests.cs
+++ b/tests/Circus.Tests/Sequencing/LiveDriverTests.cs
@@ -1,0 +1,176 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Time;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sequencing;
+
+// LiveDriver is where wall-clock time enters a running venue and the only place it does. What is
+// under test is that it stamps arriving actions rather than trusting them, and that a tick
+// dispatches whatever has come due - not the sequencer's ordering, which is tested where it
+// lives.
+[TestFixture]
+public class LiveDriverTests
+{
+    private static readonly DateTime Day = new(2000, 1, 1);
+
+    private static readonly Security Gold = new("GCZ6", SecurityType.Future, 10, 10);
+
+    private static readonly TimeSpan PauseFor = TimeSpan.FromMinutes(2);
+
+    // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it.
+    private static readonly Security PausingGold = new("GCZ6", SecurityType.Future, 10, 10,
+        PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)});
+
+    private static MarketSchedule TradingDay() => new(new(9, 0, 0), new(9, 30, 0), new(17, 0, 0));
+
+    private static MarketSchedule Quiet() => new(new(23, 0, 0), new(23, 15, 0), new(23, 45, 0));
+
+    private static DateTime At(int hour, int minute) => Day.Add(new TimeSpan(hour, minute, 0));
+
+    [Test]
+    public void Submit_StampsTheActionWithTheTimeItArrived()
+    {
+        // arrange
+        var clock = new ManualClock(At(12, 0));
+        var (driver, _) = Venue(Gold, clock, Quiet());
+        driver.Submit(new OpenTrading {Security = Gold});
+
+        // act - the order arrives a minute later
+        clock.SetCurrentTime(At(12, 1));
+        driver.Submit(Order("Buy1", Side.Buy, 100));
+        var dispatched = driver.Tick();
+
+        // assert
+        var order = dispatched.Select(d => d.Action).OfType<CreateLimitOrder>().Single();
+        Assert.AreEqual(At(12, 1), order.Time);
+    }
+
+    [Test]
+    public void Submit_StampsOverATimeTheActionAlreadyCarried()
+    {
+        // arrange
+        var clock = new ManualClock(At(12, 0));
+        var (driver, _) = Venue(Gold, clock, Quiet());
+        driver.Submit(new OpenTrading {Security = Gold});
+
+        // act - a client claiming its order arrived an hour ago
+        var backdated = Order("Buy1", Side.Buy, 100) with {Time = At(11, 0)};
+        driver.Submit(backdated);
+        var dispatched = driver.Tick();
+
+        // assert - a participant does not get to say when its order reached the exchange
+        var order = dispatched.Select(d => d.Action).OfType<CreateLimitOrder>().Single();
+        Assert.AreEqual(At(12, 0), order.Time);
+    }
+
+    [Test]
+    public void Tick_DispatchesScheduleBoundariesThatHaveComeDue()
+    {
+        // arrange - a clock starting before the trading day
+        var clock = new ManualClock(Day);
+        var (driver, book) = Venue(Gold, clock, TradingDay());
+
+        // act
+        clock.SetCurrentTime(At(10, 0));
+        var dispatched = driver.Tick();
+
+        // assert - stamped at the boundaries themselves, not at whatever the clock read when the
+        // tick happened to land
+        Assert.AreEqual(2, dispatched.Count);
+        Assert.AreEqual(At(9, 0), dispatched[0].Action.Time);
+        Assert.AreEqual(At(9, 30), dispatched[1].Action.Time);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void Tick_NothingDue_DispatchesNothing()
+    {
+        // arrange
+        var clock = new ManualClock(At(12, 0));
+        var (driver, _) = Venue(Gold, clock, Quiet());
+
+        // act
+        clock.SetCurrentTime(At(12, 5));
+
+        // assert
+        Assert.IsEmpty(driver.Tick());
+    }
+
+    [Test]
+    public void Tick_PastAnInterruptionDeadline_BringsTheBookBack()
+    {
+        // arrange - trade through the band, so the book pauses for two minutes
+        var clock = new ManualClock(At(12, 0));
+        var (driver, book) = Venue(PausingGold, clock, Quiet());
+
+        driver.Submit(new OpenTrading {Security = PausingGold, ReferencePrice = 100});
+        clock.SetCurrentTime(At(12, 1));
+        driver.Submit(Order("Sell1", Side.Sell, 200));
+        driver.Submit(Order("Buy1", Side.Buy, 200));
+        driver.Tick();
+
+        Assert.AreEqual(OrderBookStatus.Paused, book.Status, "expected the band to be breached");
+
+        // act - a tick after the deadline, with no client flow to carry it there
+        clock.SetCurrentTime(At(12, 4));
+        var dispatched = driver.Tick();
+
+        // assert - the poke came from the driver, stamped at the deadline rather than at the tick
+        var tick = dispatched.Select(d => d.Action).OfType<AdvanceTime>().Single();
+        Assert.AreEqual(At(12, 1) + PauseFor, tick.Time);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void Tick_TwiceAtTheSameInstant_DispatchesNothingTheSecondTime()
+    {
+        // arrange
+        var clock = new ManualClock(Day);
+        var (driver, _) = Venue(Gold, clock, TradingDay());
+        clock.SetCurrentTime(At(10, 0));
+
+        // act
+        var first = driver.Tick();
+        var second = driver.Tick();
+
+        // assert - a host ticking on a timer faster than anything comes due is not a problem
+        Assert.IsNotEmpty(first);
+        Assert.IsEmpty(second);
+    }
+
+    [Test]
+    public void Submit_AClockThatWentBackwards_IsRefusedRatherThanReorderingTheVenue()
+    {
+        // arrange
+        var clock = new ManualClock(At(12, 0));
+        var (driver, _) = Venue(Gold, clock, Quiet());
+        driver.Submit(new OpenTrading {Security = Gold});
+        driver.Tick();
+
+        // act - an NTP correction, or a clock nobody guaranteed was monotonic
+        clock.SetCurrentTime(At(11, 59));
+
+        // assert - loud, rather than quietly inserting into a past the venue has dispatched
+        Assert.Throws<ArgumentException>(() => driver.Submit(Order("Buy1", Side.Buy, 100)));
+    }
+
+    private static (LiveDriver Driver, OrderBook Book) Venue(Security security, IClock clock,
+        MarketSchedule schedule)
+    {
+        var book = new OrderBook(security);
+        var sequencer = new Sequencer(clock.GetCurrentTime());
+        sequencer.Add(book, schedule);
+        return (new LiveDriver(sequencer, clock), book);
+    }
+
+    // No time: the driver is the thing that decides that, which is the point.
+    private static CreateLimitOrder Order(string clientOrderId, Side side, decimal price) =>
+        new()
+        {
+            Security = Gold, CompanyId = "Company1", ClientOrderId = clientOrderId,
+            OrderValidity = new OrderValidity.Day(), Side = side, Quantity = 5, Price = price
+        };
+}

--- a/tests/Circus.Tests/Sequencing/ReplayTests.cs
+++ b/tests/Circus.Tests/Sequencing/ReplayTests.cs
@@ -1,0 +1,190 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Simulator;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sequencing;
+
+// Replay feeds a recorded trace through a sequencer with no clock involved. Two things are worth
+// holding: that feeding it action by action produces the same dispatch order as submitting the
+// whole thing up front, since that equivalence is the only reason it is allowed to stream; and
+// that a replay of a trace reproduces a run rather than resembling it.
+[TestFixture]
+public class ReplayTests
+{
+    private static readonly DateTime Day = new(2000, 1, 1);
+
+    private static readonly Security Gold = new("GCZ6", SecurityType.Future, 10, 10);
+    private static readonly Security Silver = new("SIZ6", SecurityType.Future, 10, 10);
+
+    private static MarketSchedule TradingDay() => new(new(9, 0, 0), new(9, 30, 0), new(17, 0, 0));
+
+    // Boundaries late enough that a trace running from midday never reaches them.
+    private static MarketSchedule Quiet() => new(new(23, 0, 0), new(23, 15, 0), new(23, 45, 0));
+
+    private static DateTime At(int hour, int minute) => Day.Add(new TimeSpan(hour, minute, 0));
+
+    [Test]
+    public void Run_DispatchesTheWholeTraceInOrder()
+    {
+        // arrange
+        var book = new OrderBook(Gold);
+        var sequencer = new Sequencer(At(12, 0));
+        sequencer.Add(book, Quiet());
+
+        var trace = new OrderBookAction[]
+        {
+            new OpenTrading {Security = Gold, Time = At(12, 0)},
+            Order(Gold, "Sell1", Side.Sell, 100, At(12, 1)),
+            Order(Gold, "Buy1", Side.Buy, 100, At(12, 2))
+        };
+
+        // act
+        var dispatched = new List<Dispatched>();
+        Replay.Run(sequencer, trace, dispatched.Add);
+
+        // assert - every action, in the order recorded, and the book actually traded
+        Assert.AreEqual(3, dispatched.Count);
+        Assert.AreEqual(new long[] {1, 2, 3}, dispatched.Select(d => d.Sequence).ToArray());
+        Assert.AreEqual(1, dispatched.SelectMany(d => d.Events).OfType<OrdersMatched>().Count());
+    }
+
+    [Test]
+    public void Run_StreamedActionByAction_MatchesSubmittingTheWholeTraceUpFront()
+    {
+        // arrange - a trace long enough, and mixed enough, that a difference in tie-breaking
+        // would show up somewhere in it
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 99).Generate(400);
+
+        // act
+        var streamed = new List<string>();
+        var streamedSequencer = Venue();
+        Replay.Run(streamedSequencer, trace, d => streamed.Add(Describe(d)));
+
+        var upFront = new List<string>();
+        var upFrontSequencer = Venue();
+        foreach (var action in trace)
+            upFrontSequencer.Submit(action);
+        foreach (var d in upFrontSequencer.AdvanceTo(trace[^1].Time))
+            upFront.Add(Describe(d));
+
+        // assert - this is what lets Replay stream rather than hold the whole trace in the queue.
+        // Ties are settled by kind before the submission counter, so client flow never reorders
+        // against a schedule transition however the counters fall, and two entries of one kind
+        // keep their relative counters however many others were queued between them.
+        Assert.AreEqual(upFront, streamed);
+        Assert.IsNotEmpty(streamed);
+    }
+
+    [Test]
+    public void Run_TwiceOverTheSameTrace_ReproducesItExactly()
+    {
+        // arrange
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 4).Generate(400);
+
+        // act
+        var first = new List<string>();
+        Replay.Run(Venue(), trace, d => first.Add(Describe(d)));
+
+        var second = new List<string>();
+        Replay.Run(Venue(), trace, d => second.Add(Describe(d)));
+
+        // assert - the same events, timestamps included, which is what a journal of the trace
+        // would be worth
+        Assert.AreEqual(first, second);
+        Assert.IsNotEmpty(first);
+    }
+
+    [Test]
+    public void Run_Until_DispatchesTheCloseTheTraceStoppedShortOf()
+    {
+        // arrange - a trace that ends mid-session, on a book whose day closes at 17:00
+        var book = new OrderBook(Gold);
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(book, TradingDay());
+
+        var trace = new OrderBookAction[] {Order(Gold, "Buy1", Side.Buy, 100, At(10, 0))};
+
+        // act
+        var dispatched = new List<Dispatched>();
+        Replay.Run(sequencer, trace, dispatched.Add, until: At(18, 0));
+
+        // assert - pre-open and open came due before the order, the close after it
+        Assert.AreEqual(
+            new[]
+            {
+                nameof(PreOpenTrading), nameof(OpenTrading), nameof(CreateLimitOrder),
+                nameof(CloseTrading)
+            },
+            dispatched.Select(d => d.Action.GetType().Name).ToArray());
+        Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+    }
+
+    [Test]
+    public void Run_UntilBehindWhereTheTraceEnded_IsIgnoredRatherThanThrowing()
+    {
+        // arrange
+        var book = new OrderBook(Gold);
+        var sequencer = new Sequencer(At(12, 0));
+        sequencer.Add(book, Quiet());
+
+        var trace = new OrderBookAction[]
+        {
+            new OpenTrading {Security = Gold, Time = At(12, 0)},
+            Order(Gold, "Buy1", Side.Buy, 100, At(14, 0))
+        };
+
+        // act - asking to finish somewhere the trace has already gone past
+        Assert.DoesNotThrow(() => Replay.Run(sequencer, trace, until: At(13, 0)));
+
+        // assert - left where the trace left it, not wound back
+        Assert.AreEqual(At(14, 0), sequencer.LogicalNow);
+    }
+
+    [Test]
+    public void Run_NoTrace_LeavesTheSequencerAlone()
+    {
+        // arrange
+        var sequencer = new Sequencer(At(12, 0));
+        sequencer.Add(new OrderBook(Gold), Quiet());
+
+        // act
+        var dispatched = new List<Dispatched>();
+        Replay.Run(sequencer, Array.Empty<OrderBookAction>(), dispatched.Add);
+
+        // assert
+        Assert.IsEmpty(dispatched);
+        Assert.AreEqual(At(12, 0), sequencer.LogicalNow);
+    }
+
+    // A simulator trace steps a millisecond per action, so 400 of them span 400ms and an ordinary
+    // day's boundaries would leave only the pre-open falling inside it. Compressed so all three
+    // land in the middle of the flow instead: a transition sharing an instant with client flow is
+    // the tie the ordering has to get right, and one at the very start barely tests it.
+    private static Sequencer Venue()
+    {
+        var compressed = new MarketSchedule(
+            new TimeSpan(0, 0, 9, 0, 50),
+            new TimeSpan(0, 0, 9, 0, 150),
+            new TimeSpan(0, 0, 9, 0, 300));
+
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Gold), compressed);
+        sequencer.Add(new OrderBook(Silver), compressed);
+        return sequencer;
+    }
+
+    private static CreateLimitOrder Order(Security security, string clientOrderId, Side side,
+        decimal price, DateTime time) =>
+        new()
+        {
+            Security = security, Time = time, CompanyId = "Company1", ClientOrderId = clientOrderId,
+            OrderValidity = new OrderValidity.Day(), Side = side, Quantity = 5, Price = price
+        };
+
+    private static string Describe(Dispatched d) =>
+        $"{d.Sequence} {d.Action.Security.Name} {d.Action.GetType().Name} {d.Action.Time:O} " +
+        $"-> {string.Join("|", d.Events.Select(e => e.GetType().Name))}";
+}

--- a/tests/Circus.Tests/Simulator/OrderFlowSimulatorTests.cs
+++ b/tests/Circus.Tests/Simulator/OrderFlowSimulatorTests.cs
@@ -1,0 +1,112 @@
+using Circus.Actions;
+using Circus.Simulator;
+using NUnit.Framework;
+
+namespace Circus.Tests.Simulator;
+
+// The simulator generates traces the rest of the suite and the benchmarks depend on, so what is
+// worth pinning is that a seed reproduces one exactly, and that covering several securities
+// interleaves them without letting one security's flow depend on another's.
+[TestFixture]
+public class OrderFlowSimulatorTests
+{
+    private static readonly Security Gold = new("GCZ6", SecurityType.Future, 10, 10);
+    private static readonly Security Silver = new("SIZ6", SecurityType.Future, 10, 10);
+    private static readonly Security Copper = new("HGZ6", SecurityType.Future, 10, 10);
+
+    [Test]
+    public void Generate_SameSeed_SameTrace()
+    {
+        var first = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 123).Generate(200);
+        var second = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 123).Generate(200);
+
+        Assert.AreEqual(Describe(first), Describe(second));
+    }
+
+    [Test]
+    public void Generate_DifferentSeeds_DifferentTraces()
+    {
+        var first = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 1).Generate(200);
+        var second = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 2).Generate(200);
+
+        Assert.AreNotEqual(Describe(first), Describe(second));
+    }
+
+    [Test]
+    public void Generate_SeveralSecurities_InterleavesThemInOneTrace()
+    {
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver, Copper}, seed: 7).Generate(600);
+
+        // every security represented, and mixed rather than generated in blocks
+        var names = trace.Select(a => a.Security.Name).ToList();
+        Assert.That(
+            names.Distinct().OrderBy(n => n).ToList(),
+            Is.EqualTo(new[] {Gold.Name, Copper.Name, Silver.Name}.OrderBy(n => n).ToList()));
+
+        var switches = names.Zip(names.Skip(1)).Count(pair => pair.First != pair.Second);
+        Assert.Greater(switches, 100, "expected the securities to be interleaved, not blocked");
+    }
+
+    [Test]
+    public void Generate_TimeRunsForwardAcrossTheWholeTrace()
+    {
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 5).Generate(300);
+
+        // one clock across all securities, so the trace is already in the order a sequencer
+        // would put it in
+        var times = trace.Select(a => a.Time).ToList();
+        Assert.AreEqual(times.OrderBy(t => t).ToList(), times);
+        Assert.AreEqual(times.Count, times.Distinct().Count(), "each action gets its own instant");
+    }
+
+    [Test]
+    public void Generate_EveryActionTargetsTheSecurityItWasGeneratedFor()
+    {
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 8).Generate(400);
+
+        // an update or cancel naming an order that never existed in that book would be routed to
+        // it and rejected, so the ids have to have been drawn per security
+        var known = new HashSet<(string Security, string ClientOrderId)>();
+
+        foreach (var action in trace)
+        {
+            var name = action.Security.Name;
+
+            switch (action)
+            {
+                case CreateOrder create:
+                    known.Add((name, create.ClientOrderId));
+                    break;
+                case UpdateOrder update:
+                    Assert.IsTrue(known.Contains((name, update.PreviousClientOrderId)),
+                        $"{name} updated {update.PreviousClientOrderId}, which it never created");
+                    known.Add((name, update.ClientOrderId));
+                    break;
+                case CancelOrder cancel:
+                    Assert.IsTrue(known.Contains((name, cancel.PreviousClientOrderId)),
+                        $"{name} cancelled {cancel.PreviousClientOrderId}, which it never created");
+                    break;
+            }
+        }
+    }
+
+    [Test]
+    public void Generate_ClientOrderIdsAreUniqueAcrossSecurities()
+    {
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver, Copper}, seed: 3).Generate(400);
+
+        // one counter across all books, so nothing in a venue-wide trace collides even though
+        // each book would only have noticed a collision within itself
+        var created = trace.OfType<CreateOrder>().Select(c => c.ClientOrderId).ToList();
+        Assert.AreEqual(created.Count, created.Distinct().Count());
+    }
+
+    [Test]
+    public void Generate_NoSecurities_ArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new OrderFlowSimulator(Array.Empty<Security>()));
+    }
+
+    private static List<string> Describe(IReadOnlyList<OrderBookAction> trace) =>
+        trace.Select(a => $"{a.Security.Name} {a.Time:O} {a}").ToList();
+}


### PR DESCRIPTION
Phase 4 of the sequencer plan: the drivers.

They are the same component seen from either end. A sequencer needs to be told what time it is, and where that comes from is the only thing separating replaying a recording from running a venue.

## `Replay`

Feeds a recorded trace through a sequencer with **no clock anywhere** — every instant involved comes from the actions themselves, which is what makes a replay reproduce a run rather than resemble it.

Fed action by action rather than submitted all at once, so the queue holds one action's worth of client flow plus whatever the schedules have pending, instead of the entire trace.

That streaming is only legitimate because both orderings come out identical, and the reasoning is worth stating: ties are settled by **kind** before the submission counter, so client flow never reorders against a schedule transition however the counters fall; and two entries of the same kind keep their relative counters however many others were queued between them. `Run_StreamedActionByAction_MatchesSubmittingTheWholeTraceUpFront` asserts it rather than leaving it as an argument.

`until` advances once more after the last action, so a trace that stops mid-session can still close its day. Ignored rather than throwing if it is behind where the trace already left the sequencer.

## `LiveDriver`

The other end, and the only place in a running venue that reads wall-clock time. Books hold no clock and the sequencer holds none either.

- `Submit` stamps an arriving action with the time it arrived, **over** whatever it carried — a participant doesn't get to say when its order reached the exchange, which is asserted with a backdated order.
- `Tick` advances to whatever the clock now says. This is what brings a book back from an interruption when no client flow would have carried it there — tested with a paused book and nothing but ticks.
- A clock that jumps backwards (an NTP correction mid-session) is refused rather than quietly reordering the venue.

## `OrderFlowSimulator` across several securities

Now generates **one interleaved trace** rather than one per book — a venue's flow arrives mixed, and putting it back in order is the thing a sequencer exists to do. Each security gets its own shadow book, level view and live-order set, so flow on one never depends on what another was doing.

Two deliberate calls worth flagging:

**The shadow books do not go through a sequencer.** The plan said the simulator should become a client of the replay driver rather than driving a book directly, and I didn't do that. Its shadow books are tracking devices for "what is still resting" — opened once, never moved through a session again. Routing them through a sequencer would buy nothing and cost the simulator a schedule it has no opinion about. The *benchmark* is the natural replay client, and it is one now.

**The single-security trace is byte-identical to before.** Picking a book only draws from the seeded sequence when there is more than one to pick — drawing unconditionally would have shifted every trace this class has ever produced, including the committed benchmark baseline, for nothing but tidiness. Verified by generating a 5000-action trace and hashing it against the pre-refactor code (`D4826ED9F58A1214` both sides), not assumed.

## Benchmark

The throughput benchmark gains a second path replaying the same trace through a sequencer, with the existing one as `Baseline = true`. The difference is what sequencing costs per action — a priority-queue insert and pop, a routing lookup, and a scan of each action's events for an interruption deadline. Worth having as a number rather than an assumption, since every action in a running venue pays it.

## Also

`Circus.Tests` now references `Circus.Simulator`, so the simulator's own behaviour can be pinned — seed reproducibility, interleaving, per-security independence of order ids, and that no action ever references an order its own book never created.

## Checks

Built and tested locally: **449 passed, 0 failed** (up from 429). The replay equivalence test was verified non-vacuous — instrumented to confirm it compares 406 dispatches spanning 6 schedule transitions and all four client-flow action kinds, rather than a trace where the only transition falls before any flow.

## Not in here

The samples still drive books through `SessionProvider` and `TimestampingOrderBook` rather than through a driver. Rewriting them onto the sequencer is really "retire `SessionProvider`", which the plan puts later — they still compile and work as they are.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGRw4mRd2xujbSffPvTXZr)_