### PR TITLE
Add InstrumentGroup — shared sequencer + market data channel

### DIFF
--- a/src/Circus/Sequencing/InstrumentGroup.cs
+++ b/src/Circus/Sequencing/InstrumentGroup.cs
@@ -1,0 +1,59 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sessions;
+
+namespace Circus.Sequencing;
+
+// A group of instruments that share a single sequencer and a single market data channel.
+// Registering an instrument here adds it to both, so the wiring between them cannot be wrong.
+//
+// A product complex -- a spread and its legs -- needs a common dispatch order the moment implied
+// pricing exists, and it needs a single channel so the per-instrument messages carry contiguous
+// sequence numbers a subscriber can count. This is the unit that provides both, bundled together.
+//
+// Single-threaded, like the sequencer and the channel inside it.
+public sealed class InstrumentGroup
+{
+    private readonly Sequencer _sequencer;
+    private readonly MarketDataChannel _channel;
+    private readonly List<string> _symbols = new();
+
+    public InstrumentGroup(DateTime start)
+    {
+        _sequencer = new Sequencer(start);
+        _channel = new MarketDataChannel();
+    }
+
+    public Sequencer Sequencer => _sequencer;
+    public MarketDataChannel Channel => _channel;
+    public IReadOnlyList<string> Symbols => _symbols;
+
+    // Registers an instrument: creates a bare OrderBook and a SecurityFeed, adds the book and
+    // schedule to the sequencer and the feed to the channel. maxLevels sets the depth of the
+    // level data producer (default 10).
+    public void Add(Instrument instrument, MarketSchedule schedule, int maxLevels = 10)
+    {
+        ArgumentNullException.ThrowIfNull(instrument);
+        ArgumentNullException.ThrowIfNull(schedule);
+
+        var book = new OrderBook(instrument);
+        _sequencer.Add(book, schedule);
+        _channel.Add(new SecurityFeed(instrument.Symbol, maxLevels));
+        _symbols.Add(instrument.Symbol);
+    }
+
+    // Registers a pre-built book (e.g. with custom price restrictions) alongside its schedule and
+    // a security feed for it.
+    public void Add(IOrderBook book, MarketSchedule schedule, int maxLevels = 10)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+        ArgumentNullException.ThrowIfNull(schedule);
+
+        _sequencer.Add(book, schedule);
+        _channel.Add(new SecurityFeed(book.Symbol, maxLevels));
+        _symbols.Add(book.Symbol);
+    }
+
+    // Submits an action to the group's sequencer.
+    public void Submit(OrderBookAction action) => _sequencer.Submit(action);
+}

--- a/src/Circus/Sequencing/Replay.cs
+++ b/src/Circus/Sequencing/Replay.cs
@@ -1,4 +1,5 @@
 using Circus.Actions;
+using Circus.MarketData;
 
 namespace Circus.Sequencing;
 
@@ -41,6 +42,20 @@ public static class Replay
 
         if (until is { } end && end > sequencer.LogicalNow)
             Report(sequencer.AdvanceTo(end), onDispatched);
+    }
+
+    // Runs a trace through an InstrumentGroup's sequencer, publishing every dispatch through the
+    // group's channel, and returns the channel messages in order. A convenience that replaces the
+    // manual wiring of Run(group.Sequencer, trace, d => ...) with a single call.
+    public static IReadOnlyList<ChannelMessage> Run(InstrumentGroup group,
+        IEnumerable<OrderBookAction> trace, DateTime? until = null)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(trace);
+
+        var messages = new List<ChannelMessage>();
+        Run(group.Sequencer, trace, d => messages.AddRange(group.Channel.Publish(d.Events)), until);
+        return messages;
     }
 
     private static void Report(IReadOnlyList<Dispatched> dispatched, Action<Dispatched>? onDispatched)

--- a/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
+++ b/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
@@ -30,19 +30,14 @@ public class ChannelFromDispatchTests
     public void MarketDataFollowsTheOrderTheVenueDispatchedIn()
     {
         // arrange
-        var sequencer = new Sequencer(Day);
-        sequencer.Add(new OrderBook(Gold), OpenThroughout());
-        sequencer.Add(new OrderBook(Silver), OpenThroughout());
-
-        var channel = new MarketDataChannel();
-        channel.Add(new SecurityFeed(Gold.Symbol, maxLevels: 10));
-        channel.Add(new SecurityFeed(Silver.Symbol, maxLevels: 10));
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+        group.Add(Silver, OpenThroughout());
 
         var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 21).Generate(400);
 
-        // act - publish each dispatch's events as they come out
-        var published = new List<ChannelMessage>();
-        Replay.Run(sequencer, trace, d => published.AddRange(channel.Publish(d.Events)));
+        // act - the group wires sequencer dispatch to channel publish automatically
+        var published = Replay.Run(group, trace);
 
         // assert
         Assert.IsNotEmpty(published);
@@ -123,20 +118,13 @@ public class ChannelFromDispatchTests
 
     private static List<string> PublishAll(IReadOnlyList<OrderBookAction> trace)
     {
-        var sequencer = new Sequencer(Day);
-        sequencer.Add(new OrderBook(Gold), OpenThroughout());
-        sequencer.Add(new OrderBook(Silver), OpenThroughout());
-
-        var channel = new MarketDataChannel();
-        channel.Add(new SecurityFeed(Gold.Symbol, maxLevels: 10));
-        channel.Add(new SecurityFeed(Silver.Symbol, maxLevels: 10));
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+        group.Add(Silver, OpenThroughout());
 
         var rendered = new List<string>();
-        Replay.Run(sequencer, trace, d =>
-        {
-            foreach (var message in channel.Publish(d.Events))
-                rendered.Add($"{message.Sequence} {message.Data.Symbol} {Describe(message.Data)}");
-        });
+        foreach (var message in Replay.Run(group, trace))
+            rendered.Add($"{message.Sequence} {message.Data.Symbol} {Describe(message.Data)}");
 
         return rendered;
     }

--- a/tests/Circus.Tests/Sequencing/InstrumentGroupTests.cs
+++ b/tests/Circus.Tests/Sequencing/InstrumentGroupTests.cs
@@ -1,0 +1,145 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Simulator;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sequencing;
+
+// InstrumentGroup bundles registration of a book and its market-data feed into one step.
+// What is here is that the two registrations stay in sync, and that the convenience methods
+// produce the same result the manual wiring would have.
+[TestFixture]
+public class InstrumentGroupTests
+{
+    private static readonly DateTime Day = new(2000, 1, 1);
+
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly Instrument Silver = new("SIZ6", 10, 10);
+
+    // A book that pauses when it trades through 105 (5 ticks from reference 100).
+    private static readonly Instrument PausingGold = new("GCZ6", 10, 10,
+        PriceRestrictions: new PriceRestriction[] {new VolatilityBand(5, TimeSpan.FromMinutes(2))});
+
+    private static MarketSchedule OpenThroughout() =>
+        new(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(17, 0, 0));
+
+    private static MarketSchedule Quiet() =>
+        new(new TimeSpan(23, 0, 0), new TimeSpan(23, 15, 0), new TimeSpan(23, 45, 0));
+
+    private static DateTime At(int hour, int minute) => Day.Add(new TimeSpan(hour, minute, 0));
+
+    [Test]
+    public void Add_RegistersBookAndFeed()
+    {
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+
+        group.Submit(new OpenTrading {Symbol = Gold.Symbol, Time = At(9, 0)});
+        var dispatched = group.Sequencer.AdvanceTo(At(10, 0));
+        var messages = group.Channel.Publish(dispatched.SelectMany(d => d.Events).ToList());
+
+        Assert.IsNotEmpty(messages);
+        Assert.AreEqual(1, messages[0].Sequence);
+        Assert.AreEqual(
+            Enumerable.Range(1, messages.Count).Select(i => (long) i).ToList(),
+            messages.Select(m => m.Sequence).ToList());
+    }
+
+    [Test]
+    public void TwoInstrumentsShareOneSequence()
+    {
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+        group.Add(Silver, OpenThroughout());
+
+        group.Submit(new OpenTrading {Symbol = Gold.Symbol, Time = At(9, 0)});
+        group.Submit(new OpenTrading {Symbol = Silver.Symbol, Time = At(9, 0)});
+        var dispatched = group.Sequencer.AdvanceTo(At(10, 0));
+
+        var messages = new List<ChannelMessage>();
+        foreach (var d in dispatched)
+            messages.AddRange(group.Channel.Publish(d.Events));
+
+        Assert.IsNotEmpty(messages);
+        Assert.AreEqual(
+            Enumerable.Range(1, messages.Count).Select(i => (long) i).ToList(),
+            messages.Select(m => m.Sequence).ToList());
+
+        // both symbols appear
+        Assert.AreEqual(
+            new[] {Gold.Symbol, Silver.Symbol},
+            messages.Select(m => m.Data.Symbol).Distinct().OrderBy(n => n).ToArray());
+    }
+
+    [Test]
+    public void Add_IOrderBook_AcceptsPreBuiltBook()
+    {
+        var group = new InstrumentGroup(Day);
+        group.Add(new OrderBook(PausingGold), OpenThroughout());
+
+        group.Submit(new OpenTrading {Symbol = PausingGold.Symbol, Time = At(9, 0), ReferencePrice = 100});
+        group.Sequencer.AdvanceTo(At(10, 0));
+
+        Assert.That(group.Symbols, Has.Member(PausingGold.Symbol));
+    }
+
+    [Test]
+    public void Add_TwiceForSameSymbol_Throws()
+    {
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+
+        Assert.Throws<ArgumentException>(() => group.Add(Gold, OpenThroughout()));
+    }
+
+    [Test]
+    public void Submit_UnknownSymbol_Throws()
+    {
+        var group = new InstrumentGroup(Day);
+
+        Assert.Throws<ArgumentException>(() =>
+            group.Submit(new OpenTrading {Symbol = "UNKNOWN", Time = At(9, 0)}));
+    }
+
+    [Test]
+    public void ExposesSequencerAndChannel()
+    {
+        var group = new InstrumentGroup(Day);
+
+        Assert.IsNotNull(group.Sequencer);
+        Assert.IsNotNull(group.Channel);
+        Assert.AreEqual(Day, group.Sequencer.LogicalNow);
+    }
+
+    [Test]
+    public void Replay_Run_Convenience_ProducesSameResultAsManualWiring()
+    {
+        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 42).Generate(200);
+
+        // Manual wiring
+        var manual = new InstrumentGroup(Day);
+        manual.Add(Gold, OpenThroughout());
+        manual.Add(Silver, OpenThroughout());
+
+        var manualMessages = new List<ChannelMessage>();
+        Replay.Run(manual.Sequencer, trace,
+            d => manualMessages.AddRange(manual.Channel.Publish(d.Events)));
+
+        // Convenience
+        var convenience = new InstrumentGroup(Day);
+        convenience.Add(Gold, OpenThroughout());
+        convenience.Add(Silver, OpenThroughout());
+
+        var convenienceMessages = Replay.Run(convenience, trace);
+
+        // assert
+        Assert.IsNotEmpty(manualMessages);
+        Assert.IsNotEmpty(convenienceMessages);
+        Assert.AreEqual(manualMessages.Count, convenienceMessages.Count);
+        Assert.AreEqual(
+            manualMessages.Select(m => m.Sequence).ToList(),
+            convenienceMessages.Select(m => m.Sequence).ToList());
+    }
+}


### PR DESCRIPTION
A grouping concept that registers an instrument's book and its market-data feed in one step, so the wiring between sequencer and channel cannot be wrong.

**Motivation:** A product complex (e.g. a spread and its legs) needs a common dispatch order and a single market data channel with contiguous sequence numbers. Today that requires 6 lines of manual registration + callback wiring; InstrumentGroup collapses it to 2 lines.

**Changes:**
- New InstrumentGroup class in Circus.Sequencing — holds a Sequencer and a MarketDataChannel, exposes both as properties
- Add(Instrument, schedule) creates a bare OrderBook and SecurityFeed, registers both
- Add(IOrderBook, schedule) for pre-built books (e.g. with custom price restrictions)
- Submit(action) delegates to the sequencer
- New Replay.Run(InstrumentGroup, trace) convenience overload — runs the trace and collects all channel messages
- 7 new tests covering registration, dispatch ordering, error cases, and Replay convenience
- 2 existing ChannelFromDispatchTests simplified to use InstrumentGroup

**Verification:** 445 tests pass, 0 fail.
