### PR TITLE
Publish several instruments down one channel

### DIFF
--- a/samples/Circus.Examples/MarketDataProducerExample.cs
+++ b/samples/Circus.Examples/MarketDataProducerExample.cs
@@ -1,5 +1,3 @@
-using Circus.Actions;
-using Circus.Events;
 using Circus.MarketData;
 using Circus.Time;
 
@@ -17,88 +15,43 @@ public class MarketDataProducerExample
         IOrderBook book1 = new TimestampingOrderBook(sec1, time);
         IOrderBook book2 = new TimestampingOrderBook(sec2, time);
 
-        var feed1 = new BookFeed();
-        var feed2 = new BookFeed();
+        // Both instruments on one channel, the way a venue publishes them: one sequence a
+        // subscriber counts to notice it missed something, and each message saying which
+        // instrument it is about. A feed per security, because every producer behind one builds
+        // its view from a single book's events and none can resync after a missed one.
+        var channel = new MarketDataChannel();
+        channel.Add(new SecurityFeed(sec1, maxLevels: 10));
+        channel.Add(new SecurityFeed(sec2, maxLevels: 10));
 
         // book1 opens on an auction: orders accumulate in pre-open with the indicative quote
         // tracking them, and the print happens on the way out - the same orders as book2, which
         // opens first and trades them continuously.
-        feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.PreOpen));
-        feed1.Publish(book1,
+        Publish(channel, book1.UpdateStatus(OrderBookStatus.PreOpen));
+        Publish(channel,
             book1.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
-        feed1.Publish(book1,
+        Publish(channel,
             book1.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
-        feed1.Publish(book1, book1.UpdateStatus(OrderBookStatus.Open));
+        Publish(channel, book1.UpdateStatus(OrderBookStatus.Open));
 
-        feed2.Publish(book2, book2.UpdateStatus(OrderBookStatus.Open));
-        feed2.Publish(book2,
+        Publish(channel, book2.UpdateStatus(OrderBookStatus.Open));
+        Publish(channel,
             book2.CreateLimitOrder("Buyer", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
-        feed2.Publish(book2,
+        Publish(channel,
             book2.CreateLimitOrder("Seller", "Order2", new OrderValidity.Day(), Side.Sell, 5, 100));
     }
 
-    // One set of producers per book. The level and status producers each build their own view
-    // of a single book out of its event stream alone, so a set cannot be shared across two -
-    // and there is no way to resync one that missed an event, which is why they are created
-    // before the book they follow processes anything.
-    private sealed class BookFeed
+    private static void Publish(MarketDataChannel channel, IReadOnlyList<Events.OrderBookEvent> events)
     {
-        private readonly TradeDataProducer _trades = new();
-        private readonly LevelDataProducer _bbo = new(1);
-        private readonly LevelDataProducer _top10 = new(10);
-        private readonly FullBookDataProducer _fullBook = new();
-        private readonly IndicativePriceDataProducer _indicative = new();
-        private readonly SecurityStatusDataProducer _status = new();
-
-        public void Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
-        {
-            Print(_trades.Process(book, events));
-            Print(_bbo.Process(book, events));
-            Print(_top10.Process(book, events));
-            Print(_fullBook.Process(book, events));
-            Print(_indicative.Process(book, events));
-            Print(_status.Process(book, events));
-        }
+        foreach (var message in channel.Publish(events))
+            Console.WriteLine($"{message.Sequence,3} {message.Data.Security.Name} {Describe(message.Data)}");
     }
 
-    private static void Print(IEnumerable<TradedDataEvent> events)
+    // LevelsDataEvent holds lists, which a record's generated ToString renders as type names.
+    private static string Describe(MarketDataEvent data) => data switch
     {
-        foreach (var @event in events)
-        {
-            Console.WriteLine(@event);
-        }
-    }
-
-    private static void Print(IEnumerable<LevelsDataEvent> events)
-    {
-        foreach (var @event in events)
-        {
-            Console.WriteLine(
-                $"LevelsDataEvent {{ Bids = [{string.Join(", ", @event.Bids)}], Offers = [{string.Join(", ", @event.Offers)}] }}");
-        }
-    }
-
-    private static void Print(IEnumerable<IndicativePriceDataEvent> events)
-    {
-        foreach (var @event in events)
-        {
-            Console.WriteLine(@event);
-        }
-    }
-
-    private static void Print(IEnumerable<OrderBookDeltaEvent> events)
-    {
-        foreach (var @event in events)
-        {
-            Console.WriteLine(@event);
-        }
-    }
-
-    private static void Print(IEnumerable<SecurityStatusDataEvent> events)
-    {
-        foreach (var @event in events)
-        {
-            Console.WriteLine(@event);
-        }
-    }
+        LevelsDataEvent levels =>
+            $"LevelsDataEvent {{ Bids = [{string.Join(", ", levels.Bids)}], " +
+            $"Offers = [{string.Join(", ", levels.Offers)}] }}",
+        _ => data.ToString()!
+    };
 }

--- a/src/Circus.Simulator/OrderFlowSimulator.cs
+++ b/src/Circus.Simulator/OrderFlowSimulator.cs
@@ -238,14 +238,14 @@ public sealed class OrderFlowSimulator
         public BookState(Security security, DateTime openedAt)
         {
             Security = security;
+            Levels = new LevelsDataEvent(security, default, Array.Empty<Level>(), Array.Empty<Level>());
             _shadowBook = new OrderBook(security);
             _shadowBook.Process(new OpenTrading {Security = security, Time = openedAt});
         }
 
         public Security Security { get; }
 
-        public LevelsDataEvent Levels { get; private set; } =
-            new(default, Array.Empty<Level>(), Array.Empty<Level>());
+        public LevelsDataEvent Levels { get; private set; }
 
         public bool HasLive => _liveIds.Count > 0;
 
@@ -255,7 +255,7 @@ public sealed class OrderFlowSimulator
         {
             var events = _shadowBook.Process(action);
 
-            foreach (var levels in _touch.Process(_shadowBook, events))
+            foreach (var levels in _touch.Process(events))
                 Levels = levels;
 
             foreach (var e in events)

--- a/src/Circus/MarketData/ChannelMessage.cs
+++ b/src/Circus/MarketData/ChannelMessage.cs
@@ -1,0 +1,6 @@
+namespace Circus.MarketData;
+
+// One message as it leaves a channel. Sequence is that channel's own contiguous count, so a
+// subscriber that sees it skip has missed something - which is the only reason to number
+// messages at all.
+public readonly record struct ChannelMessage(long Sequence, MarketDataEvent Data);

--- a/src/Circus/MarketData/FullBookDataProducer.cs
+++ b/src/Circus/MarketData/FullBookDataProducer.cs
@@ -21,7 +21,7 @@ namespace Circus.MarketData;
 // change against an id that kept its place.
 public class FullBookDataProducer : IDataProducer<OrderBookDeltaEvent>
 {
-    public IList<OrderBookDeltaEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+    public IList<OrderBookDeltaEvent> Process(IReadOnlyList<OrderBookEvent> events)
     {
         List<OrderBookDeltaEvent>? output = null;
 
@@ -33,8 +33,9 @@ public class FullBookDataProducer : IDataProducer<OrderBookDeltaEvent>
             {
                 foreach (var fill in matched.Fills)
                 {
-                    Add(ref output, new OrderBookDeltaEvent(fill.Time, fill.Order.Side, fill.Order.ExchangeOrderId,
-                        fill.Order.Price!.Value, fill.Quantity, OrderBookDeltaAction.Filled));
+                    Add(ref output, new OrderBookDeltaEvent(fill.Security, fill.Time, fill.Order.Side,
+                        fill.Order.ExchangeOrderId, fill.Order.Price!.Value, fill.Quantity,
+                        OrderBookDeltaAction.Filled));
                 }
 
                 continue;
@@ -44,16 +45,16 @@ public class FullBookDataProducer : IDataProducer<OrderBookDeltaEvent>
             {
                 if (moved.PreviousExchangeOrderId != moved.Order.ExchangeOrderId)
                 {
-                    Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
+                    Add(ref output, new OrderBookDeltaEvent(moved.Security, moved.Time, moved.Order.Side,
                         moved.PreviousExchangeOrderId, movedFromPrice, moved.PreviousQuantity,
                         OrderBookDeltaAction.Removed));
-                    Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
+                    Add(ref output, new OrderBookDeltaEvent(moved.Security, moved.Time, moved.Order.Side,
                         moved.Order.ExchangeOrderId, moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
                         OrderBookDeltaAction.Added));
                 }
                 else
                 {
-                    Add(ref output, new OrderBookDeltaEvent(moved.Time, moved.Order.Side,
+                    Add(ref output, new OrderBookDeltaEvent(moved.Security, moved.Time, moved.Order.Side,
                         moved.Order.ExchangeOrderId, moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
                         OrderBookDeltaAction.Modified));
                 }
@@ -64,22 +65,26 @@ public class FullBookDataProducer : IDataProducer<OrderBookDeltaEvent>
             OrderBookDeltaEvent? delta = ev switch
             {
                 CreateOrderConfirmed {Order.Status: not OrderStatus.Hidden} create =>
-                    new OrderBookDeltaEvent(create.Time, create.Order.Side, create.Order.ExchangeOrderId,
-                        create.Order.Price!.Value, create.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
+                    new OrderBookDeltaEvent(create.Security, create.Time, create.Order.Side,
+                        create.Order.ExchangeOrderId, create.Order.Price!.Value,
+                        create.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
 
                 UpdateOrderConfirmed {PreviousPrice: null, Order.Status: OrderStatus.Hidden} => null,
 
                 UpdateOrderConfirmed {PreviousPrice: null} update =>
-                    new OrderBookDeltaEvent(update.Time, update.Order.Side, update.Order.ExchangeOrderId,
-                        update.Order.Price!.Value, update.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
+                    new OrderBookDeltaEvent(update.Security, update.Time, update.Order.Side,
+                        update.Order.ExchangeOrderId, update.Order.Price!.Value,
+                        update.Order.DisplayedQuantity, OrderBookDeltaAction.Added),
 
                 CancelOrderConfirmed {PreviousPrice: {} previousPrice} cancel =>
-                    new OrderBookDeltaEvent(cancel.Time, cancel.Order.Side, cancel.Order.ExchangeOrderId,
-                        previousPrice, cancel.PreviousQuantity, OrderBookDeltaAction.Removed),
+                    new OrderBookDeltaEvent(cancel.Security, cancel.Time, cancel.Order.Side,
+                        cancel.Order.ExchangeOrderId, previousPrice, cancel.PreviousQuantity,
+                        OrderBookDeltaAction.Removed),
 
                 ExpireOrderConfirmed {PreviousPrice: {} previousPrice} expire =>
-                    new OrderBookDeltaEvent(expire.Time, expire.Order.Side, expire.Order.ExchangeOrderId,
-                        previousPrice, expire.PreviousQuantity, OrderBookDeltaAction.Removed),
+                    new OrderBookDeltaEvent(expire.Security, expire.Time, expire.Order.Side,
+                        expire.Order.ExchangeOrderId, previousPrice, expire.PreviousQuantity,
+                        OrderBookDeltaAction.Removed),
 
                 _ => null
             };

--- a/src/Circus/MarketData/IDataProducer.cs
+++ b/src/Circus/MarketData/IDataProducer.cs
@@ -2,7 +2,14 @@ using Circus.Events;
 
 namespace Circus.MarketData;
 
-public interface IDataProducer<T>
+// Turns a book's events into what a subscriber sees. A pure function of the event stream and
+// nothing else: no producer is handed the book, because everything a consumer knows is derived
+// from the events rather than queried back out of it - which is also what lets market data be
+// rebuilt from a journal of those events, with no books involved at all.
+//
+// Most implementations are stateful, so one instance per security, created before that book
+// processes its first action. None of them can resync after a missed event.
+public interface IDataProducer<T> where T : MarketDataEvent
 {
-    IList<T> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events);
+    IList<T> Process(IReadOnlyList<OrderBookEvent> events);
 }

--- a/src/Circus/MarketData/IndicativePriceDataEvent.cs
+++ b/src/Circus/MarketData/IndicativePriceDataEvent.cs
@@ -1,3 +1,4 @@
 namespace Circus.MarketData;
 
-public record IndicativePriceDataEvent(DateTime Time, decimal? Price, int Quantity);
+public record IndicativePriceDataEvent(Security Security, DateTime Time, decimal? Price, int Quantity)
+    : MarketDataEvent(Security, Time);

--- a/src/Circus/MarketData/IndicativePriceDataProducer.cs
+++ b/src/Circus/MarketData/IndicativePriceDataProducer.cs
@@ -11,7 +11,7 @@ namespace Circus.MarketData;
 // subscriber must publish as such rather than leaving the last price standing.
 public class IndicativePriceDataProducer : IDataProducer<IndicativePriceDataEvent>
 {
-    public IList<IndicativePriceDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+    public IList<IndicativePriceDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
     {
         List<IndicativePriceDataEvent>? output = null;
 
@@ -20,7 +20,7 @@ public class IndicativePriceDataProducer : IDataProducer<IndicativePriceDataEven
             if (ev is IndicativePriceChanged changed)
             {
                 output ??= new List<IndicativePriceDataEvent>();
-                output.Add(new IndicativePriceDataEvent(changed.Time, changed.Price, changed.Quantity));
+                output.Add(new IndicativePriceDataEvent(changed.Security, changed.Time, changed.Price, changed.Quantity));
             }
         }
 

--- a/src/Circus/MarketData/LevelDataProducer.cs
+++ b/src/Circus/MarketData/LevelDataProducer.cs
@@ -32,7 +32,7 @@ public class LevelDataProducer : IDataProducer<LevelsDataEvent>
         _maxLevels = maxLevels;
     }
 
-    public IList<LevelsDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+    public IList<LevelsDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
     {
         if (events.Count == 0)
             return Array.Empty<LevelsDataEvent>();
@@ -79,7 +79,7 @@ public class LevelDataProducer : IDataProducer<LevelsDataEvent>
 
         var bids = Snapshot(Side.Buy);
         var offers = Snapshot(Side.Sell);
-        return new[] {new LevelsDataEvent(events[0].Time, bids, offers)};
+        return new[] {new LevelsDataEvent(events[0].Security, events[0].Time, bids, offers)};
     }
 
     private void Add(Side side, decimal price, int quantity)

--- a/src/Circus/MarketData/LevelsDataEvent.cs
+++ b/src/Circus/MarketData/LevelsDataEvent.cs
@@ -1,3 +1,5 @@
 namespace Circus.MarketData;
 
-public record LevelsDataEvent(DateTime Time, IReadOnlyList<Level> Bids, IReadOnlyList<Level> Offers);
+public record LevelsDataEvent(Security Security, DateTime Time, IReadOnlyList<Level> Bids,
+        IReadOnlyList<Level> Offers)
+    : MarketDataEvent(Security, Time);

--- a/src/Circus/MarketData/MarketDataChannel.cs
+++ b/src/Circus/MarketData/MarketDataChannel.cs
@@ -1,0 +1,113 @@
+using Circus.Events;
+
+namespace Circus.MarketData;
+
+// A feed carrying several instruments under one sequence, and the unit whose ordering is
+// actually guaranteed.
+//
+// Within a channel, messages are published in the order the venue dispatched the actions behind
+// them; across channels nothing is promised, which is what lets channels be published
+// independently rather than through one path the whole venue queues behind. Real venues draw the
+// line in the same place - CME assigns instruments to channels each with its own MsgSeqNum,
+// Nasdaq ITCH runs one sequenced stream carrying every symbol - and it is why a product complex
+// belongs on one channel: a spread and its legs need a common order the moment implied pricing
+// exists, and two channels do not give them one.
+//
+// The sequence is this channel's own count of messages, not the venue's dispatch count. That is
+// the whole point of it. A channel carrying three instruments out of a hundred would see the
+// venue's numbering jump constantly, so a subscriber counting it could never tell a filtered-out
+// dispatch from a lost message - whereas a contiguous per-channel count means a gap is loss and
+// nothing else.
+//
+// Single-threaded, like the sequencer that feeds it: one channel, one publishing thread.
+public sealed class MarketDataChannel
+{
+    // Keyed on the security's name rather than the record, for the reason the sequencer's routing
+    // table is: two Security records describing the same contract need not be equal, since the
+    // restriction list on them compares by reference.
+    private readonly Dictionary<string, SecurityFeed> _feeds = new();
+
+    private long _sequence;
+
+    // What a subscriber has seen so far, so a caller resuming one can say where it got to.
+    public long Sequence => _sequence;
+
+    public void Add(SecurityFeed feed)
+    {
+        ArgumentNullException.ThrowIfNull(feed);
+
+        if (!_feeds.TryAdd(feed.Security.Name, feed))
+            throw new ArgumentException(
+                $"a feed is already registered for {feed.Security.Name}", nameof(feed));
+    }
+
+    // Turns one dispatch's events into the messages this channel publishes for them.
+    //
+    // Events for a security this channel does not carry are ignored rather than refused: a
+    // channel is deliberately a subset of the venue, and the securities it leaves out are the
+    // normal case rather than a routing mistake.
+    public IReadOnlyList<ChannelMessage> Publish(IReadOnlyList<OrderBookEvent> events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        if (events.Count == 0)
+            return Array.Empty<ChannelMessage>();
+
+        List<ChannelMessage>? output = null;
+
+        foreach (var (name, forSecurity) in GroupBySecurity(events))
+        {
+            if (!_feeds.TryGetValue(name, out var feed))
+                continue;
+
+            foreach (var data in feed.Process(forSecurity))
+            {
+                output ??= new List<ChannelMessage>();
+                output.Add(new ChannelMessage(++_sequence, data));
+            }
+        }
+
+        return output ?? (IReadOnlyList<ChannelMessage>) Array.Empty<ChannelMessage>();
+    }
+
+    // One dispatch is one book's events today, so the common path is a single group and the whole
+    // list is passed straight through. Grouped rather than assumed anyway, because an action that
+    // implied a fill in another book would arrive here as events spanning securities, and each
+    // book's producers must be handed their own book's events and only those.
+    private static IEnumerable<(string Name, IReadOnlyList<OrderBookEvent> Events)> GroupBySecurity(
+        IReadOnlyList<OrderBookEvent> events)
+    {
+        var first = events[0].Security.Name;
+
+        var spansSecurities = false;
+        for (var i = 1; i < events.Count; i++)
+        {
+            if (events[i].Security.Name == first) continue;
+
+            spansSecurities = true;
+            break;
+        }
+
+        if (!spansSecurities)
+            return new[] {(first, events)};
+
+        // Grouped in order of first appearance, so a channel's output order follows the events
+        // rather than a dictionary's.
+        var groups = new Dictionary<string, List<OrderBookEvent>>();
+        var order = new List<string>();
+
+        foreach (var ev in events)
+        {
+            var name = ev.Security.Name;
+            if (!groups.TryGetValue(name, out var list))
+            {
+                groups[name] = list = new List<OrderBookEvent>();
+                order.Add(name);
+            }
+
+            list.Add(ev);
+        }
+
+        return order.Select(name => (name, (IReadOnlyList<OrderBookEvent>) groups[name]));
+    }
+}

--- a/src/Circus/MarketData/MarketDataEvent.cs
+++ b/src/Circus/MarketData/MarketDataEvent.cs
@@ -1,0 +1,18 @@
+namespace Circus.MarketData;
+
+// What a subscriber receives, and the one type a feed carrying several instruments can be a
+// stream of.
+//
+// Security travels on every message because a feed is not per instrument. A subscriber filtering
+// to one contract, or keying its own mirrored book off it, has to be able to tell them apart from
+// the message rather than from which stream it arrived on - the same reason a stock locate code
+// is on every ITCH message and a SecurityID on every CME one.
+//
+// Mirrors OrderBookEvent, which carries the same pair for the same reason. A wire protocol would
+// replace Security here with a compact numeric id resolved once per session, but that is a
+// serialization concern and belongs at whatever boundary does the encoding rather than in the
+// events themselves - in process this is a reference, not a repeated payload.
+//
+// Keyed on Security.Name where a consumer needs a dictionary: two Security records describing the
+// same contract need not be equal, since the restriction list on them compares by reference.
+public abstract record MarketDataEvent(Security Security, DateTime Time);

--- a/src/Circus/MarketData/OrderBookDeltaEvent.cs
+++ b/src/Circus/MarketData/OrderBookDeltaEvent.cs
@@ -2,5 +2,6 @@ namespace Circus.MarketData;
 
 // ExchangeOrderId only - never CompanyId/ClientOrderId, which identify the originating
 // client and must not be broadcast on a public depth feed.
-public record OrderBookDeltaEvent(DateTime Time, Side Side, string ExchangeOrderId, decimal Price, int Quantity,
-    OrderBookDeltaAction Action);
+public record OrderBookDeltaEvent(Security Security, DateTime Time, Side Side, string ExchangeOrderId,
+        decimal Price, int Quantity, OrderBookDeltaAction Action)
+    : MarketDataEvent(Security, Time);

--- a/src/Circus/MarketData/SecurityFeed.cs
+++ b/src/Circus/MarketData/SecurityFeed.cs
@@ -1,0 +1,66 @@
+using Circus.Events;
+
+namespace Circus.MarketData;
+
+// Everything a venue publishes about one instrument, assembled in one place. A book's events go
+// in, the messages a subscriber would receive come out.
+//
+// One bundle per security, created before that book processes its first action: the level, depth
+// and status producers inside it are each stateful and none can resync after a missed event.
+//
+// One level producer at one depth, unlike the several a caller might otherwise run side by side.
+// Two LevelsDataEvent streams at different depths are indistinguishable once merged into a
+// channel, so depth is a property of the feed rather than something stacked within it - which is
+// also how a venue does it, publishing a five-deep and a ten-deep product as two feeds rather
+// than one carrying both.
+//
+// A venue separating market-by-price from market-by-order would compose its own bundle rather
+// than use this: both are here, which is the useful default for a simulator and more than a real
+// depth feed carries.
+public sealed class SecurityFeed
+{
+    private readonly LevelDataProducer _levels;
+    private readonly FullBookDataProducer _orderByOrder = new();
+    private readonly TradeDataProducer _trades = new();
+    private readonly IndicativePriceDataProducer _indicative = new();
+    private readonly SecurityStatusDataProducer _status = new();
+
+    public SecurityFeed(Security security, int maxLevels)
+    {
+        Security = security ?? throw new ArgumentNullException(nameof(security));
+        _levels = new LevelDataProducer(maxLevels);
+    }
+
+    public Security Security { get; }
+
+    // Ordering within one call is by producer, in the fixed order below, rather than interleaved
+    // by time: every event in a single dispatch shares an instant, so there is no time order
+    // among them to preserve. Across calls it is the order the venue dispatched them in, which is
+    // the ordering that actually carries meaning.
+    public IReadOnlyList<MarketDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    {
+        if (events.Count == 0)
+            return Array.Empty<MarketDataEvent>();
+
+        List<MarketDataEvent>? output = null;
+
+        Collect(ref output, _status.Process(events));
+        Collect(ref output, _trades.Process(events));
+        Collect(ref output, _levels.Process(events));
+        Collect(ref output, _orderByOrder.Process(events));
+        Collect(ref output, _indicative.Process(events));
+
+        return output ?? (IReadOnlyList<MarketDataEvent>) Array.Empty<MarketDataEvent>();
+    }
+
+    private static void Collect<T>(ref List<MarketDataEvent>? output, IList<T> produced)
+        where T : MarketDataEvent
+    {
+        if (produced.Count == 0)
+            return;
+
+        output ??= new List<MarketDataEvent>();
+        foreach (var data in produced)
+            output.Add(data);
+    }
+}

--- a/src/Circus/MarketData/SecurityStatusDataEvent.cs
+++ b/src/Circus/MarketData/SecurityStatusDataEvent.cs
@@ -3,5 +3,6 @@ namespace Circus.MarketData;
 // ResumesAt is when a timed interruption is due back, null when nothing is pending. LimitState
 // is which way a daily limit has the market stuck - Buy for limit up, where buyers cannot push
 // higher - and null when it is free to trade.
-public record SecurityStatusDataEvent(DateTime Time, OrderBookStatus Status, StatusChangeReason Reason,
-    DateTime? ResumesAt, Side? LimitState);
+public record SecurityStatusDataEvent(Security Security, DateTime Time, OrderBookStatus Status,
+        StatusChangeReason Reason, DateTime? ResumesAt, Side? LimitState)
+    : MarketDataEvent(Security, Time);

--- a/src/Circus/MarketData/SecurityStatusDataProducer.cs
+++ b/src/Circus/MarketData/SecurityStatusDataProducer.cs
@@ -22,7 +22,7 @@ public class SecurityStatusDataProducer : IDataProducer<SecurityStatusDataEvent>
     private DateTime? _resumesAt;
     private Side? _limitState;
 
-    public IList<SecurityStatusDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+    public IList<SecurityStatusDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
     {
         List<SecurityStatusDataEvent>? output = null;
 
@@ -49,7 +49,7 @@ public class SecurityStatusDataProducer : IDataProducer<SecurityStatusDataEvent>
             // One per contributing event, carrying that event's own time rather than a time
             // chosen for a batch. Each is a complete picture, so a consumer never needs two.
             output ??= new List<SecurityStatusDataEvent>();
-            output.Add(new SecurityStatusDataEvent(ev.Time, _status, _reason, _resumesAt, _limitState));
+            output.Add(new SecurityStatusDataEvent(ev.Security, ev.Time, _status, _reason, _resumesAt, _limitState));
         }
 
         return output ?? (IList<SecurityStatusDataEvent>) Array.Empty<SecurityStatusDataEvent>();

--- a/src/Circus/MarketData/TradeDataProducer.cs
+++ b/src/Circus/MarketData/TradeDataProducer.cs
@@ -4,7 +4,7 @@ namespace Circus.MarketData;
 
 public class TradeDataProducer : IDataProducer<TradedDataEvent>
 {
-    public IList<TradedDataEvent> Process(IOrderBook book, IReadOnlyList<OrderBookEvent> events)
+    public IList<TradedDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
     {
         List<TradedDataEvent>? output = null;
 
@@ -13,7 +13,7 @@ public class TradeDataProducer : IDataProducer<TradedDataEvent>
             if (ev is OrdersMatched matched)
             {
                 output ??= new List<TradedDataEvent>();
-                output.Add(new TradedDataEvent(matched.Time, matched.Price, matched.Quantity));
+                output.Add(new TradedDataEvent(matched.Security, matched.Time, matched.Price, matched.Quantity));
             }
         }
 

--- a/src/Circus/MarketData/TradedDataEvent.cs
+++ b/src/Circus/MarketData/TradedDataEvent.cs
@@ -1,3 +1,4 @@
 namespace Circus.MarketData;
 
-public record TradedDataEvent(DateTime Time, decimal Price, int Quantity);
+public record TradedDataEvent(Security Security, DateTime Time, decimal Price, int Quantity)
+    : MarketDataEvent(Security, Time);

--- a/tests/Circus.Tests/Helpers/LevelTrackingOrderBook.cs
+++ b/tests/Circus.Tests/Helpers/LevelTrackingOrderBook.cs
@@ -17,11 +17,12 @@ internal sealed class LevelTrackingOrderBook : IOrderBook
 
     private readonly IOrderBook _book;
     private readonly LevelDataProducer _levelDataProducer = new(MaxLevels);
-    private LevelsDataEvent _levels = new(default, Array.Empty<Level>(), Array.Empty<Level>());
+    private LevelsDataEvent _levels;
 
     public LevelTrackingOrderBook(Security security, IClock clock)
     {
         _book = new TimestampingOrderBook(security, clock);
+        _levels = new LevelsDataEvent(security, default, Array.Empty<Level>(), Array.Empty<Level>());
     }
 
     public Security Security => _book.Security;
@@ -32,7 +33,7 @@ internal sealed class LevelTrackingOrderBook : IOrderBook
     {
         var events = _book.Process(action);
 
-        foreach (var levels in _levelDataProducer.Process(_book, events))
+        foreach (var levels in _levelDataProducer.Process(events))
             _levels = levels;
 
         return events;

--- a/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
+++ b/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
@@ -1,0 +1,152 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Simulator;
+using NUnit.Framework;
+
+namespace Circus.Tests.MarketData;
+
+// The whole outbound path, end to end: a sequencer decides what order things happened in, and a
+// channel publishes market data for them in that order. Everything either side of that is tested
+// on its own; what is here is that the two compose, and that the ordering a channel promises is
+// the ordering the venue actually dispatched.
+[TestFixture]
+public class ChannelFromDispatchTests
+{
+    private static readonly DateTime Day = new(2000, 1, 1);
+
+    private static readonly Security Gold = new("GCZ6", SecurityType.Future, 10, 10);
+    private static readonly Security Silver = new("SIZ6", SecurityType.Future, 10, 10);
+
+    // Open before the trace starts and closed long after it ends, so the books actually trade
+    // for the whole of it. A schedule with boundaries inside the trace would leave most of the
+    // flow arriving at a closed book and being rejected - and rejections still produce market
+    // data, so the test would pass while measuring almost nothing.
+    private static MarketSchedule OpenThroughout() =>
+        new(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(17, 0, 0));
+
+    [Test]
+    public void MarketDataFollowsTheOrderTheVenueDispatchedIn()
+    {
+        // arrange
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Gold), OpenThroughout());
+        sequencer.Add(new OrderBook(Silver), OpenThroughout());
+
+        var channel = new MarketDataChannel();
+        channel.Add(new SecurityFeed(Gold, maxLevels: 10));
+        channel.Add(new SecurityFeed(Silver, maxLevels: 10));
+
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 21).Generate(400);
+
+        // act - publish each dispatch's events as they come out
+        var published = new List<ChannelMessage>();
+        Replay.Run(sequencer, trace, d => published.AddRange(channel.Publish(d.Events)));
+
+        // assert
+        Assert.IsNotEmpty(published);
+
+        // one contiguous run of numbers, so a subscriber counting them can tell loss from silence
+        Assert.AreEqual(
+            Enumerable.Range(1, published.Count).Select(i => (long) i).ToList(),
+            published.Select(m => m.Sequence).ToList());
+
+        // both instruments on the one channel, each message saying which
+        Assert.AreEqual(
+            new[] {Gold.Name, Silver.Name},
+            published.Select(m => m.Data.Security.Name).Distinct().OrderBy(n => n).ToArray());
+
+        // and time never runs backwards along the channel, because the venue's dispatch order is
+        // what put the messages there
+        var times = published.Select(m => m.Data.Time).ToList();
+        Assert.AreEqual(times.OrderBy(t => t).ToList(), times);
+    }
+
+    [Test]
+    public void TwoChannelsSplittingTheVenue_EachNumberItsOwnMessagesFromOne()
+    {
+        // arrange - one channel per instrument, which is how a venue actually splits its feeds
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Gold), OpenThroughout());
+        sequencer.Add(new OrderBook(Silver), OpenThroughout());
+
+        var goldChannel = new MarketDataChannel();
+        goldChannel.Add(new SecurityFeed(Gold, maxLevels: 10));
+
+        var silverChannel = new MarketDataChannel();
+        silverChannel.Add(new SecurityFeed(Silver, maxLevels: 10));
+
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 22).Generate(400);
+
+        // act
+        var goldMessages = new List<ChannelMessage>();
+        var silverMessages = new List<ChannelMessage>();
+        Replay.Run(sequencer, trace, d =>
+        {
+            goldMessages.AddRange(goldChannel.Publish(d.Events));
+            silverMessages.AddRange(silverChannel.Publish(d.Events));
+        });
+
+        // assert - neither channel's numbering has a hole where the other's instrument traded.
+        // This is why the sequence is the channel's own count rather than the venue's dispatch
+        // count: a subscriber to one instrument would otherwise see gaps constantly and never be
+        // able to tell one from a lost message.
+        Assert.IsNotEmpty(goldMessages);
+        Assert.IsNotEmpty(silverMessages);
+
+        Assert.AreEqual(
+            Enumerable.Range(1, goldMessages.Count).Select(i => (long) i).ToList(),
+            goldMessages.Select(m => m.Sequence).ToList());
+        Assert.AreEqual(
+            Enumerable.Range(1, silverMessages.Count).Select(i => (long) i).ToList(),
+            silverMessages.Select(m => m.Sequence).ToList());
+
+        // each carrying only its own instrument
+        Assert.IsTrue(goldMessages.All(m => m.Data.Security.Name == Gold.Name));
+        Assert.IsTrue(silverMessages.All(m => m.Data.Security.Name == Silver.Name));
+    }
+
+    [Test]
+    public void ReplayingTheSameTrace_PublishesTheSameMessages()
+    {
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 23).Generate(400);
+
+        var first = PublishAll(trace);
+        var second = PublishAll(trace);
+
+        // market data is a function of the dispatch stream, which is a function of the trace -
+        // so a feed can be rebuilt from a journal rather than having to have been recorded
+        Assert.AreEqual(first, second);
+        Assert.IsNotEmpty(first);
+    }
+
+    private static List<string> PublishAll(IReadOnlyList<OrderBookAction> trace)
+    {
+        var sequencer = new Sequencer(Day);
+        sequencer.Add(new OrderBook(Gold), OpenThroughout());
+        sequencer.Add(new OrderBook(Silver), OpenThroughout());
+
+        var channel = new MarketDataChannel();
+        channel.Add(new SecurityFeed(Gold, maxLevels: 10));
+        channel.Add(new SecurityFeed(Silver, maxLevels: 10));
+
+        var rendered = new List<string>();
+        Replay.Run(sequencer, trace, d =>
+        {
+            foreach (var message in channel.Publish(d.Events))
+                rendered.Add($"{message.Sequence} {message.Data.Security.Name} {Describe(message.Data)}");
+        });
+
+        return rendered;
+    }
+
+    // Rendered rather than compared directly: LevelsDataEvent holds its ladders in lists, and a
+    // record's generated equality compares those by reference.
+    private static string Describe(MarketDataEvent data) => data switch
+    {
+        LevelsDataEvent levels =>
+            $"Levels {levels.Time:O} [{string.Join(",", levels.Bids)}] [{string.Join(",", levels.Offers)}]",
+        _ => data.ToString()!
+    };
+}

--- a/tests/Circus.Tests/MarketData/FullBookDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/FullBookDataProducerTests.cs
@@ -48,7 +48,7 @@ public class FullBookDataProducerTests
         Book.UpdateStatus(OrderBookStatus.Open);
 
         var bookEvents = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         Assert.AreEqual(1, deltas.Count);
         Assert.AreEqual(Side.Buy, deltas[0].Side);
@@ -66,7 +66,7 @@ public class FullBookDataProducerTests
         // total 20, only 5 displayed at a time
         var bookEvents = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 20, 100,
             maxVisibleQuantity: 5);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         Assert.AreEqual(1, deltas.Count);
         Assert.AreEqual(5, deltas[0].Quantity, "only the displayed peak, never the hidden reserve");
@@ -81,11 +81,11 @@ public class FullBookDataProducerTests
         var created = Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 12, 100,
                 maxVisibleQuantity: 5)
             .OfType<CreateOrderConfirmed>().Single();
-        producer.Process(Book, new OrderBookEvent[] {created});
+        producer.Process(new OrderBookEvent[] {created});
 
         // aggressor larger than the peak - exhausts and replenishes the iceberg mid-match
         var bookEvents = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 100);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         // one Filled delta per leg of the match (the iceberg resting, and the aggressor)
         var filled = deltas.Where(d => d.Action == OrderBookDeltaAction.Filled).ToList();
@@ -112,7 +112,7 @@ public class FullBookDataProducerTests
             .OfType<CreateOrderConfirmed>().Single();
 
         var bookEvents = Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, price: 110);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         Assert.AreEqual(2, deltas.Count);
         Assert.AreEqual(created.Order.ExchangeOrderId, deltas[0].ExchangeOrderId);
@@ -133,7 +133,7 @@ public class FullBookDataProducerTests
             .OfType<CreateOrderConfirmed>().Single();
 
         var bookEvents = Book.UpdateOrder(CompanyId1, OrderId2, OrderId1, newTotalQuantity: 3);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         Assert.AreEqual(1, deltas.Count);
         Assert.AreEqual(created.Order.ExchangeOrderId, deltas[0].ExchangeOrderId);
@@ -149,7 +149,7 @@ public class FullBookDataProducerTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 3, 100);
 
         var bookEvents = Book.CancelOrder(CompanyId1, OrderId2, OrderId1);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         Assert.AreEqual(1, deltas.Count);
         Assert.AreEqual(100, deltas[0].Price);
@@ -165,7 +165,7 @@ public class FullBookDataProducerTests
         Book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
 
         var bookEvents = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 3, 100);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         var filled = deltas.Where(d => d.Action == OrderBookDeltaAction.Filled).ToList();
         Assert.AreEqual(2, filled.Count, "expected one Filled delta per leg of the match");
@@ -191,7 +191,7 @@ public class FullBookDataProducerTests
 
         var bookEvents =
             Book.CreateStopLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5, 530, 510);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         Assert.IsEmpty(deltas, "a stop order that hasn't triggered yet isn't part of the displayed order book");
     }
@@ -216,7 +216,7 @@ public class FullBookDataProducerTests
         // act - trade at the trigger price, converting the stop into a working limit order
         Clock.SetCurrentTime(Now6);
         var bookEvents = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
-        var deltas = producer.Process(Book, bookEvents);
+        var deltas = producer.Process(bookEvents);
 
         var activation = deltas.SingleOrDefault(d => d.Price == 530 && d.Action != OrderBookDeltaAction.Filled);
         Assert.IsNotNull(activation, "expected the triggered order's arrival into the working book");

--- a/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
@@ -25,7 +25,7 @@ public class IndicativePriceDataProducerTests
 
     private static IList<IndicativePriceDataEvent> Publish(IndicativePriceDataProducer producer,
         IReadOnlyList<OrderBookEvent> bookEvents) =>
-        producer.Process(Book, bookEvents);
+        producer.Process(bookEvents);
 
     [Test]
     public void CrossedPreOpenBook_PublishesTheQuote()

--- a/tests/Circus.Tests/MarketData/LevelDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/LevelDataProducerTests.cs
@@ -47,7 +47,7 @@ public class LevelDataProducerTests
 
     private static LevelsDataEvent Publish(LevelDataProducer producer, IReadOnlyList<OrderBookEvent> bookEvents)
     {
-        var events = producer.Process(Book, bookEvents);
+        var events = producer.Process(bookEvents);
         Assert.AreEqual(1, events.Count);
         return events[0];
     }

--- a/tests/Circus.Tests/MarketData/MarketDataChannelTests.cs
+++ b/tests/Circus.Tests/MarketData/MarketDataChannelTests.cs
@@ -1,0 +1,150 @@
+using Circus.Events;
+using Circus.MarketData;
+using Circus.Time;
+using NUnit.Framework;
+
+namespace Circus.Tests.MarketData;
+
+// A channel carries several instruments under one sequence. The sequence is the whole reason it
+// exists as a type rather than a list of feeds, so most of what is here is about that: it counts
+// this channel's own messages, contiguously, so a subscriber seeing it skip knows it lost one.
+[TestFixture]
+public class MarketDataChannelTests
+{
+    private static readonly Security Gold = new("GCZ6", SecurityType.Future, 10, 10);
+    private static readonly Security Silver = new("SIZ6", SecurityType.Future, 10, 10);
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+
+    [Test]
+    public void Publish_NumbersMessagesContiguouslyFromOne()
+    {
+        // arrange
+        var channel = Channel(Gold, Silver);
+        var gold = Book(Gold);
+        var silver = Book(Silver);
+
+        // act
+        var messages = new List<ChannelMessage>();
+        messages.AddRange(channel.Publish(gold.UpdateStatus(OrderBookStatus.Open)));
+        messages.AddRange(channel.Publish(silver.UpdateStatus(OrderBookStatus.Open)));
+        messages.AddRange(channel.Publish(
+            gold.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100)));
+
+        // assert
+        Assert.IsNotEmpty(messages);
+        Assert.AreEqual(
+            Enumerable.Range(1, messages.Count).Select(i => (long) i).ToList(),
+            messages.Select(m => m.Sequence).ToList());
+        Assert.AreEqual(messages.Count, channel.Sequence);
+    }
+
+    [Test]
+    public void Publish_CarriesBothInstrumentsAndSaysWhichIsWhich()
+    {
+        // arrange
+        var channel = Channel(Gold, Silver);
+        var gold = Book(Gold);
+        var silver = Book(Silver);
+
+        // act
+        var messages = new List<ChannelMessage>();
+        messages.AddRange(channel.Publish(gold.UpdateStatus(OrderBookStatus.Open)));
+        messages.AddRange(channel.Publish(silver.UpdateStatus(OrderBookStatus.Open)));
+
+        // assert - filtered to the status messages, since a level producer republishes its
+        // ladders on any non-empty batch and so contributes one of its own here too
+        Assert.AreEqual(
+            new[] {Gold.Name, Silver.Name},
+            messages.Where(m => m.Data is SecurityStatusDataEvent)
+                .Select(m => m.Data.Security.Name).ToArray());
+    }
+
+    [Test]
+    public void Publish_ASecurityTheChannelDoesNotCarry_IsIgnoredAndDoesNotConsumeASequence()
+    {
+        // arrange - a channel carrying gold only, which is the normal case rather than a mistake:
+        // a venue splits its instruments across channels deliberately
+        var channel = Channel(Gold);
+        var gold = Book(Gold);
+        var silver = Book(Silver);
+
+        // act
+        var first = channel.Publish(gold.UpdateStatus(OrderBookStatus.Open));
+        var ignored = channel.Publish(silver.UpdateStatus(OrderBookStatus.Open));
+        var second = channel.Publish(
+            gold.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+
+        // assert - silver contributed nothing, and crucially left no hole in gold's numbering.
+        // Had the channel carried the venue's own dispatch count instead of its own, a subscriber
+        // could never have told a filtered-out instrument from a lost message.
+        Assert.IsEmpty(ignored);
+        Assert.AreEqual(
+            Enumerable.Range(1, first.Count + second.Count).Select(i => (long) i).ToList(),
+            first.Concat(second).Select(m => m.Sequence).ToList());
+    }
+
+    [Test]
+    public void Publish_EventsSpanningSecurities_ReachEachSecuritysOwnFeed()
+    {
+        // arrange - nothing produces this today, since one dispatch is one book. It is what an
+        // action implying a fill in another book would look like, and each book's producers must
+        // be handed their own book's events and only those.
+        var channel = Channel(Gold, Silver);
+
+        var mixed = new OrderBookEvent[]
+        {
+            new StatusChanged(Gold, Now1, OrderBookStatus.Open),
+            new StatusChanged(Silver, Now1, OrderBookStatus.Halted),
+            new StatusChanged(Gold, Now1, OrderBookStatus.Closed)
+        };
+
+        // act
+        var messages = channel.Publish(mixed);
+
+        // assert - grouped by security in order of first appearance, and each feed saw only its
+        // own: gold's status producer tracked two changes, silver's one
+        var statuses = messages
+            .Select(m => m.Data)
+            .OfType<SecurityStatusDataEvent>()
+            .Select(d => (d.Security.Name, d.Status))
+            .ToList();
+
+        Assert.AreEqual(
+            new[]
+            {
+                (Gold.Name, OrderBookStatus.Open),
+                (Gold.Name, OrderBookStatus.Closed),
+                (Silver.Name, OrderBookStatus.Halted)
+            },
+            statuses);
+    }
+
+    [Test]
+    public void Publish_NoEvents_ProducesNothing()
+    {
+        var channel = Channel(Gold);
+
+        Assert.IsEmpty(channel.Publish(Array.Empty<OrderBookEvent>()));
+        Assert.AreEqual(0, channel.Sequence);
+    }
+
+    [Test]
+    public void Add_TwiceForTheSameSecurity_ArgumentException()
+    {
+        var channel = Channel(Gold);
+
+        Assert.Throws<ArgumentException>(() => channel.Add(new SecurityFeed(Gold, maxLevels: 10)));
+    }
+
+    private static MarketDataChannel Channel(params Security[] securities)
+    {
+        var channel = new MarketDataChannel();
+        foreach (var security in securities)
+            channel.Add(new SecurityFeed(security, maxLevels: 10));
+
+        return channel;
+    }
+
+    private static IOrderBook Book(Security security) =>
+        new TimestampingOrderBook(security, new ManualClock(Now1));
+}

--- a/tests/Circus.Tests/MarketData/SecurityFeedTests.cs
+++ b/tests/Circus.Tests/MarketData/SecurityFeedTests.cs
@@ -1,0 +1,103 @@
+using Circus.Events;
+using Circus.MarketData;
+using Circus.Time;
+using NUnit.Framework;
+
+namespace Circus.Tests.MarketData;
+
+// SecurityFeed is the bundle of producers a venue publishes for one instrument. The producers
+// themselves are tested individually; what is worth holding here is that the bundle runs all of
+// them, that everything it emits says which instrument it is about, and that its order within a
+// call is fixed rather than incidental.
+[TestFixture]
+public class SecurityFeedTests
+{
+    private static readonly Security Sec = new("GCZ6", SecurityType.Future, 10, 10);
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+
+    [Test]
+    public void Process_ATrade_ProducesFromEveryProducerThatHasSomethingToSay()
+    {
+        // arrange
+        var (feed, book) = Feed();
+        feed.Process(book.UpdateStatus(OrderBookStatus.Open));
+        feed.Process(book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+
+        // act - the crossing order: a print, a level change, and depth deltas, all from one action
+        var data = feed.Process(
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
+
+        // assert
+        Assert.IsNotEmpty(data.OfType<TradedDataEvent>());
+        Assert.IsNotEmpty(data.OfType<LevelsDataEvent>());
+        Assert.IsNotEmpty(data.OfType<OrderBookDeltaEvent>());
+    }
+
+    [Test]
+    public void Process_AStatusChange_ProducesTheStatusMessage()
+    {
+        var (feed, book) = Feed();
+
+        var data = feed.Process(book.UpdateStatus(OrderBookStatus.Open));
+
+        var status = data.OfType<SecurityStatusDataEvent>().Single();
+        Assert.AreEqual(OrderBookStatus.Open, status.Status);
+    }
+
+    [Test]
+    public void Process_EverythingItEmitsCarriesTheSecurity()
+    {
+        // arrange
+        var (feed, book) = Feed();
+        var all = new List<MarketDataEvent>();
+
+        // act - a pre-open auction, so the indicative producer contributes too
+        all.AddRange(feed.Process(book.UpdateStatus(OrderBookStatus.PreOpen)));
+        all.AddRange(feed.Process(
+            book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100)));
+        all.AddRange(feed.Process(
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100)));
+        all.AddRange(feed.Process(book.UpdateStatus(OrderBookStatus.Open)));
+
+        // assert - this is what lets several instruments share a channel
+        Assert.IsNotEmpty(all);
+        Assert.IsNotEmpty(all.OfType<IndicativePriceDataEvent>(), "expected an auction quote");
+        Assert.IsTrue(all.All(d => ReferenceEquals(d.Security, Sec)),
+            "every message must say which instrument it is about");
+    }
+
+    [Test]
+    public void Process_OrdersItsOutputByProducerRatherThanIncidentally()
+    {
+        // arrange
+        var (feed, book) = Feed();
+        feed.Process(book.UpdateStatus(OrderBookStatus.Open));
+        feed.Process(book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100));
+
+        // act
+        var data = feed.Process(
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100));
+
+        // assert - trades ahead of levels ahead of depth. Every event in one dispatch shares an
+        // instant, so there is no time order among them to preserve and the bundle's own order is
+        // what a subscriber gets. Fixed, so it is the same on every run.
+        var kinds = data.Select(d => d.GetType().Name).Distinct().ToList();
+        Assert.AreEqual(
+            new[] {nameof(TradedDataEvent), nameof(LevelsDataEvent), nameof(OrderBookDeltaEvent)},
+            kinds);
+    }
+
+    [Test]
+    public void Process_NoEvents_ProducesNothing()
+    {
+        var (feed, _) = Feed();
+
+        Assert.IsEmpty(feed.Process(Array.Empty<OrderBookEvent>()));
+    }
+
+    private static (SecurityFeed Feed, IOrderBook Book) Feed()
+    {
+        var book = new TimestampingOrderBook(Sec, new ManualClock(Now1));
+        return (new SecurityFeed(Sec, maxLevels: 10), book);
+    }
+}

--- a/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
@@ -22,7 +22,7 @@ public class SecurityStatusDataProducerTests
     }
 
     private IList<SecurityStatusDataEvent> Publish(IOrderBook book, IReadOnlyList<OrderBookEvent> bookEvents) =>
-        Producer.Process(book, bookEvents);
+        Producer.Process(bookEvents);
 
     private IOrderBook PlainBook() =>
         new TimestampingOrderBook(new Security("GCZ6", SecurityType.Future, 10, 10), Clock);
@@ -184,7 +184,7 @@ public class SecurityStatusDataProducerTests
 
         // act - a limit event arriving on its own carries the remembered status with it, which
         // is what holding state is for
-        var events = Producer.Process(book,
+        var events = Producer.Process(
             new OrderBookEvent[] {new LimitStateChanged(book.Security, Now1, Side.Sell, 90)});
 
         // assert

--- a/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
@@ -23,7 +23,7 @@ public class TradeDataProducerTests
             book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100);
 
         // act
-        var events = producer.Process(book, bookEvents);
+        var events = producer.Process(bookEvents);
 
         // assert
         Assert.IsNotNull(events);


### PR DESCRIPTION
Phase 5 of the sequencer plan: the outbound path. A book's events already went through producers; what was missing was anything carrying more than one instrument, which is what a venue actually publishes.

## Producers drop `IOrderBook`

Not one of the five ever read it — every mention was the parameter declaration or a comment. Dropping it makes a producer a pure function of the event stream, which is what the repo already claimed about market data, and it means **a feed can be rebuilt from a journal with no books involved at all**.

## Every market data event carries its `Security`

All five now derive from a common `MarketDataEvent(Security, DateTime)`, mirroring `OrderBookEvent`. Without it a message can't say which instrument it's about — fine for a per-book subscription, useless on a feed carrying several. It's the reason a stock locate code is on every ITCH message and a `SecurityID` on every CME one.

I deviated from the plan here. It called for "a compact numeric id resolved once per security, not the full `Security` record repeated on every message." That reasoning conflated wire size with in-process cost — in process this is a reference, not a repeated payload, and a numeric id needs a registry, an allocation policy and a mapping published to subscribers. A wire protocol should map `Security` → numeric id at the encoding boundary, which doesn't exist yet. Noted in the type's comment.

## `SecurityFeed`

The samples' private `BookFeed` promoted into the core, with one change: **one level producer at one depth** rather than several stacked. Two `LevelsDataEvent` streams at different depths are indistinguishable once merged into a channel, so depth is a property of a feed rather than something layered inside it — which is also how venues do it, publishing five-deep and ten-deep as separate products.

## `MarketDataChannel`

Carries several feeds under one sequence. **The sequence is the channel's own contiguous count, not the venue's dispatch count** — and that's a correction to the plan worth calling out.

The plan said the channel should carry "the dispatch sequence so subscribers can detect gaps." That doesn't work: a channel carrying three instruments out of a hundred would see the venue's numbering jump constantly, so a subscriber could never tell a filtered-out instrument from a lost message. Per-channel numbering makes a gap mean loss and nothing else, which is the only reason to number messages at all. Real feeds do exactly this — `MsgSeqNum` is per channel.

Ordering is promised within a channel and not across them, the same line CME and Nasdaq draw. That's why a product complex belongs on one channel, once implied pricing gives a spread and its legs a reason to share an order.

Events for a security a channel doesn't carry are ignored rather than refused — a channel is deliberately a subset of the venue. Routing groups by security rather than assuming one, so an action that implies a fill in another book still reaches each book's own producers; there's a test for that path even though nothing produces it today.

## Sample

Now shows both instruments on one channel rather than keeping its own bundle. Verified by running it: one contiguous run of sequence numbers 1–20 across the two securities, each message tagged.

It also incidentally confirms the Phase 3 finding — `GCZ6` (which went through pre-open) has ids like `202607300000000001` while `SIZ6` (straight to open) has `1`.

## Checks

**463 passed, 0 failed** (up from 449). All 449 pre-existing tests passed with no assertion changes, which is the evidence that dropping `IOrderBook` and adding `Security` changed no behaviour.

The end-to-end test was verified non-vacuous, and that caught a real problem with my first version: I'd used a compressed schedule so boundaries fell inside the trace, which left the books **closed for most of it**. 412 messages, of which 406 were `LevelsDataEvent` and zero were trades — nearly all of it rejection noise, since the level producer emits on any non-empty batch including rejections. Rewritten with a schedule that keeps the books open throughout: now 1053 messages — 573 depth deltas, 404 level updates, 72 trades.

## Observation, not fixed here

`LevelDataProducer` emits a `LevelsDataEvent` for any non-empty event batch, including ones that change no levels at all — a status change or a rejection republishes the unchanged ladders. That's real feed noise and pre-existing behaviour; changing it would alter producer semantics and its own tests, so it belongs on its own rather than buried in this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGRw4mRd2xujbSffPvTXZr)_