### PR TITLE
Rename Auction/PriceTime, StatusChangeReason, PriceRestrictionConfig

### DIFF
--- a/src/Circus/Events/OrderBookEvent.cs
+++ b/src/Circus/Events/OrderBookEvent.cs
@@ -8,7 +8,7 @@ public record OrderBookEvent(string Symbol, DateTime Time);
 // includes an interruption configured to last until told otherwise, and every ordinary
 // transition, since an explicit one supersedes whatever was pending.
 public record StatusChanged(string Symbol, DateTime Time, OrderBookStatus Status,
-        StatusChangeReason Reason = StatusChangeReason.Requested, DateTime? ResumesAt = null)
+        OrderBookStatusChangeReason Reason = OrderBookStatusChangeReason.Requested, DateTime? ResumesAt = null)
     : OrderBookEvent(Symbol, Time);
 
 public record OrderEvent(string Symbol, DateTime Time, string CompanyId, string ClientOrderId,

--- a/src/Circus/Instrument.cs
+++ b/src/Circus/Instrument.cs
@@ -7,5 +7,5 @@ public record Instrument(
     string Symbol,
     decimal TickSize,
     int MarketOrderProtectionTicks = 10,
-    IReadOnlyList<PriceRestrictionConfig>? PriceRestrictions = null
+    IReadOnlyList<PriceRestriction>? PriceRestrictions = null
 );

--- a/src/Circus/MarketData/SecurityStatusDataEvent.cs
+++ b/src/Circus/MarketData/SecurityStatusDataEvent.cs
@@ -4,5 +4,5 @@ namespace Circus.MarketData;
 // is which way a daily limit has the market stuck - Buy for limit up, where buyers cannot push
 // higher - and null when it is free to trade.
 public record SecurityStatusDataEvent(string Symbol, DateTime Time, OrderBookStatus Status,
-        StatusChangeReason Reason, DateTime? ResumesAt, Side? LimitState)
+        OrderBookStatusChangeReason Reason, DateTime? ResumesAt, Side? LimitState)
     : MarketDataEvent(Symbol, Time);

--- a/src/Circus/MarketData/SecurityStatusDataProducer.cs
+++ b/src/Circus/MarketData/SecurityStatusDataProducer.cs
@@ -18,7 +18,7 @@ namespace Circus.MarketData;
 public class SecurityStatusDataProducer : IDataProducer<SecurityStatusDataEvent>
 {
     private OrderBookStatus _status = OrderBookStatus.Closed;
-    private StatusChangeReason _reason = StatusChangeReason.Requested;
+    private OrderBookStatusChangeReason _reason = OrderBookStatusChangeReason.Requested;
     private DateTime? _resumesAt;
     private Side? _limitState;
 

--- a/src/Circus/Matching/AuctionMatchingAlgorithm.cs
+++ b/src/Circus/Matching/AuctionMatchingAlgorithm.cs
@@ -3,7 +3,7 @@ namespace Circus.Matching;
 // A call-auction print: every trade clears at one price, sized off each side's full remaining
 // quantity. The print is a single atomic allocation, not a sequence of continuous touches an
 // iceberg would have to ration its displayed size across.
-internal sealed class Auction : IMatchingAlgorithm
+internal sealed class AuctionMatchingAlgorithm : IMatchingAlgorithm
 {
     // Feeds the tie-break below and nothing else. Seeded from an explicit reference price
     // (CME's settlement price, pre-open) and thereafter tracks the last trade.

--- a/src/Circus/Matching/PriceTimeMatchingAlgorithm.cs
+++ b/src/Circus/Matching/PriceTimeMatchingAlgorithm.cs
@@ -5,7 +5,7 @@ namespace Circus.Matching;
 // the time-priority rule - at that order's own limit price, so an aggressor whose limit was
 // better than the touch gets the improvement. Sized off displayed quantity, since an iceberg
 // shows one peak at a time.
-internal sealed class PriceTime : IMatchingAlgorithm
+internal sealed class PriceTimeMatchingAlgorithm : IMatchingAlgorithm
 {
     public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
 

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -53,12 +53,12 @@ public class OrderBook : IOrderBook
         {
             {
                 OrderBookStatus.PreOpen,
-                new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                new TradingPhase(new AuctionMatchingAlgorithm(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
                     MatchesContinuously: false, StartsSession: true, ExpiresDayOrders: false)
             },
             {
                 OrderBookStatus.Open,
-                new TradingPhase(new PriceTime(), AcceptsOrderActions: true, AcceptsMarketOrders: true,
+                new TradingPhase(new PriceTimeMatchingAlgorithm(), AcceptsOrderActions: true, AcceptsMarketOrders: true,
                     MatchesContinuously: true, StartsSession: false, ExpiresDayOrders: false)
             },
             {
@@ -72,7 +72,7 @@ public class OrderBook : IOrderBook
                 // an interruption within a session and not the start of one, though, so unlike
                 // pre-open it neither reseeds sequence numbers nor retires anything.
                 OrderBookStatus.Paused,
-                new TradingPhase(new Auction(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
+                new TradingPhase(new AuctionMatchingAlgorithm(), AcceptsOrderActions: true, AcceptsMarketOrders: false,
                     MatchesContinuously: false, StartsSession: false, ExpiresDayOrders: false)
             },
             {
@@ -108,10 +108,10 @@ public class OrderBook : IOrderBook
     // Config in, enforcement out. The instrument describes what it trades under; this is the only
     // place that knows which adapter each description means, so a new restriction is a new arm
     // rather than a change to how books are constructed.
-    private static IReadOnlyList<IPriceRestriction> Adapt(IReadOnlyList<PriceRestrictionConfig>? configs) =>
+    private static IReadOnlyList<IPriceRestriction> Adapt(IReadOnlyList<PriceRestriction>? configs) =>
         configs == null
             ? Array.Empty<IPriceRestriction>()
-            : configs.Select<PriceRestrictionConfig, IPriceRestriction>(config => config switch
+            : configs.Select<PriceRestriction, IPriceRestriction>(config => config switch
             {
                 OrderPriceBand band => new OrderPriceRestriction(band.BandTicks),
                 VolatilityBand band => new VolatilityBandRestriction(band.RangeTicks, band.PauseFor,
@@ -197,11 +197,11 @@ public class OrderBook : IOrderBook
             UpdateOrder update => UpdateOrder(update.CompanyId, update.ClientOrderId,
                 update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice, time),
             CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId, time),
-            PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice, true, StatusChangeReason.Requested, time),
-            OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice, true, StatusChangeReason.Requested, time),
-            CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay, StatusChangeReason.Requested, time),
-            PauseTrading => UpdateStatus(OrderBookStatus.Paused, null, true, StatusChangeReason.Requested, time),
-            HaltTrading => UpdateStatus(OrderBookStatus.Halted, null, true, StatusChangeReason.Requested, time),
+            PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice, true, OrderBookStatusChangeReason.Requested, time),
+            OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice, true, OrderBookStatusChangeReason.Requested, time),
+            CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay, OrderBookStatusChangeReason.Requested, time),
+            PauseTrading => UpdateStatus(OrderBookStatus.Paused, null, true, OrderBookStatusChangeReason.Requested, time),
+            HaltTrading => UpdateStatus(OrderBookStatus.Halted, null, true, OrderBookStatusChangeReason.Requested, time),
 
             // Carries nothing and does nothing: the work is the due-interruption check every
             // Process already runs, and this is how a caller with no order flow reaches it.
@@ -228,7 +228,7 @@ public class OrderBook : IOrderBook
         // which checks inbound actions rather than emitted events.
         var due = _resumeAt.Value;
         _resumeAt = null;
-        return UpdateStatus(_resumeTo, null, true, StatusChangeReason.InterruptionElapsed, due);
+        return UpdateStatus(_resumeTo, null, true, OrderBookStatusChangeReason.InterruptionElapsed, due);
     }
 
     // Asked of the phase's own algorithm, so a quote exists exactly when there is an auction
@@ -798,7 +798,7 @@ public class OrderBook : IOrderBook
                     ? OrderBookStatus.Halted
                     : OrderBookStatus.Paused;
                 _resumeAt = breach.ResumeAfter.HasValue ? time + breach.ResumeAfter.Value : null;
-                events.Add(new StatusChanged(_instrument.Symbol, time, _status, StatusChangeReason.PriceRestriction,
+                events.Add(new StatusChanged(_instrument.Symbol, time, _status, OrderBookStatusChangeReason.PriceRestriction,
                     _resumeAt));
                 break;
 
@@ -952,7 +952,7 @@ public class OrderBook : IOrderBook
     // last of them ends it. The phase table stays the authority on whether a phase expires day
     // orders at all - this only says whether this particular close is that day's last.
     private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null,
-        bool endsTradingDay = true, StatusChangeReason reason = StatusChangeReason.Requested, DateTime time = default)
+        bool endsTradingDay = true, OrderBookStatusChangeReason reason = OrderBookStatusChangeReason.Requested, DateTime time = default)
     {
         if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
         {
@@ -973,7 +973,7 @@ public class OrderBook : IOrderBook
             // interruption is still running and why, which is the same thing a fresh one says.
             _resumeAt = extension.Value.ResumeAfter.HasValue ? time + extension.Value.ResumeAfter.Value : null;
             return new List<OrderBookEvent>
-                {new StatusChanged(_instrument.Symbol, time, _status, StatusChangeReason.PriceRestriction, _resumeAt)};
+                {new StatusChanged(_instrument.Symbol, time, _status, OrderBookStatusChangeReason.PriceRestriction, _resumeAt)};
         }
 
         // Any transition supersedes a pending one, so a session closing over a running pause

--- a/src/Circus/OrderBookStatusChangeReason.cs
+++ b/src/Circus/OrderBookStatusChangeReason.cs
@@ -4,7 +4,7 @@ namespace Circus;
 // infer from context - a session opening looks nothing like a volatility pause on a feed, but
 // both are just a status. Only what the book itself can tell apart: which restriction fired is
 // not yet part of this, since the book sees a breach action rather than a named restriction.
-public enum StatusChangeReason
+public enum OrderBookStatusChangeReason
 {
     // Driven from outside - a session schedule, or an operator.
     Requested,

--- a/src/Circus/PriceRestriction.cs
+++ b/src/Circus/PriceRestriction.cs
@@ -1,8 +1,8 @@
 namespace Circus;
 
-// What restrictions a security trades under, as data. The book turns each of these into the
+// What restrictions an instrument trades under, as data. The book turns each of these into the
 // adapter that enforces it, so adding a restriction is adding a case here rather than another
-// optional parameter on Security - which is what these replaced.
+// optional parameter on Instrument - which is what these replaced.
 //
 // A restriction that does not apply is left out of the list rather than configured with no
 // width: absence is modelled by absence.
@@ -11,10 +11,10 @@ namespace Circus;
 // OrderBook/Restrictions: this is part of describing an instrument, so a caller building an
 // Instrument should not have to reach into the book to say what it trades under. Each adapter is
 // named for the config it enforces - VolatilityBand is enforced by VolatilityBandRestriction.
-public abstract record PriceRestrictionConfig;
+public abstract record PriceRestriction;
 
 // Rejects an order priced too far from the reference, at entry. CME's price banding.
-public sealed record OrderPriceBand(int BandTicks) : PriceRestrictionConfig;
+public sealed record OrderPriceBand(int BandTicks) : PriceRestriction;
 
 // Interrupts trading when a prospective trade price falls too far from where the market has
 // recently traded, rather than rejecting the order that would have caused it. Eurex's dynamic
@@ -29,12 +29,12 @@ public sealed record VolatilityBand(
     int RangeTicks,
     TimeSpan? PauseFor = null,
     TimeSpan? Window = null,
-    int? ExtendedRangeTicks = null) : PriceRestrictionConfig;
+    int? ExtendedRangeTicks = null) : PriceRestriction;
 
 // Interrupts trading on distance from a fixed reference rather than from recent trades, so it
 // catches a whole day's drift that a range following the market never notices. Eurex's static
 // volatility interruption. Anchored only by the reference prices supplied at status changes.
-public sealed record StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null) : PriceRestrictionConfig;
+public sealed record StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null) : PriceRestriction;
 
 // "Too far, too fast": the same windowed range a dynamic volatility interruption uses, at the
 // short timescale that catches a run of steps each unremarkable next to the last. CME's
@@ -48,7 +48,7 @@ public sealed record StaticPriceRange(int RangeTicks, TimeSpan? PauseFor = null)
 // Window is required, unlike VolatilityBand's - a velocity limit without one would just be a
 // range around the last trade, which is the other config.
 public sealed record VelocityLimit(int RangeTicks, TimeSpan Window, TimeSpan? PauseFor = null)
-    : PriceRestrictionConfig;
+    : PriceRestriction;
 
 // How wide a limit is. Every restriction above measures in ticks because it tracks a market
 // that has already moved; the ones below are set against a settlement price before the day
@@ -64,7 +64,7 @@ public abstract record PriceLimitWidth
 // A session-long ceiling and floor. Trading continues at the limit price but nothing prints
 // through it and no order may be entered beyond it - CME's limit-lock, which is not a halt: the
 // market stays open, quotes, and can trade back inside.
-public sealed record DailyPriceLimit(PriceLimitWidth Width) : PriceRestrictionConfig;
+public sealed record DailyPriceLimit(PriceLimitWidth Width) : PriceRestriction;
 
 // A threshold that stops trading outright rather than capping it. Several are ordinarily
 // configured together - CME's equity index breakers halt at 7 and 13 percent and end the day at
@@ -73,4 +73,4 @@ public sealed record DailyPriceLimit(PriceLimitWidth Width) : PriceRestrictionCo
 //
 // HaltFor null never resumes on its own, which is what the level that ends a trading day wants:
 // whoever drives the book closes it.
-public sealed record CircuitBreaker(PriceLimitWidth Width, TimeSpan? HaltFor = null) : PriceRestrictionConfig;
+public sealed record CircuitBreaker(PriceLimitWidth Width, TimeSpan? HaltFor = null) : PriceRestriction;

--- a/src/Circus/Restrictions/IPriceRestriction.cs
+++ b/src/Circus/Restrictions/IPriceRestriction.cs
@@ -3,7 +3,7 @@ using Circus.Events;
 namespace Circus.Restrictions;
 
 // The enforcement half of price restrictions. The declarations these are built from are
-// PriceRestrictionConfig and its subtypes, which live beside Instrument because they describe an
+// PriceRestriction and its subtypes, which live beside Instrument because they describe an
 // instrument rather than the book; each adapter here is named for the config it enforces.
 // OrderBook.Adapt is what turns one into the other.
 

--- a/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/SecurityStatusDataProducerTests.cs
@@ -31,7 +31,7 @@ public class SecurityStatusDataProducerTests
     private IOrderBook PausingBook() =>
         new TimestampingOrderBook(
             new Instrument("GCZ6", 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)}),
+                PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5, PauseFor)}),
             Clock);
 
     [Test]
@@ -47,7 +47,7 @@ public class SecurityStatusDataProducerTests
         Assert.AreEqual(1, events.Count);
         Assert.AreEqual(Now1, events[0].Time);
         Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
-        Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.Requested, events[0].Reason);
         Assert.IsNull(events[0].ResumesAt);
         Assert.IsNull(events[0].LimitState);
     }
@@ -83,7 +83,7 @@ public class SecurityStatusDataProducerTests
         // could not be published at all before this producer existed
         Assert.AreEqual(1, events.Count);
         Assert.AreEqual(OrderBookStatus.Paused, events[0].Status);
-        Assert.AreEqual(StatusChangeReason.PriceRestriction, events[0].Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.PriceRestriction, events[0].Reason);
         Assert.AreEqual(Now1 + PauseFor, events[0].ResumesAt);
     }
 
@@ -103,7 +103,7 @@ public class SecurityStatusDataProducerTests
         // assert
         Assert.AreEqual(1, events.Count);
         Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
-        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, events[0].Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.InterruptionElapsed, events[0].Reason);
         Assert.IsNull(events[0].ResumesAt, "back to trading, so nothing is pending");
     }
 
@@ -113,7 +113,7 @@ public class SecurityStatusDataProducerTests
         // arrange - a range with no duration configured stands until something ends it
         var book = new TimestampingOrderBook(
             new Instrument("GCZ6", 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)}),
+                PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5)}),
             Clock);
         Publish(book, book.UpdateStatus(OrderBookStatus.Open, 100));
         book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Sell, 5, 200);
@@ -135,7 +135,7 @@ public class SecurityStatusDataProducerTests
         // clock moves on so that buy is genuinely the older order when the sell arrives.
         var book = new TimestampingOrderBook(
             new Instrument("GCZ6", 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
+                PriceRestrictions: new PriceRestriction[]
                 {
                     new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
                 }),
@@ -158,7 +158,7 @@ public class SecurityStatusDataProducerTests
         Assert.AreEqual(1, events.Count);
         Assert.AreEqual(Side.Buy, events[0].LimitState);
         Assert.AreEqual(OrderBookStatus.Open, events[0].Status);
-        Assert.AreEqual(StatusChangeReason.Requested, events[0].Reason,
+        Assert.AreEqual(OrderBookStatusChangeReason.Requested, events[0].Reason,
             "the last status change is still what put it here");
 
         // act - the order out beyond the ceiling is pulled and the book trades inside the limit

--- a/tests/Circus.Tests/Matching/AuctionTests.cs
+++ b/tests/Circus.Tests/Matching/AuctionTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace Circus.Tests.Matching;
 
 [TestFixture]
-public class AuctionTests
+public class AuctionMatchingAlgorithmTests
 {
     private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
     private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
@@ -362,7 +362,7 @@ public class AuctionTests
         // pause the book. This order doesn't cross anything (isolated at 200, nothing on the
         // opposing side), so it must not trigger a pause just for being entered.
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5)});
         var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
@@ -382,7 +382,7 @@ public class AuctionTests
         // sell stop (trigger 90) is added, plus a resting sell at 200 that hasn't crossed
         // anything yet (so hasn't paused anything, per the test above)
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5)});
         var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
@@ -438,7 +438,7 @@ public class AuctionTests
         // arrange - #23's hard-reject band still works exactly as before with no volatility
         // band alongside it
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new OrderPriceBand(5)});
         var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 

--- a/tests/Circus.Tests/Matching/MatcherTests.cs
+++ b/tests/Circus.Tests/Matching/MatcherTests.cs
@@ -74,7 +74,7 @@ public class MatcherTests
         var matcher = BookWithThreeRestingBuys(out var first, out _, out _);
 
         // act
-        var outcome = FirstOutcome(matcher, new PriceTime());
+        var outcome = FirstOutcome(matcher, new PriceTimeMatchingAlgorithm());
 
         // assert
         var trade = outcome as TradeExecuted;
@@ -93,7 +93,7 @@ public class MatcherTests
         var matcher = BookWithThreeRestingBuys(out _, out _, out _);
 
         // act
-        var outcomes = matcher.Run(new DeclinesToMatch(), new PriceTime(), _ => null).ToList();
+        var outcomes = matcher.Run(new DeclinesToMatch(), new PriceTimeMatchingAlgorithm(), _ => null).ToList();
 
         // assert
         Assert.IsEmpty(outcomes);
@@ -106,7 +106,7 @@ public class MatcherTests
         var matcher = BookWithThreeRestingBuys(out _, out _, out _);
 
         // act
-        var outcomes = matcher.Run(new DeclinesToBegin(), new PriceTime(), _ => null).ToList();
+        var outcomes = matcher.Run(new DeclinesToBegin(), new PriceTimeMatchingAlgorithm(), _ => null).ToList();
 
         // assert
         Assert.IsEmpty(outcomes);

--- a/tests/Circus.Tests/Restrictions/CircuitBreakerTests.cs
+++ b/tests/Circus.Tests/Restrictions/CircuitBreakerTests.cs
@@ -30,7 +30,7 @@ public class CircuitBreakerTests
     private IOrderBook LeveledBook()
     {
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor),
                 new CircuitBreaker(new PriceLimitWidth.Percent(13), HaltFor),
@@ -67,7 +67,7 @@ public class CircuitBreakerTests
         var events = book.AdvanceTime();
 
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
+        Assert.AreEqual(OrderBookStatusChangeReason.InterruptionElapsed,
             events.OfType<StatusChanged>().Single().Reason);
     }
 
@@ -98,7 +98,7 @@ public class CircuitBreakerTests
         // arrange - a volatility band far narrower than the breaker, so any price tripping the
         // breaker trips the band too. The severer consequence has to win.
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new VolatilityBand(2, PauseFor: TimeSpan.FromMinutes(2)),
                 new CircuitBreaker(new PriceLimitWidth.Percent(7), HaltFor)

--- a/tests/Circus.Tests/Restrictions/DailyLimitTests.cs
+++ b/tests/Circus.Tests/Restrictions/DailyLimitTests.cs
@@ -28,7 +28,7 @@ public class DailyLimitTests
     private IOrderBook LimitedBook()
     {
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
             });
@@ -78,7 +78,7 @@ public class DailyLimitTests
     private IOrderBook BookWithRestingOrderAboveTheLimit()
     {
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new DailyPriceLimit(new PriceLimitWidth.Ticks(5))
             });
@@ -148,7 +148,7 @@ public class DailyLimitTests
     {
         // arrange - 7 percent of a reference of 1000, so 70 either side
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new DailyPriceLimit(new PriceLimitWidth.Percent(7))
             });
@@ -168,7 +168,7 @@ public class DailyLimitTests
     {
         // arrange - a percentage of nothing is not a width
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new DailyPriceLimit(new PriceLimitWidth.Percent(7))
             });

--- a/tests/Circus.Tests/Restrictions/PriceBandTests.cs
+++ b/tests/Circus.Tests/Restrictions/PriceBandTests.cs
@@ -54,7 +54,7 @@ public class PriceBandTests
         // two could be crossed over. A wide entry band must not reject, and a narrow volatility
         // band must still pause on the resulting trade.
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new OrderPriceBand(1000),
                 new VolatilityBand(5)
@@ -80,7 +80,7 @@ public class PriceBandTests
     {
         // arrange - band is configured, but there's no anchor to check against yet
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new OrderPriceBand(5)});
         var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open);
 
@@ -96,7 +96,7 @@ public class PriceBandTests
     {
         // arrange - band of 5 ticks (50) around a seeded reference of 100, so [50, 150]
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new OrderPriceBand(5)});
         var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
@@ -120,7 +120,7 @@ public class PriceBandTests
     {
         // arrange - reference seeded at 100, band [50, 150]
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new OrderPriceBand(5)});
         var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
 
@@ -147,7 +147,7 @@ public class PriceBandTests
     {
         // arrange - reference seeded at 100, band [50, 150]
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new OrderPriceBand(5)});
         var book = new LevelTrackingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Buy, 5, 100);
@@ -169,7 +169,7 @@ public class PriceBandTests
     // A band of 5 ticks on a tick size of 10 is 50 either side of wherever the reference is.
     private static Instrument BandedSecurity() =>
         new("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new OrderPriceBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new OrderPriceBand(5)});
 
     [Test]
     public void PreOpen_ReferenceMovesFromTheSettlementPriceToTheIndicativePrice()

--- a/tests/Circus.Tests/Restrictions/VelocityLogicTests.cs
+++ b/tests/Circus.Tests/Restrictions/VelocityLogicTests.cs
@@ -29,7 +29,7 @@ public class VelocityLogicTests
     private IOrderBook VelocityBook(TimeSpan? pauseFor = null) =>
         new TimestampingOrderBook(
             new Instrument("GCZ6", 10, 10,
-                PriceRestrictions: new PriceRestrictionConfig[]
+                PriceRestrictions: new PriceRestriction[]
                 {
                     new VelocityLimit(5, Window, pauseFor)
                 }),
@@ -85,7 +85,7 @@ public class VelocityLogicTests
         // arrange - a wide volatility band with no window of its own alongside the velocity
         // limit. The band is four times the width, so nothing below comes close to it.
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new VolatilityBand(20),
                 new VelocityLimit(5, Window)

--- a/tests/Circus.Tests/Restrictions/VolatilityInterruptionTests.cs
+++ b/tests/Circus.Tests/Restrictions/VolatilityInterruptionTests.cs
@@ -32,7 +32,7 @@ public class VolatilityInterruptionTests
     // that is 50 and 80 either side of the reference.
     private static Instrument ExtendingSecurity() =>
         new("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new VolatilityBand(5, PauseFor: PauseFor, ExtendedRangeTicks: 8)
             });
@@ -59,7 +59,7 @@ public class VolatilityInterruptionTests
 
         var stillPaused = events.OfType<StatusChanged>().Single();
         Assert.AreEqual(OrderBookStatus.Paused, stillPaused.Status);
-        Assert.AreEqual(StatusChangeReason.PriceRestriction, stillPaused.Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.PriceRestriction, stillPaused.Reason);
     }
 
     [Test]
@@ -81,7 +81,7 @@ public class VolatilityInterruptionTests
         // book poked punctually never sees any of this
         Assert.AreEqual(OrderBookStatus.Paused, book.Status);
         var stillPaused = events.OfType<StatusChanged>().Single();
-        Assert.AreEqual(StatusChangeReason.PriceRestriction, stillPaused.Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.PriceRestriction, stillPaused.Reason);
         Assert.AreEqual(Now1 + PauseFor, stillPaused.Time);
         Assert.AreEqual(Now1 + PauseFor + PauseFor, stillPaused.ResumesAt);
     }
@@ -125,7 +125,7 @@ public class VolatilityInterruptionTests
         // Each step below is well inside the dynamic range; it is the distance from where the
         // day started that eventually trips.
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[]
+            PriceRestrictions: new PriceRestriction[]
             {
                 new VolatilityBand(3),
                 new StaticPriceRange(5)

--- a/tests/Circus.Tests/Sequencing/LiveDriverTests.cs
+++ b/tests/Circus.Tests/Sequencing/LiveDriverTests.cs
@@ -22,7 +22,7 @@ public class LiveDriverTests
 
     // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it.
     private static readonly Instrument PausingGold = new("GCZ6", 10, 10,
-        PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)});
+        PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5, PauseFor)});
 
     private static MarketSchedule TradingDay() => new(new(9, 0, 0), new(9, 30, 0), new(17, 0, 0));
 

--- a/tests/Circus.Tests/Sequencing/SequencerRoutingTests.cs
+++ b/tests/Circus.Tests/Sequencing/SequencerRoutingTests.cs
@@ -32,7 +32,7 @@ public class SequencerRoutingTests
     // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it and pauses
     // that book for two minutes. Only gold gets one, so the others carry on regardless.
     private static readonly Instrument PausingGold = new("GCZ6", 10, 10,
-        PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)});
+        PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5, PauseFor)});
 
     private static MarketSchedule TradingDay() => new(PreOpenAt, OpenAt, CloseAt);
 
@@ -191,7 +191,7 @@ public class SequencerRoutingTests
 
         // and only gold was told anything about a status change
         var statuses = dispatched.SelectMany(d => d.Events).OfType<StatusChanged>()
-            .Where(s => s.Reason == StatusChangeReason.PriceRestriction)
+            .Where(s => s.Reason == OrderBookStatusChangeReason.PriceRestriction)
             .ToList();
         Assert.AreEqual(1, statuses.Count);
         Assert.AreEqual(Gold.Symbol, statuses[0].Symbol);

--- a/tests/Circus.Tests/Sequencing/SequencerTests.cs
+++ b/tests/Circus.Tests/Sequencing/SequencerTests.cs
@@ -26,7 +26,7 @@ public class SequencerTests
     // A 5-tick volatility band on a reference of 100, so a trade at 200 breaches it and pauses the
     // book for two minutes.
     private static readonly Instrument PausingSec = new("GCZ6", 10, 10,
-        PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, PauseFor)});
+        PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5, PauseFor)});
 
     private static MarketSchedule TradingDay() => new(PreOpenAt, OpenAt, CloseAt);
 
@@ -181,7 +181,7 @@ public class SequencerTests
         Assert.IsInstanceOf<AdvanceTime>(dispatched[3].Action);
         var resumed = dispatched[3].Events.OfType<StatusChanged>().Single();
         Assert.AreEqual(OrderBookStatus.Open, resumed.Status);
-        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.InterruptionElapsed, resumed.Reason);
 
         Assert.IsInstanceOf<CreateLimitOrder>(dispatched[4].Action);
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
@@ -225,7 +225,7 @@ public class SequencerTests
         // poked punctually, the deadline and the poke are the same instant - which is what stops
         // the resume being stamped anywhere else
         var resumed = tick.Events.OfType<StatusChanged>().Single();
-        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.InterruptionElapsed, resumed.Reason);
         Assert.AreEqual(Deadline, resumed.Time);
 
         // and the pause resolves into one uncrossing print, stamped there too

--- a/tests/Circus.Tests/Sessions/PausedHaltedTests.cs
+++ b/tests/Circus.Tests/Sessions/PausedHaltedTests.cs
@@ -200,7 +200,7 @@ public class PausedHaltedTests
     {
         // arrange - a reference of 100 and a 5-tick volatility band
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5)});
+            PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5)});
         var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         book.CreateLimitOrder(CompanyId1, OrderId1, new OrderValidity.Day(), Side.Sell, 5, 200);

--- a/tests/Circus.Tests/Sessions/TimedResumeTests.cs
+++ b/tests/Circus.Tests/Sessions/TimedResumeTests.cs
@@ -38,7 +38,7 @@ public class TimedResumeTests
     private IOrderBook PausingBook(TimeSpan? duration)
     {
         var security = new Instrument("GCZ6", 10, 10,
-            PriceRestrictions: new PriceRestrictionConfig[] {new VolatilityBand(5, duration)});
+            PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5, duration)});
         var book = new TimestampingOrderBook(security, Clock);
         book.UpdateStatus(OrderBookStatus.Open, 100);
         return book;
@@ -68,7 +68,7 @@ public class TimedResumeTests
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
         var resumed = events.OfType<StatusChanged>().Single();
         Assert.AreEqual(OrderBookStatus.Open, resumed.Status);
-        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.InterruptionElapsed, resumed.Reason);
     }
 
     [Test]
@@ -133,7 +133,7 @@ public class TimedResumeTests
 
         // assert - resumed first, so the order arrived into an open book
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        Assert.AreEqual(StatusChangeReason.InterruptionElapsed,
+        Assert.AreEqual(OrderBookStatusChangeReason.InterruptionElapsed,
             events.OfType<StatusChanged>().Single().Reason);
         Assert.AreEqual(1, events.OfType<CreateOrderConfirmed>().Count());
     }
@@ -152,7 +152,7 @@ public class TimedResumeTests
         // assert - the interruption ended when it elapsed, not when something got round to asking
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
         var resumed = events.OfType<StatusChanged>().Single();
-        Assert.AreEqual(StatusChangeReason.InterruptionElapsed, resumed.Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.InterruptionElapsed, resumed.Reason);
         Assert.AreEqual(Now1 + PauseFor, resumed.Time);
     }
 
@@ -235,8 +235,8 @@ public class TimedResumeTests
         var breached = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 200);
 
         // assert
-        Assert.AreEqual(StatusChangeReason.Requested, opened.OfType<StatusChanged>().Single().Reason);
-        Assert.AreEqual(StatusChangeReason.PriceRestriction,
+        Assert.AreEqual(OrderBookStatusChangeReason.Requested, opened.OfType<StatusChanged>().Single().Reason);
+        Assert.AreEqual(OrderBookStatusChangeReason.PriceRestriction,
             breached.OfType<StatusChanged>().Single().Reason);
     }
 


### PR DESCRIPTION

## Summary

Renames four types for clarity:

- `Auction` → `AuctionMatchingAlgorithm` — unambiguous about what kind of thing it is
- `PriceTime` → `PriceTimeMatchingAlgorithm` — same
- `StatusChangeReason` → `OrderBookStatusChangeReason` — scoped to its domain
- `PriceRestrictionConfig` → `PriceRestriction` — shorter, the 'Config' suffix added nothing

## Verification
- ✅ `src/Circus` builds 0 errors
- ✅ `tests/Circus.Tests` builds 0 errors, **463/463 tests pass**
- ✅ `samples/Circus.Examples` builds 0 errors
- ✅ `benchmarks/Circus.Benchmarks` builds 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)