### PR TITLE
Plan the fake venue, and the flattening of OrdersMatched it depends on

### DIFF
--- a/docs/direction.md
+++ b/docs/direction.md
@@ -1,0 +1,194 @@
+# Direction
+
+Circus is being pointed at two uses, and everything below is judged against them. Work that
+serves neither is not on this list, however interesting it is.
+
+**A. Counterfactual backtesting.** Replay a venue's recorded order flow, interleave our own
+orders into it, and find out what they would have done — real queue position, real partial
+fills, real band and limit rejections. Ultimately with a twin book, so the divergence between
+the perturbed run and reality is measured rather than assumed.
+
+**B. A deterministic fake venue.** An in-process exchange the live trading stack can be tested
+against: real acks, fills, rejects and market data, and the exchange behaviour that is
+impossible to provoke on a real venue — halts, limit locks, priority loss on modify, GTD expiry
+at a session boundary.
+
+The property both rest on is the one the library already has: a book is a pure function of the
+stamped actions it is handed, and every derived view is a function of the events that come back
+out. Nothing below should be allowed to weaken that.
+
+---
+
+## Where we actually are
+
+B is mostly packaging. `OrderBook`, `LiveDriver`, `ManualClock`, `InstrumentGroup` and the
+market data producers already do the work; what is missing is a way to ask for a scenario
+without hand-building the price sequence that trips it, and somewhere to put the harness.
+
+A is where the engineering is. Today nothing can get real market data into the engine at all:
+the only things that produce actions are hand-written ones and `OrderFlowSimulator`. Every
+producer must exist before its book's first action and can never resync, so a capture that
+starts mid-session has nowhere to start from. And there is no way to tell whether a replay
+reproduced the venue it came from, which is the question everything else depends on.
+
+---
+
+## Phase 0 — clear the ground
+
+Small, and worth doing first because the samples currently teach the wrong architecture to
+anyone arriving at the repo, including us.
+
+### Samples
+
+Not one sample uses `Sequencer`, `Replay`, `InstrumentGroup` or `OrderFlowSimulator`. They are a
+snapshot of the design as it stood before the sequencing work, and `Program.cs` only ever calls
+`OrderBookExample.TestExample()` — so `BackTestExample`, `LiveExample` and
+`MarketDataProducerExample.Run` are unreferenced, and nothing but the compiler has looked at
+them in some time.
+
+- **Delete `OrderBookExample.LiveExample`.** It starts a `Task.Run` that drives the book's
+  schedule on a background thread while the caller submits orders to the same book from the
+  main one. The book is single-threaded by construction; the sample's own comment says the
+  driving "needs to happen on same thread as book is updated" and then the code does the
+  opposite. `LiveDriver` is the answer to what this was reaching for. Replace it with a sample
+  built on `LiveDriver` + `ManualClock`.
+
+- **Delete `OrderBookExample.BackTestExample`.** This is the sample closest to what we now want
+  and the most misleading one we have. It hand-rolls a `DriveTo` walk of the schedule that
+  `Sequencer` exists to do, never touches `Replay`, and its loop stamps all hundred orders at
+  the same instant and puts them all on the same side at the same price, so nothing ever
+  trades. Rewrite as a `Replay` over an `OrderFlowSimulator` trace.
+
+- **Delete the `DriveTo` helper** with them. `Sequencer.Add` queues a book's transitions from
+  its schedule; nothing should be walking one by hand any more.
+
+- **Rewrite `MarketDataProducerExample` on `InstrumentGroup`.** It is the most current sample we
+  have, but it wires a channel to its books by hand — which is the wiring `InstrumentGroup`
+  exists so that we cannot get wrong — and drives them off a `SystemClock`, so its output
+  differs every run. A sample about a deterministic engine should print the same thing twice.
+
+- **Make the samples runnable and deterministic**, each reachable from `Program.cs` by name, and
+  smoke-run them in CI. A sample nothing executes is a sample that rots, which is how we got
+  here.
+
+### Pro-rata is implemented but unreachable
+
+`ProRataMatchingAlgorithm` landed in #76 with tests, and `OrderBook`'s phase table still
+hardcodes `PriceTimeMatchingAlgorithm` for the open phase. Until the algorithm is selectable per
+instrument it is tested dead code — and pro-rata markets are exactly the ones where a naive fill
+assumption is most wrong, so this matters to A rather than being housekeeping.
+
+### README
+
+Says pro-rata is not done when it is, and describes no part of the sequencing or market data
+architecture — a reader learns about order types and safety features and nothing about the
+action/event model the library is actually built on.
+
+---
+
+## Phase 1 — get real data in, and prove it went in correctly
+
+The foundation for A. Nothing after this is worth anything without it.
+
+**1. An ingest contract: venue messages to `OrderBookAction`.** A `Circus.Ingest` project holding
+the mapping, with no venue-specific parsing in the core. Two details the mapping has to get
+right, both of which are quiet if wrong: build the trace from add/modify/cancel only and let
+the matcher generate the prints, because a venue's trade messages are its matcher's *output*
+and feeding them back in double-counts; and leave `SelfMatchPrevention` null on historical
+orders, since it is opt-in and a shared `CompanyId` across the tape would manufacture
+self-match cancels that never happened.
+
+**2. Initialising a book from a snapshot.** Captures start mid-session and have gaps. Today a
+book and its producers must be present from the first action of the day and can never resync —
+`IDataProducer` says so explicitly. We need a way to seed a book with resting orders as of an
+instant, and to seed the producers to match, without replaying a day to get there. This is the
+largest structural gap in the library and everything about A is limited by it.
+
+**3. A reconciliation harness.** Replay a capture with no orders of ours in it and diff the
+`OrdersMatched` the engine generates against the trades the venue recorded. Report match rate,
+first divergence, and a classification of what caused it. The first runs will not reconcile —
+an MBO feed shows neither iceberg reserve nor implieds, so the engine can only match what was
+visible — and knowing the size of that gap is the point. Until this exists, a counterfactual
+result is a number with no error bar.
+
+---
+
+## Phase 2 — the twin, and honest fills
+
+**4. A twin session.** One reference book fed the trace alone, one perturbed book fed the trace
+plus our actions, off the same stream. The reference is ground truth; the difference is what we
+did. Report: first divergence instant, rejects against historical company ids counted by reason,
+phantom depth (perturbed minus reference), and the count of orders cancelled with
+`UpdatedQuantityLowerThanFilledQuantity`.
+
+That last one is worth naming because it is where a partial fill of ours turns a legal size
+reduction into a cancellation. Reality reduces an untouched order from 10 to 2; we had taken 5
+of it, so 2 is at or below what is filled and `OrderBook` cancels the whole order. Liquidity
+that should have stayed disappears, and nothing about it looks like an error.
+
+The other leak runs the other way and is quieter still: rest ahead of a historical order, take
+the fill that was theirs, and their order survives in our book though it was filled in reality —
+so the tape holds no further action for it, nothing ever removes it, and it sits there as depth
+that never existed until the close expires it. Note that this is the *passive* case, which is
+the one that feels safe.
+
+**5. Delta translation.** The fix for both, and the "super realistic" part of the fill
+simulation. Rather than applying the trace's absolute quantities to the perturbed book, apply
+each action to the reference first, observe what it did there, and apply that effect to the
+perturbed book. Spurious cancellations stop; an order dying in the reference takes its phantom
+residue with it. Only possible because there is a real matcher on both sides, which is the whole
+reason to do this here rather than with a book reconstructor.
+
+**6. A strategy drive loop with latency.** A host that hands a strategy each `Dispatched` and the
+channel messages behind it, and lets it enqueue actions at `event time + its latency`.
+`Sequencer.Submit` already refuses anything stamped behind logical now, so lookahead is
+structurally impossible rather than merely discouraged — make that an explicit guarantee with a
+test that names it, because it is one of the better properties we have and it is currently an
+accident of the queue's design.
+
+---
+
+## Phase 3 — the fake venue
+
+Mostly assembly of parts that exist.
+
+**7. A harness package.** Build a venue from configuration, drive it with `LiveDriver` over a
+`ManualClock` so a test owns the clock and stays deterministic, submit orders, assert on what
+came back.
+
+**8. Scenario injection.** `HaltTrading` and `PauseTrading` can already be sent as actions, but
+the interesting states — a volatility interruption, a circuit breaker, limit up — are reachable
+only by constructing a price sequence that trips them. A stack under test wants to say "go limit
+up at 10:15" and get on with it. This is the single change that decides whether B is genuinely
+useful to whoever owns the OMS.
+
+**9. Assertion helpers.** Capture the dispatch stream, assert an order was rejected for a given
+reason, golden-file an event stream so a change in venue behaviour shows up as a diff.
+
+---
+
+## Phase 4 — scale
+
+Only once A works end to end, and only against measurements.
+
+**10. Allocation per action.** Every action returns a freshly allocated
+`IReadOnlyList<OrderBookEvent>`. A day of one liquid future is many millions of messages and
+this will dominate. The benchmark harness to measure it already exists; measure before changing
+anything.
+
+---
+
+## What this does not make Circus
+
+Worth writing down so it is not rediscovered in an argument later.
+
+The tape does not react to us. No participant fades our quote, no one races us, nobody is
+adversely selected by our presence. That is inherent to replaying a recording and no amount of
+bookkeeping in phase 2 fixes it — it is why counterfactual results decay with horizon and with
+size, and why the divergence report in phase 2 is a headline number rather than a diagnostic.
+
+For a passive strategy at small size there is a cheaper and stricter alternative worth keeping
+in view: never insert into the book at all, track a notional queue position from the L3 stream,
+and infer fills from prints sweeping through it. Zero divergence by construction, because
+nothing is perturbed. It cannot model our own impact and cannot honestly model an aggressive
+order, but it needs only the reconstruction from phase 1 and none of phase 2.

--- a/docs/phase-3-fake-venue.md
+++ b/docs/phase-3-fake-venue.md
@@ -1,0 +1,189 @@
+# Phase 3 — the fake venue
+
+The second of the two uses in `direction.md`: an in-process exchange a live trading stack can be
+tested against, with real acks, fills, rejects and market data, and the venue behaviour that is
+impossible to provoke on a real one.
+
+Mostly assembly of parts that already exist, with one piece of genuine design in it. Taking that
+piece first, because it is the one that decides whether the rest is worth having.
+
+---
+
+## The participant view, which does not exist today
+
+A book's events are the whole venue's events. Every participant's orders are in the one stream,
+and nothing anywhere filters them - there is not a single `CompanyId` comparison in `src`. A
+stack under test is one participant, and what it should see is its own order lifecycle plus the
+public feed, which is not what any current type hands out.
+
+Filtering by `CompanyId` looks like a morning's work and is not, because of one event:
+
+```csharp
+public record OrdersMatched(string Symbol, DateTime Time, decimal Price, int Quantity,
+    IList<FillOrderConfirmed> Fills) : OrderBookEvent(Symbol, Time);
+```
+
+`OrdersMatched` carries no `CompanyId` of its own and holds a fill for *both* sides of the
+trade. So the two obvious filters are both wrong:
+
+- Keep events whose `CompanyId` matches, and a participant never sees its own fills at all -
+  `OrdersMatched` has no company to match on, so it is dropped whole.
+- Keep any `OrdersMatched` holding one of the participant's fills, and the counterparty's
+  `FillOrderConfirmed` goes out with it. That carries their whole `Order` record: their company,
+  their client order id, their remaining and displayed quantities. A venue that leaked that
+  would be teaching the stack under test to rely on something no real venue sends.
+
+So the view has to rewrite the event rather than filter it - reducing `OrdersMatched.Fills` to
+the participant's own - and the same question has to be asked of every composite event added
+later. That is the design work in this phase, and it belongs in one place rather than in each
+consumer's LINQ.
+
+What a participant sees, then, is two streams, exactly as at a real venue:
+
+- **Private**: its own `OrderEvent`s - confirms, rejects, fills, expiries - and nothing else's.
+- **Public**: `MarketDataChannel`, unchanged and unfiltered. It is already public by
+  construction: every producer derives from events without naming a participant, and depth is
+  already reported as `DisplayedQuantity` so an iceberg's reserve never reaches it.
+
+A test asserting "my order was rejected for `PriceOutsideBands`" reads the first. A test
+asserting the market moved reads the second. Conflating them is what makes fake venues teach
+stacks to depend on information they will not have in production.
+
+---
+
+## Scenario injection, which is nearly free
+
+The interesting venue states - a volatility interruption, a circuit breaker, limit up - are
+reachable today only by constructing a price sequence that trips them. An OMS team wants to say
+"go limit up now" and get on with the test.
+
+The seam for it already exists and is worth noticing before building anything:
+
+```csharp
+internal OrderBook(Instrument instrument, IReadOnlyList<IPriceRestriction> priceRestrictions)
+```
+
+`IPriceRestriction` is already the complete vocabulary of what a restriction can do to a book -
+refuse an entry with a named `OrderRejectedReason`, block a print, pause or halt, for a stated
+duration, resuming under its own conditions. A scenario is nothing more than a restriction that
+answers on command instead of on price. Nothing in `OrderBook` needs to change to support one.
+
+What that buys, with no new machinery in the engine:
+
+| Scenario | How |
+| --- | --- |
+| Reject the next entry, any reason | Scripted `OrderEntry` restriction |
+| Limit up / limit down | Scripted `Trade` restriction returning `Block`, which is what makes the book emit `LimitStateChanged` while staying open |
+| Volatility pause, timed resume | Scripted `Trade` restriction returning `Pause` with a `ResumeAfter` |
+| Circuit breaker halt | The same returning `Halt` |
+| Interruption that extends rather than resolving | `AllowsResumption` returning false |
+
+The rest needs no injection at all, because it is already an action or a schedule: an outright
+halt or pause (`HaltTrading`, `PauseTrading`), a session boundary, a day roll, order expiry at
+the close. Priority loss on a modify needs nothing but a modify.
+
+**The one decision here** is how the harness reaches `IPriceRestriction`, which is `internal`
+and deliberately so - `Circus.csproj` grants internals to `Circus.Tests` alone. Either add the
+harness assembly to that list, or promote the interface to public API. I would add to the list:
+the harness can expose a public `Scenario` vocabulary of its own and implement the internal
+interface behind it, which keeps a genuinely internal seam internal and keeps Circus from owing
+compatibility on a type whose shape is still moving.
+
+---
+
+## The shape of it
+
+A new project, `src/Circus.TestKit`, packable, holding a facade over the parts that exist:
+
+```csharp
+var venue = new Venue(start: new DateTime(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc));
+venue.Add(gold, schedule);
+
+var me = venue.Participant("MyFirm");
+
+venue.AdvanceTo("08:30");                       // pre-open arrives from the schedule
+me.Submit(new CreateLimitOrder { ... });
+venue.AdvanceTo("09:00");                       // the open, and its auction print
+
+me.AssertFilled("B1", quantity: 3, price: 1000);
+
+venue.Scenario.LimitUp(at: 1010);
+me.AssertRejected("B2", OrderRejectedReason.BeyondDailyPriceLimit);
+```
+
+Underneath: `InstrumentGroup` for the books and the channel, `LiveDriver` over a `ManualClock`
+for time, a participant view per company, and a recorder over the dispatch stream.
+
+`AdvanceTo` is the whole of time control - set the clock, tick the driver, publish what came
+back. Worth one test of its own: advancing thirty minutes in a single jump must still resume an
+interruption whose deadline fell inside it, because the sequencer queues that deadline as a tick
+and `AdvanceTo` drains everything at or before the target rather than only what was queued on
+entry. That is already how it behaves; a harness that made it stop behaving that way would be
+worse than useless.
+
+`ManualClock` rather than `SystemClock` is what makes a test deterministic, and it is the only
+difference from a production host - which is the point worth making in the sample.
+
+---
+
+## Recording, and why golden files actually work here
+
+Everything downstream of the actions is a pure function of them, so a recorded dispatch stream
+is a complete and reproducible description of a session. That makes golden-file testing
+genuinely sound rather than flaky-by-construction: a diff in the file is a change in venue
+behaviour, not a change in timing.
+
+Two pieces:
+
+- **`VenueRecorder`** over the `Dispatched` stream, and a way to write it back out.
+- **A stable rendering.** Records' generated `ToString` renders a list as its type name, which
+  `samples/Circus.Examples/Display.cs` already works around for `LevelsDataEvent`. A golden file
+  needs that done properly and in one place - and the harness and the samples should share it
+  rather than each carrying a copy.
+
+---
+
+## Order of work
+
+**3a. `Venue`, time control, participant views.** The foundation, and where the design risk is.
+Nothing else is worth building first, and the participant view is the piece to get right before
+anyone depends on its shape.
+
+**3b. Scenario injection.** Cheap once 3a exists, given the seam is already there. Mostly a
+question of what vocabulary to expose.
+
+**3c. Recording, golden files, assertion helpers.** Polish, and the part most easily changed
+later.
+
+**3d. A sample.** `samples/Circus.Examples` should grow one showing a stack-under-test shape -
+submit, advance, assert - alongside the four already there. CI runs the samples now, so it stays
+honest.
+
+---
+
+## What this is not, and should not pretend to be
+
+Worth stating plainly, because a fake venue that quietly implies more than it models is how a
+stack passes its tests and fails in production.
+
+- **No transport.** No FIX, no binary protocol, no sockets. The harness is in-process, so a
+  stack's encoding, session and reconnect layers are not exercised by it. This is the one thing
+  most likely to be assumed and is worth saying in the README of the package itself.
+- **No disconnects, gaps or resends**, which follows from the above: they are transport
+  behaviour, and the market data producers cannot resync after a missed event by design.
+- **No credit, risk, position or margin checks.** Circus models a matching engine, not a
+  clearing house.
+- **Single-threaded**, like everything else here. A stack submitting from several threads has to
+  marshal onto the venue's thread, and the harness should make that obvious rather than papering
+  over it with a lock.
+
+---
+
+## Open question
+
+Whether the stack under test is in-process .NET, or talks a wire protocol.
+
+Everything above is the in-process core and is needed either way - a transport shim would sit on
+top of exactly these parts. But if the point is to exercise a FIX gateway end to end, that shim
+is a substantial piece of work in its own right and belongs in the plan explicitly rather than
+being discovered halfway through 3a.


### PR DESCRIPTION
Planning only — no engine or test changes. Two documents, plus `docs/direction.md` recovered from `claude/library-use-cases-fjovgf`, which never merged and left the plan it indexes stranded.

## `docs/phase-3-fake-venue.md`

Phase 3 of the direction doc: an in-process exchange a trading stack can be tested against. Mostly assembly of parts that exist — `InstrumentGroup`, `LiveDriver`, `ManualClock` — with one piece of real design in it, and one thing that turns out to be nearly free.

**Scenario injection is nearly free.** The seam already exists: `internal OrderBook(Instrument, IReadOnlyList<IPriceRestriction>)`, and `IPriceRestriction` is already the complete vocabulary of what can be done to a book — refuse an entry with a named reason, block a print, pause, halt, for a stated duration. A scenario is a restriction that answers on command instead of on price, so limit-up, timed volatility pauses and circuit-breaker halts need nothing new in the engine.

**The participant view was the design work**, and the follow-up commit changes the answer.

## `docs/flatten-ordersmatched.md`

`OrdersMatched` carries no `CompanyId` of its own and holds a fill for both sides of a trade, so a per-participant filter either drops a participant's own fills or hands them their counterparty's order record. Every other event is already scoped to one participant — `OrderEvent` carries `CompanyId`, `ClientOrderId` and `ExchangeOrderId`, and `FillOrderConfirmed` inherits all three.

The plan removes `OrdersMatched` entirely. A trade becomes two top-level `FillOrderConfirmed` events sharing a trade id, which reduces the participant view to a filter on `CompanyId` and nothing more.

Points worth review:

- **Nothing is lost.** `Symbol`, `Time`, `Price` and `Quantity` are already on every fill.
- **It also removes a wart.** `DeterminismTests` renders `OrdersMatched` rather than comparing it, because a record's generated equality compares its `IList<FillOrderConfirmed>` by reference. With no composite event left, every event compares by value — which the golden files planned for phase 3c rest on.
- **The trade id follows the order-id conventions exactly**: per book, its own counter, seeded from the session date, forward-only via `Math.Max`, `string` for consistency with `ExchangeOrderId`. Venue-wide identity is the pair `(Instrument, TradeId)`.
- **`TradeDataProducer` is the one consumer that gets harder** — it must derive one public print from two private fills, by emitting when the trade id differs from the previous fill's.
- **The engine change is six references across five files; the tests are ~100 across 22.** Event counts per action change, so positional assertions move too. Sliced into four independently reviewable steps.

## A caveat on execution

The environment this was planned in has no .NET SDK and no route to one — the network policy blocks the build servers — so the test migration in particular will compile-and-fail rather than fail-to-compile, and CI is the only verification available. The plan says so, and suggests steps 1–2 are the part worth doing from here if the ~100 test edits are better done by someone who can run them locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8NsmnuK5HdsBEYnoMKYSX)_