### PR TITLE
Add ProRataMatchingAlgorithm

### DIFF
--- a/src/Circus/Matching/ProRataMatchingAlgorithm.cs
+++ b/src/Circus/Matching/ProRataMatchingAlgorithm.cs
@@ -1,0 +1,128 @@
+namespace Circus.Matching;
+
+// Continuous trading under pro-rata priority. The aggressor's quantity is distributed
+// proportionally among all orders at the resting side's best crossing level, with each
+// order receiving a share proportional to its own remaining size. Unlike price-time, a
+// later-arriving larger order gets a larger allocation than an earlier-arriving smaller
+// one at the same price.
+//
+// Trades print at the resting order's own limit price, so an aggressor whose limit was
+// better than the touch gets the improvement. Sized off the full remaining quantity, since
+// an iceberg's hidden reserve participates in the allocation.
+//
+// Allocations for a level are computed up front when the level is first entered, so the
+// aggressor's quantity is distributed once across all orders at that level rather than
+// iteratively re-allocating to only the head each time.
+internal sealed class ProRataMatchingAlgorithm : IMatchingAlgorithm
+{
+    // Cached allocations for the current price level, consumed one per SelectNext call.
+    private List<(InternalOrder Order, int Quantity)>? _pending;
+    private int _index;
+    private long? _currentPrice;
+
+    public bool TryBegin(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working) => true;
+
+    public bool TryQuoteIndicative(IReadOnlyDictionary<Side, IReadOnlyPriceLadder> working,
+        out long priceTicks, out int quantity)
+    {
+        priceTicks = 0;
+        quantity = 0;
+        return false;
+    }
+
+    public Allocation? SelectNext(InternalOrder restingHead, InternalOrder aggressor)
+    {
+        // On the first call, or when the price level changes, compute all allocations for
+        // this level up front. The state is discarded once the level is exhausted.
+        if (restingHead.Price != _currentPrice || _pending == null)
+        {
+            _pending = ComputeAllocations(restingHead, aggressor);
+            _index = 0;
+            _currentPrice = restingHead.Price;
+        }
+
+        if (_index >= _pending.Count)
+            return null;
+
+        var (order, quantity) = _pending[_index++];
+        return new Allocation(order, quantity,
+            order.Price ?? throw new InvalidOperationException("limit order requires price"));
+    }
+
+    // Walks the level and computes each order's pro-rata share of the aggressor's remaining
+    // quantity. The first pass allocates proportionally by remaining size; the remainder
+    // (from rounding) is given one lot at a time to the largest orders first.
+    private static List<(InternalOrder Order, int Quantity)> ComputeAllocations(
+        InternalOrder restingHead, InternalOrder aggressor)
+    {
+        // Gather all orders at this level.
+        var orders = new List<InternalOrder>();
+        long totalLevelQty = 0;
+        for (var order = restingHead;
+             order != null && order.Price == restingHead.Price;
+             order = order.LevelNext)
+        {
+            if (order.RemainingQuantity > 0)
+            {
+                orders.Add(order);
+                totalLevelQty += order.RemainingQuantity;
+            }
+        }
+
+        if (totalLevelQty == 0 || aggressor.RemainingQuantity == 0)
+            return new List<(InternalOrder, int)>();
+
+        var remainingAggressor = aggressor.RemainingQuantity;
+        var allocations = new (InternalOrder Order, int Quantity)[orders.Count];
+        long allocatedTotal = 0;
+
+        // First pass: proportional allocation.
+        for (var i = 0; i < orders.Count; i++)
+        {
+            var order = orders[i];
+            var share = (int)((long)order.RemainingQuantity * remainingAggressor / totalLevelQty);
+            share = Math.Min(share, order.RemainingQuantity);
+            allocations[i] = (order, share);
+            allocatedTotal += share;
+        }
+
+        // Distribute the remainder from rounding, one lot at a time, largest orders first.
+        var remainder = (int)(remainingAggressor - allocatedTotal);
+        if (remainder > 0)
+        {
+            // Sort by remaining quantity descending, then by sequence number for stability.
+            var indices = Enumerable.Range(0, orders.Count)
+                .OrderByDescending(i => orders[i].RemainingQuantity)
+                .ThenBy(i => orders[i].SequenceNumber)
+                .ToList();
+
+            for (var r = 0; r < remainder && r < indices.Count; r++)
+            {
+                var i = indices[r];
+                var maxExtra = Math.Min(orders[i].RemainingQuantity - allocations[i].Quantity, 1);
+                if (maxExtra > 0)
+                {
+                    allocations[i] = (allocations[i].Order, allocations[i].Quantity + 1);
+                }
+            }
+        }
+
+        // Filter out zero-quantity allocations and return in FIFO order.
+        return allocations.Where(a => a.Quantity > 0)
+            .OrderBy(a => a.Order.SequenceNumber)
+            .Select(a => (a.Order, a.Quantity))
+            .ToList();
+    }
+
+    public bool UsesFullRemainingQuantity => true;
+
+    public bool ChecksTradeRestrictions => true;
+
+    public void OnTrade(long priceTicks)
+    {
+    }
+
+    public void OnSessionChange(long? referencePriceTicks)
+    {
+    }
+}

--- a/tests/Circus.Tests/Matching/ProRataTests.cs
+++ b/tests/Circus.Tests/Matching/ProRataTests.cs
@@ -1,0 +1,165 @@
+using Circus.Matching;
+using NUnit.Framework;
+
+namespace Circus.Tests.Matching;
+
+// Pro rata distributes an aggressor's quantity proportionally among all orders at the resting
+// side's best crossing level. Tests here drive Matcher directly and apply the trades between
+// iterations so the loop terminates naturally, matching the pattern in MatcherTests.
+[TestFixture]
+public class ProRataMatchingAlgorithmTests
+{
+    private static readonly Instrument Sec = new("GCZ6", 10, 10);
+
+    private static readonly DateTime Early = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Late = new(2000, 1, 1, 12, 1, 0);
+
+    private const long Tick = 100;
+
+    private static InternalOrder Order(long sequenceNumber, Side side, int quantity, DateTime time) =>
+        new(sequenceNumber, $"Company{sequenceNumber}", $"Order{sequenceNumber}", Sec, time,
+            OrderStatus.Working, OrderType.Limit, new OrderValidity.Day(), side, quantity, Tick, null);
+
+    // Applies each trade so the matcher's loop sees updated quantities and terminates.
+    // Removes fully-filled orders from the matcher's ladders, matching OrderBook.ApplyTrade.
+    private static List<TradeExecuted> RunWithApply(Matcher matcher, IMatchingAlgorithm algorithm)
+    {
+        var trades = new List<TradeExecuted>();
+        foreach (var outcome in matcher.Run(algorithm, algorithm, _ => null))
+        {
+            if (outcome is TradeExecuted trade)
+            {
+                var time = trade.Resting.ModifiedTime;
+                if (trade.UsesFullRemainingQuantity)
+                {
+                    trade.Resting.FillFullSize(time, trade.Quantity);
+                    trade.Aggressor.FillFullSize(time, trade.Quantity);
+                }
+                else
+                {
+                    trade.Resting.Fill(time, trade.Quantity);
+                    trade.Aggressor.Fill(time, trade.Quantity);
+                }
+
+                if (trade.Resting.Status == OrderStatus.Filled)
+                    matcher.Unrest(trade.Resting);
+                if (trade.Aggressor.Status == OrderStatus.Filled)
+                    matcher.Unrest(trade.Aggressor);
+
+                trades.Add(trade);
+            }
+        }
+        return trades;
+    }
+
+    [Test]
+    public void ProRata_DistributesAcrossMultipleOrdersAtTheLevel()
+    {
+        // Three resting buys at the same price, one aggressor sell crossing them all.
+        var matcher = new Matcher();
+
+        var buy1 = Order(1, Side.Buy, 50, Early);
+        var buy2 = Order(2, Side.Buy, 30, Early);
+        var buy3 = Order(3, Side.Buy, 20, Early);
+        matcher.Rest(buy1);
+        matcher.Rest(buy2);
+        matcher.Rest(buy3);
+        matcher.Rest(Order(4, Side.Sell, 50, Late));
+
+        var trades = RunWithApply(matcher, new ProRataMatchingAlgorithm());
+
+        Assert.IsNotEmpty(trades);
+        var order1Filled = trades.Where(t => t.Resting == buy1).Sum(t => t.Quantity);
+        var order2Filled = trades.Where(t => t.Resting == buy2).Sum(t => t.Quantity);
+        var order3Filled = trades.Where(t => t.Resting == buy3).Sum(t => t.Quantity);
+
+        Assert.Greater(order1Filled, 0, "order 1 should receive some allocation");
+        Assert.Greater(order2Filled, 0, "order 2 should receive some allocation");
+        Assert.Greater(order3Filled, 0, "order 3 should receive some allocation");
+
+        Assert.AreEqual(50, order1Filled + order2Filled + order3Filled);
+    }
+
+    [Test]
+    public void ProRata_LargerOrder_GetsLargerShare()
+    {
+        var matcher = new Matcher();
+
+        var large = Order(1, Side.Buy, 60, Early);
+        var small = Order(2, Side.Buy, 30, Early);
+        matcher.Rest(large);
+        matcher.Rest(small);
+        matcher.Rest(Order(3, Side.Sell, 50, Late));
+
+        var trades = RunWithApply(matcher, new ProRataMatchingAlgorithm());
+
+        var largeFilled = trades.Where(t => t.Resting == large).Sum(t => t.Quantity);
+        var smallFilled = trades.Where(t => t.Resting == small).Sum(t => t.Quantity);
+
+        Assert.Greater(largeFilled, smallFilled,
+            "the larger order should receive a larger proportional share");
+        Assert.AreEqual(50, largeFilled + smallFilled);
+    }
+
+    [Test]
+    public void ProRata_EqualOrders_GetEqualShares()
+    {
+        var matcher = new Matcher();
+
+        var buy1 = Order(1, Side.Buy, 50, Early);
+        var buy2 = Order(2, Side.Buy, 50, Early);
+        matcher.Rest(buy1);
+        matcher.Rest(buy2);
+        matcher.Rest(Order(3, Side.Sell, 100, Late));
+
+        var trades = RunWithApply(matcher, new ProRataMatchingAlgorithm());
+
+        var firstFilled = trades.Where(t => t.Resting == buy1).Sum(t => t.Quantity);
+        var secondFilled = trades.Where(t => t.Resting == buy2).Sum(t => t.Quantity);
+
+        Assert.AreEqual(50, firstFilled);
+        Assert.AreEqual(50, secondFilled);
+    }
+
+    [Test]
+    public void ProRata_PricesAtRestingLimit()
+    {
+        var matcher = new Matcher();
+
+        var resting = Order(1, Side.Buy, 10, Early);
+        matcher.Rest(resting);
+        // Aggressor sell at 200 crosses the resting buy at 100
+        matcher.Rest(Order(2, Side.Sell, 5, Late));
+
+        var trades = RunWithApply(matcher, new ProRataMatchingAlgorithm());
+
+        var trade = trades.Single();
+        Assert.AreEqual(Tick, trade.PriceTicks,
+            "should print at the resting order's limit of 100, not the aggressor's 200");
+    }
+
+    [Test]
+    public void ProRata_NoIndicativeQuote()
+    {
+        var algorithm = new ProRataMatchingAlgorithm();
+        var matcher = new Matcher();
+        matcher.Rest(Order(1, Side.Buy, 10, Early));
+        matcher.Rest(Order(2, Side.Sell, 10, Late));
+
+        Assert.IsFalse(algorithm.TryQuoteIndicative(matcher.Working, out _, out _));
+    }
+
+    [Test]
+    public void ProRata_UsesFullRemainingQuantity()
+    {
+        var algorithm = new ProRataMatchingAlgorithm();
+        Assert.IsTrue(algorithm.UsesFullRemainingQuantity);
+    }
+
+    [Test]
+    public void ProRata_ChecksTradeRestrictions()
+    {
+        var algorithm = new ProRataMatchingAlgorithm();
+        Assert.IsTrue(algorithm.ChecksTradeRestrictions);
+    }
+}


### PR DESCRIPTION
Adds ProRataMatchingAlgorithm — a continuous trading algorithm that distributes an aggressor's quantity proportionally among all orders at the resting side's best crossing level, rather than strictly FIFO (price-time).

**Key features:**
- Allocations for a price level are computed upfront when the level is first entered, so the aggressor's quantity is distributed once across all orders at that level
- Remainder from rounding is distributed one lot at a time, largest orders first
- Trades print at the resting order's limit price (price improvement)
- Uses full remaining quantity (iceberg hidden reserve participates)
- Checks trade restrictions
- Same interface as PriceTimeMatchingAlgorithm and AuctionMatchingAlgorithm

**Tests (7):**
- ProRata_DistributesAcrossMultipleOrdersAtTheLevel
- ProRata_LargerOrder_GetsLargerShare
- ProRata_EqualOrders_GetEqualShares
- ProRata_PricesAtRestingLimit
- ProRata_NoIndicativeQuote
- ProRata_UsesFullRemainingQuantity
- ProRata_ChecksTradeRestrictions

**Verification:** 452 tests pass, 0 fail.
