### PR TITLE
Emit a trade as two fills sharing an id, and remove OrdersMatched

### DIFF
--- a/src/Circus.Simulator/OrderFlowSimulator.cs
+++ b/src/Circus.Simulator/OrderFlowSimulator.cs
@@ -274,12 +274,9 @@ public sealed class OrderFlowSimulator
                     case ExpireOrderConfirmed expire:
                         RemoveLive(expire.Order.ClientOrderId);
                         break;
-                    case OrdersMatched matched:
-                        foreach (var fill in matched.Fills)
-                        {
-                            if (fill.Order.RemainingQuantity == 0)
-                                RemoveLive(fill.Order.ClientOrderId);
-                        }
+                    case FillOrderConfirmed fill:
+                        if (fill.Order.RemainingQuantity == 0)
+                            RemoveLive(fill.Order.ClientOrderId);
                         break;
                 }
             }

--- a/src/Circus/Events/OrderBookEvent.cs
+++ b/src/Circus/Events/OrderBookEvent.cs
@@ -46,13 +46,28 @@ public record ExpireOrderConfirmed(string Symbol, DateTime Time, string CompanyI
         decimal? PreviousPrice, int PreviousQuantity)
     : OrderConfirmedEvent(Symbol, Time, CompanyId, Order);
 
+// One side of one trade, and the whole of what the book says about it. A trade is one resting
+// order matched against one aggressor, so it produces exactly two of these - the resting side
+// first - sharing a TradeId and differing in IsResting.
+//
+// Not wrapped in an event carrying both sides, which is what OrdersMatched used to be. A fill
+// belongs to one participant and carries their CompanyId, so a feed for one of them is a filter
+// over these; a wrapper holding both sides could only be filtered by rewriting it, and handing
+// one participant the other's Order was a leak waiting to be shipped. The public print a venue
+// broadcasts is derived from these instead - see TradeDataProducer - which keeps the private and
+// public views of a trade apart the way a real venue's execution reports and trade feed are.
+//
+// TradeId identifies the trade within this instrument, not beyond it, exactly as
+// ExchangeOrderId identifies an order within it: the venue-wide identity is the pair
+// (Instrument, TradeId).
+//
 // Quantity is what traded; PreviousDisplayedQuantity is the order's DisplayedQuantity before
 // it did. The two differ whenever an auction sizes a fill off full remaining quantity - an
 // iceberg can trade more than it was showing, and comes out of it displaying a fresh peak
 // rather than what is left of the old one. A level aggregate must move by the change in
 // displayed size, not by the traded quantity.
-public record FillOrderConfirmed(string Symbol, DateTime Time, string CompanyId, Order Order, decimal Price,
-        int Quantity, int PreviousDisplayedQuantity, bool IsResting)
+public record FillOrderConfirmed(string Symbol, DateTime Time, string CompanyId, Order Order, string TradeId,
+        decimal Price, int Quantity, int PreviousDisplayedQuantity, bool IsResting)
     : OrderConfirmedEvent(Symbol, Time, CompanyId, Order);
 
 public record OrderRejectedEvent(string Symbol, DateTime Time, string CompanyId, string ClientOrderId,
@@ -73,10 +88,6 @@ public record UpdateOrderRejected(string Symbol, DateTime Time, string CompanyId
 public record CancelOrderRejected(string Symbol, DateTime Time, string CompanyId, string ClientOrderId,
         string PreviousClientOrderId, string? ExchangeOrderId, OrderRejectedReason Reason)
     : OrderRejectedEvent(Symbol, Time, CompanyId, ClientOrderId, ExchangeOrderId, Reason);
-
-public record OrdersMatched(string Symbol, DateTime Time, decimal Price, int Quantity,
-        IList<FillOrderConfirmed> Fills)
-    : OrderBookEvent(Symbol, Time);
 
 // The price and quantity the current phase would print if it ended right now - an auction's
 // indicative quote, published as it moves rather than answered on request, so a consumer's

--- a/src/Circus/MarketData/FullBookDataProducer.cs
+++ b/src/Circus/MarketData/FullBookDataProducer.cs
@@ -27,17 +27,13 @@ public class FullBookDataProducer : IDataProducer<OrderBookDeltaEvent>
 
         foreach (var ev in events)
         {
-            // FillOrderConfirmed is only ever nested inside OrdersMatched.Fills, never a
-            // top-level event in its own right.
-            if (ev is OrdersMatched matched)
+            // One per side of a trade, arriving as two top-level events rather than one wrapping
+            // both, so each becomes its own delta.
+            if (ev is FillOrderConfirmed fill)
             {
-                foreach (var fill in matched.Fills)
-                {
-                    Add(ref output, new OrderBookDeltaEvent(fill.Symbol, fill.Time, fill.Order.Side,
-                        fill.Order.ExchangeOrderId, fill.Order.Price!.Value, fill.Quantity,
-                        OrderBookDeltaAction.Filled));
-                }
-
+                Add(ref output, new OrderBookDeltaEvent(fill.Symbol, fill.Time, fill.Order.Side,
+                    fill.Order.ExchangeOrderId, fill.Order.Price!.Value, fill.Quantity,
+                    OrderBookDeltaAction.Filled));
                 continue;
             }
 

--- a/src/Circus/MarketData/LevelDataProducer.cs
+++ b/src/Circus/MarketData/LevelDataProducer.cs
@@ -63,16 +63,12 @@ public class LevelDataProducer : IDataProducer<LevelsDataEvent>
                         Remove(expire.Order.Side, expire.PreviousPrice.Value, expire.PreviousQuantity);
                     break;
 
-                // FillOrderConfirmed is only ever nested inside OrdersMatched.Fills, never a
-                // top-level event in its own right.
-                case OrdersMatched matched:
-                    foreach (var fill in matched.Fills)
-                    {
-                        ReduceQuantity(fill.Order.Side, fill.Order.Price!.Value,
-                            fill.PreviousDisplayedQuantity - fill.Order.DisplayedQuantity,
-                            fullyFilled: fill.Order.RemainingQuantity == 0);
-                    }
-
+                // One per side of a trade, arriving as two top-level events rather than one
+                // wrapping both, so each is applied on its own.
+                case FillOrderConfirmed fill:
+                    ReduceQuantity(fill.Order.Side, fill.Order.Price!.Value,
+                        fill.PreviousDisplayedQuantity - fill.Order.DisplayedQuantity,
+                        fullyFilled: fill.Order.RemainingQuantity == 0);
                     break;
             }
         }

--- a/src/Circus/MarketData/TradeDataProducer.cs
+++ b/src/Circus/MarketData/TradeDataProducer.cs
@@ -2,19 +2,34 @@ using Circus.Events;
 
 namespace Circus.MarketData;
 
+// The public print, derived from the private fills. A trade produces two FillOrderConfirmed
+// events sharing a TradeId, and a venue broadcasts one message for the pair - so this emits on
+// the first fill of each trade and skips the second.
+//
+// Keyed on the id changing rather than on IsResting, which today would pick out the same event:
+// one print per distinct trade is what is meant, and it stays true if a trade ever involves more
+// than the two sides it does now. The two fills of a trade are emitted adjacent, so remembering
+// the last id seen is enough and no set is needed.
+//
+// The last id is kept across calls, not just within one. A trade's fills always arrive in the
+// same batch, so this only matters for the pathological case of a trade id repeating across
+// consecutive batches, which the book's forward-only numbering already rules out.
 public class TradeDataProducer : IDataProducer<TradeDataEvent>
 {
+    private string? _lastTradeId;
+
     public IList<TradeDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
     {
         List<TradeDataEvent>? output = null;
 
         foreach (var ev in events)
         {
-            if (ev is OrdersMatched matched)
-            {
-                output ??= new List<TradeDataEvent>();
-                output.Add(new TradeDataEvent(matched.Symbol, matched.Time, matched.Price, matched.Quantity));
-            }
+            if (ev is not FillOrderConfirmed fill || fill.TradeId == _lastTradeId)
+                continue;
+
+            _lastTradeId = fill.TradeId;
+            output ??= new List<TradeDataEvent>();
+            output.Add(new TradeDataEvent(fill.Symbol, fill.Time, fill.Price, fill.Quantity));
         }
 
         return output ?? (IList<TradeDataEvent>) Array.Empty<TradeDataEvent>();

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -23,6 +23,13 @@ public class OrderBook : IOrderBook
     // first action, so a book has no opinion about what time it is until something tells it.
     private DateTime _lastActionTime;
     private long _nextSequenceNumber;
+
+    // Trades are numbered separately from orders. The two are different namespaces - a trade and
+    // an order may both be 5 without ambiguity, since nothing ever holds one where the other is
+    // expected - and interleaving them into a single run would make each harder to read for no
+    // gain. Seeded alongside the order counter at the start of a session, for the reasons given
+    // there.
+    private long _nextTradeId;
     private long? _lastTradedPrice;
 
     // A timed interruption's deadline and where it returns to. Null whenever the book is not
@@ -884,15 +891,16 @@ public class OrderBook : IOrderBook
         var aggressorSnapshot = aggressor.ToOrder();
         var aggressorReplenish = FinishFill(aggressor, time);
 
-        events.Add(new OrdersMatched(_instrument.Symbol, time, price, quantity,
-            new[]
-            {
-                new FillOrderConfirmed(_instrument.Symbol, time, resting.CompanyId, restingSnapshot, price, quantity,
-                    restingDisplayed, true),
-                new FillOrderConfirmed(_instrument.Symbol, time, aggressor.CompanyId, aggressorSnapshot, price,
-                    quantity, aggressorDisplayed, false)
-            }
-        ));
+        // Resting first, then the aggressor: the order the two sides used to appear in within
+        // OrdersMatched.Fills, and the order a consumer deriving one public print from the pair
+        // relies on to see the trade begin.
+        _nextTradeId++;
+        var tradeId = _nextTradeId.ToString();
+
+        events.Add(new FillOrderConfirmed(_instrument.Symbol, time, resting.CompanyId, restingSnapshot, tradeId,
+            price, quantity, restingDisplayed, true));
+        events.Add(new FillOrderConfirmed(_instrument.Symbol, time, aggressor.CompanyId, aggressorSnapshot, tradeId,
+            price, quantity, aggressorDisplayed, false));
 
         if (restingReplenish != null)
             events.Add(restingReplenish);
@@ -1015,6 +1023,12 @@ public class OrderBook : IOrderBook
             // that no longer encodes its date beats one that repeats itself.
             var seed = ((time.Year * 10000) + (time.Month * 100) + time.Day) * 10000000000L;
             _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
+
+            // Trade ids carry the day and never run backwards for the same reasons, though a
+            // trade is finished the moment it prints and so nothing outlives a session holding
+            // one. What the forward-only seed protects here is a journal or a recorded stream
+            // spanning sessions, where a repeated id would describe two different trades.
+            _nextTradeId = Math.Max(_nextTradeId, seed);
         }
 
         // _resumeAt was cleared above, so this reports nothing pending - which is what an

--- a/tests/Circus.Tests/Helpers/Trade.cs
+++ b/tests/Circus.Tests/Helpers/Trade.cs
@@ -1,0 +1,48 @@
+using Circus.Events;
+
+namespace Circus.Tests.Helpers;
+
+// A trade as a consumer reconstructs it: the pair of FillOrderConfirmed events sharing a
+// TradeId, resting side first.
+//
+// The book emits fills rather than trades, because a fill belongs to one participant and a
+// trade does not - which is why there is no longer an event carrying both sides. A test
+// asserting "one trade printed at 100 for 5" is doing what TradeDataProducer does, and does it
+// through this rather than through the same grouping written out at every site.
+//
+// FlatteningTests covers the shape this hides - two top-level fills, one shared id - so that
+// nothing here can quietly go back to assuming a wrapper.
+internal sealed record Trade(string TradeId, string Symbol, DateTime Time, decimal Price, int Quantity,
+    IReadOnlyList<FillOrderConfirmed> Fills)
+{
+    public FillOrderConfirmed Resting => Fills[0];
+    public FillOrderConfirmed Aggressor => Fills[1];
+}
+
+internal static class TradeEvents
+{
+    // Grouped by TradeId, in the order the trades first print. The two fills of a trade are
+    // emitted adjacent and resting-first, and are kept in that order.
+    public static List<Trade> Trades(this IEnumerable<OrderBookEvent> events)
+    {
+        var byId = new Dictionary<string, List<FillOrderConfirmed>>();
+        var order = new List<string>();
+
+        foreach (var fill in events.OfType<FillOrderConfirmed>())
+        {
+            if (!byId.TryGetValue(fill.TradeId, out var fills))
+            {
+                byId[fill.TradeId] = fills = new List<FillOrderConfirmed>();
+                order.Add(fill.TradeId);
+            }
+
+            fills.Add(fill);
+        }
+
+        return order.Select(id =>
+        {
+            var fills = byId[id];
+            return new Trade(id, fills[0].Symbol, fills[0].Time, fills[0].Price, fills[0].Quantity, fills);
+        }).ToList();
+    }
+}

--- a/tests/Circus.Tests/Matching/AuctionMatchingAlgorithmTests.cs
+++ b/tests/Circus.Tests/Matching/AuctionMatchingAlgorithmTests.cs
@@ -63,7 +63,7 @@ public class AuctionMatchingAlgorithmTests
 
         // assert - every fill in this batch prints at the single auction price of 120
         Assert.IsInstanceOf<StatusChanged>(events[0]);
-        var matches = events.OfType<OrdersMatched>().ToList();
+        var matches = events.Trades().ToList();
         Assert.IsNotEmpty(matches);
         foreach (var matched in matches)
             Assert.AreEqual(120, matched.Price);
@@ -111,7 +111,7 @@ public class AuctionMatchingAlgorithmTests
         var events = book.UpdateStatus(OrderBookStatus.Open);
 
         // assert
-        var fills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills).ToList();
+        var fills = events.Trades().SelectMany(m => m.Fills).ToList();
         var icebergFilled = fills.Where(f => f.Order.ClientOrderId == OrderId1).Sum(f => f.Quantity);
         var laterOrderFilled = fills.Where(f => f.Order.ClientOrderId == OrderId2).Sum(f => f.Quantity);
 
@@ -142,7 +142,7 @@ public class AuctionMatchingAlgorithmTests
         var events = book.UpdateStatus(OrderBookStatus.Open);
 
         // assert - one clean allocation of 45, not several smaller touches
-        var icebergFills = events.OfType<OrdersMatched>().SelectMany(m => m.Fills)
+        var icebergFills = events.Trades().SelectMany(m => m.Fills)
             .Where(f => f.Order.ClientOrderId == OrderId1).ToList();
         Assert.AreEqual(1, icebergFills.Count);
         Assert.AreEqual(45, icebergFills[0].Quantity);
@@ -173,7 +173,7 @@ public class AuctionMatchingAlgorithmTests
         var events = book.UpdateStatus(OrderBookStatus.Open);
 
         // assert
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(120, matched.Price);
     }
@@ -198,7 +198,7 @@ public class AuctionMatchingAlgorithmTests
         var events = book.UpdateStatus(OrderBookStatus.Open);
 
         // assert
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(130, matched.Price);
     }
@@ -271,7 +271,7 @@ public class AuctionMatchingAlgorithmTests
         var events = book.UpdateStatus(OrderBookStatus.Closed);
 
         // assert
-        Assert.IsEmpty(events.OfType<OrdersMatched>().ToList(),
+        Assert.IsEmpty(events.Trades().ToList(),
             "the auction must not print into a phase that doesn't trade");
         Assert.AreEqual(2, events.OfType<ExpireOrderConfirmed>().ToList().Count);
         Assert.AreEqual(OrderBookStatus.Closed, book.Status);
@@ -296,7 +296,7 @@ public class AuctionMatchingAlgorithmTests
         var crossing = book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 4, 100);
 
         Assert.IsEmpty(resting.OfType<IndicativePriceChanged>().ToList());
-        Assert.IsInstanceOf<OrdersMatched>(crossing[^1]);
+        Assert.IsNotEmpty(crossing.Trades());
         Assert.IsEmpty(crossing.OfType<IndicativePriceChanged>().ToList());
 
         // ...and it comes back the moment a volatility pause interrupts trading
@@ -426,9 +426,9 @@ public class AuctionMatchingAlgorithmTests
         var reopenEvents = book.UpdateStatus(OrderBookStatus.Open, 90);
 
         // assert
-        Assert.IsTrue(reopenEvents.OfType<OrdersMatched>().Any(m => m.Price == 90));
+        Assert.IsTrue(reopenEvents.Trades().Any(m => m.Price == 90));
         var stopElected = reopenEvents.Any(e => e is UpdateOrderConfirmed u && u.Order.ClientOrderId == OrderId3) ||
-            reopenEvents.OfType<OrdersMatched>().Any(m => m.Fills.Any(f => f.ClientOrderId == OrderId3));
+            reopenEvents.Trades().Any(m => m.Fills.Any(f => f.ClientOrderId == OrderId3));
         Assert.IsTrue(stopElected);
     }
 

--- a/tests/Circus.Tests/Matching/FillEventShapeTests.cs
+++ b/tests/Circus.Tests/Matching/FillEventShapeTests.cs
@@ -16,9 +16,14 @@ public class FillEventShapeTests
     private static readonly Instrument Gold = new("GCZ6", 10, 10);
     private static readonly DateTime Open = new(2000, 1, 1, 12, 0, 0);
 
+    // Through PreOpen rather than straight to Open: StartsSession belongs to that phase alone,
+    // and the trade id counter is seeded from the session date on the way into it, exactly as
+    // the order id counter is - see ExchangeOrderIdScopeTests for that convention. A book opened
+    // directly still works, but its ids start from a bare 1 rather than carrying the date.
     private static IOrderBook OpenBook()
     {
         var book = new OrderBook(Gold);
+        book.PreOpenTrading(time: Open);
         book.OpenTrading(time: Open);
         return book;
     }

--- a/tests/Circus.Tests/Matching/FillEventShapeTests.cs
+++ b/tests/Circus.Tests/Matching/FillEventShapeTests.cs
@@ -1,0 +1,126 @@
+using Circus.Events;
+using Circus.MarketData;
+using NUnit.Framework;
+
+namespace Circus.Tests.Matching;
+
+// A trade is two top-level FillOrderConfirmed events sharing a TradeId, and nothing wraps them.
+//
+// Pinned here because Trade (the test helper) reassembles the pair for the assertions everywhere
+// else, and would go on doing so if the book quietly went back to emitting a composite event.
+// The point of the shape is the last test in this file: a participant's feed is a filter, and a
+// filter cannot leak a counterparty.
+[TestFixture]
+public class FillEventShapeTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly DateTime Open = new(2000, 1, 1, 12, 0, 0);
+
+    private static IOrderBook OpenBook()
+    {
+        var book = new OrderBook(Gold);
+        book.OpenTrading(time: Open);
+        return book;
+    }
+
+    [Test]
+    public void OneTrade_EmitsTwoFills_RestingFirst_SharingOneTradeId()
+    {
+        var book = OpenBook();
+        book.CreateLimitOrder("Resting", "R1", new OrderValidity.Day(), Side.Buy, 5, 100,
+            time: Open.AddSeconds(1));
+
+        var events = book.CreateLimitOrder("Aggressor", "A1", new OrderValidity.Day(), Side.Sell, 5, 100,
+            time: Open.AddSeconds(2));
+
+        var fills = events.OfType<FillOrderConfirmed>().ToList();
+        Assert.AreEqual(2, fills.Count);
+
+        Assert.IsTrue(fills[0].IsResting, "the resting side is emitted first");
+        Assert.IsFalse(fills[1].IsResting);
+        Assert.AreEqual("Resting", fills[0].CompanyId);
+        Assert.AreEqual("Aggressor", fills[1].CompanyId);
+
+        Assert.AreEqual(fills[0].TradeId, fills[1].TradeId, "one trade, one id");
+        Assert.AreEqual(100, fills[0].Price);
+        Assert.AreEqual(5, fills[0].Quantity);
+    }
+
+    [Test]
+    public void SeparateTrades_GetSeparateIds()
+    {
+        var book = OpenBook();
+        book.CreateLimitOrder("One", "R1", new OrderValidity.Day(), Side.Buy, 3, 100,
+            time: Open.AddSeconds(1));
+        book.CreateLimitOrder("Two", "R2", new OrderValidity.Day(), Side.Buy, 3, 90,
+            time: Open.AddSeconds(2));
+
+        // Sweeps both levels, so two trades in the one action.
+        var events = book.CreateLimitOrder("Aggressor", "A1", new OrderValidity.Day(), Side.Sell, 6, 90,
+            time: Open.AddSeconds(3));
+
+        var ids = events.OfType<FillOrderConfirmed>().Select(f => f.TradeId).Distinct().ToList();
+        Assert.AreEqual(2, ids.Count);
+        Assert.AreEqual(4, events.OfType<FillOrderConfirmed>().Count());
+    }
+
+    [Test]
+    public void TradeIdsCarryTheSessionDate()
+    {
+        var book = OpenBook();
+        book.CreateLimitOrder("Resting", "R1", new OrderValidity.Day(), Side.Buy, 5, 100,
+            time: Open.AddSeconds(1));
+
+        var events = book.CreateLimitOrder("Aggressor", "A1", new OrderValidity.Day(), Side.Sell, 5, 100,
+            time: Open.AddSeconds(2));
+
+        // Seeded from the date the session started, exactly as exchange order ids are.
+        var id = events.OfType<FillOrderConfirmed>().First().TradeId;
+        Assert.IsTrue(id.StartsWith("20000101"), $"expected an id carrying the session date, got {id}");
+    }
+
+    [Test]
+    public void TradeDataProducer_PublishesOnePrintPerTrade_NotOnePerFill()
+    {
+        var book = OpenBook();
+        var producer = new TradeDataProducer();
+
+        book.CreateLimitOrder("Resting", "R1", new OrderValidity.Day(), Side.Buy, 5, 100,
+            time: Open.AddSeconds(1));
+        var events = book.CreateLimitOrder("Aggressor", "A1", new OrderValidity.Day(), Side.Sell, 5, 100,
+            time: Open.AddSeconds(2));
+
+        var prints = producer.Process(events);
+
+        Assert.AreEqual(2, events.OfType<FillOrderConfirmed>().Count(), "two fills");
+        Assert.AreEqual(1, prints.Count, "one public print");
+        Assert.AreEqual(100, prints[0].Price);
+        Assert.AreEqual(5, prints[0].Quantity);
+    }
+
+    // The reason the wrapper had to go. A participant's feed is events filtered to their own
+    // CompanyId; with a composite event that filter could only be done by rewriting it, and
+    // keeping the event whole handed one participant the other's Order - their client order id,
+    // their remaining quantity, their company.
+    [Test]
+    public void FilteringByCompany_GivesAParticipantTheirOwnFillAndNothingOfTheCounterparty()
+    {
+        var book = OpenBook();
+        book.CreateLimitOrder("Resting", "R1", new OrderValidity.Day(), Side.Buy, 5, 100,
+            time: Open.AddSeconds(1));
+
+        var events = book.CreateLimitOrder("Aggressor", "A1", new OrderValidity.Day(), Side.Sell, 5, 100,
+            time: Open.AddSeconds(2));
+
+        var mine = events.OfType<OrderEvent>().Where(e => e.CompanyId == "Resting").ToList();
+
+        var myFill = mine.OfType<FillOrderConfirmed>().Single();
+        Assert.AreEqual("R1", myFill.ClientOrderId);
+        Assert.AreEqual(5, myFill.Quantity);
+
+        // Nothing in the filtered stream mentions the other side at all.
+        Assert.IsFalse(mine.Any(e => e.CompanyId == "Aggressor"));
+        Assert.IsFalse(mine.OfType<OrderConfirmedEvent>().Any(e => e.Order.CompanyId == "Aggressor"));
+        Assert.IsFalse(mine.OfType<OrderConfirmedEvent>().Any(e => e.Order.ClientOrderId == "A1"));
+    }
+}

--- a/tests/Circus.Tests/Matching/MatchingAlgorithmSelectionTests.cs
+++ b/tests/Circus.Tests/Matching/MatchingAlgorithmSelectionTests.cs
@@ -1,4 +1,5 @@
 using Circus.Events;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.Matching;
@@ -31,7 +32,7 @@ public class MatchingAlgorithmSelectionTests
     }
 
     private static Dictionary<string, int> FilledByCompany(IReadOnlyList<OrderBookEvent> events) =>
-        events.OfType<OrdersMatched>()
+        events.Trades()
             .SelectMany(m => m.Fills)
             .Where(f => f.IsResting)
             .GroupBy(f => f.CompanyId)

--- a/tests/Circus.Tests/Orders/CreateOrderTests.cs
+++ b/tests/Circus.Tests/Orders/CreateOrderTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -88,7 +89,7 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
         var created = events[0] as CreateOrderConfirmed;
         Assert.IsNotNull(created);
@@ -111,7 +112,7 @@ public class CreateOrderTests
         Assert.AreEqual(0, created.Order.FilledQuantity);
         Assert.AreEqual(5, created.Order.RemainingQuantity);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(wideProtectionGold.Symbol, matched.Symbol);
         Assert.AreEqual(Now2, matched.Time);
@@ -258,9 +259,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now2, matched.Time);
@@ -329,9 +330,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now2, matched.Time);
@@ -400,9 +401,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now2, matched.Time);
@@ -478,9 +479,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now3, matched.Time);
@@ -551,9 +552,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(5, events.Count);
 
-        var matched1 = events[1] as OrdersMatched;
+        var matched1 = events.Trades()[0];
         Assert.IsNotNull(matched1);
         Assert.AreEqual(Gold.Symbol, matched1.Symbol);
         Assert.AreEqual(Now3, matched1.Time);
@@ -608,7 +609,7 @@ public class CreateOrderTests
         Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
         Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
 
-        var matched2 = events[2] as OrdersMatched;
+        var matched2 = events.Trades()[1];
         Assert.IsNotNull(matched2);
         Assert.AreEqual(Gold.Symbol, matched2.Symbol);
         Assert.AreEqual(Now3, matched2.Time);
@@ -679,9 +680,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now3, matched.Time);
@@ -757,9 +758,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(5, events.Count);
 
-        var matched1 = events[1] as OrdersMatched;
+        var matched1 = events.Trades()[0];
         Assert.IsNotNull(matched1);
         Assert.AreEqual(Gold.Symbol, matched1.Symbol);
         Assert.AreEqual(Now3, matched1.Time);
@@ -814,7 +815,7 @@ public class CreateOrderTests
         Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
         Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
 
-        var matched2 = events[2] as OrdersMatched;
+        var matched2 = events.Trades()[1];
         Assert.IsNotNull(matched2);
         Assert.AreEqual(Gold.Symbol, matched2.Symbol);
         Assert.AreEqual(Now3, matched2.Time);
@@ -885,9 +886,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now3, matched.Time);
@@ -958,9 +959,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(5, events.Count);
 
-        var matched1 = events[1] as OrdersMatched;
+        var matched1 = events.Trades()[0];
         Assert.IsNotNull(matched1);
         Assert.AreEqual(Gold.Symbol, matched1.Symbol);
         Assert.AreEqual(Now3, matched1.Time);
@@ -1015,7 +1016,7 @@ public class CreateOrderTests
         Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
         Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
 
-        var matched2 = events[2] as OrdersMatched;
+        var matched2 = events.Trades()[1];
         Assert.IsNotNull(matched2);
         Assert.AreEqual(Gold.Symbol, matched2.Symbol);
         Assert.AreEqual(Now3, matched2.Time);
@@ -1086,9 +1087,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now3, matched.Time);
@@ -1164,9 +1165,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(5, events.Count);
 
-        var matched1 = events[1] as OrdersMatched;
+        var matched1 = events.Trades()[0];
         Assert.IsNotNull(matched1);
         Assert.AreEqual(Gold.Symbol, matched1.Symbol);
         Assert.AreEqual(Now3, matched1.Time);
@@ -1221,7 +1222,7 @@ public class CreateOrderTests
         Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
         Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
 
-        var matched2 = events[2] as OrdersMatched;
+        var matched2 = events.Trades()[1];
         Assert.IsNotNull(matched2);
         Assert.AreEqual(Gold.Symbol, matched2.Symbol);
         Assert.AreEqual(Now3, matched2.Time);
@@ -1294,9 +1295,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now4, matched.Time);
@@ -1369,9 +1370,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(5, events.Count);
 
-        var matched1 = events[1] as OrdersMatched;
+        var matched1 = events.Trades()[0];
         Assert.IsNotNull(matched1);
         Assert.AreEqual(Gold.Symbol, matched1.Symbol);
         Assert.AreEqual(Now4, matched1.Time);
@@ -1426,7 +1427,7 @@ public class CreateOrderTests
         Assert.AreEqual(5, matched1.Fills[1].Order.FilledQuantity);
         Assert.AreEqual(3, matched1.Fills[1].Order.RemainingQuantity);
 
-        var matched2 = events[2] as OrdersMatched;
+        var matched2 = events.Trades()[1];
         Assert.IsNotNull(matched2);
         Assert.AreEqual(Gold.Symbol, matched2.Symbol);
         Assert.AreEqual(Now4, matched2.Time);
@@ -1499,9 +1500,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now4, matched.Time);
@@ -1579,9 +1580,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(5, events.Count);
 
-        var matched1 = events[1] as OrdersMatched;
+        var matched1 = events.Trades()[0];
         Assert.IsNotNull(matched1);
         Assert.AreEqual(Gold.Symbol, matched1.Symbol);
         Assert.AreEqual(Now4, matched1.Time);
@@ -1636,7 +1637,7 @@ public class CreateOrderTests
         Assert.AreEqual(4, matched1.Fills[1].Order.FilledQuantity);
         Assert.AreEqual(4, matched1.Fills[1].Order.RemainingQuantity);
 
-        var matched2 = events[2] as OrdersMatched;
+        var matched2 = events.Trades()[1];
         Assert.IsNotNull(matched2);
         Assert.AreEqual(Gold.Symbol, matched2.Symbol);
         Assert.AreEqual(Now4, matched2.Time);
@@ -1709,9 +1710,9 @@ public class CreateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now4, matched.Time);

--- a/tests/Circus.Tests/Orders/IcebergTests.cs
+++ b/tests/Circus.Tests/Orders/IcebergTests.cs
@@ -89,10 +89,10 @@ public class IcebergTests
         // replenishes (to a full peak of 5 again) and is requeued behind Company2 - visible in
         // the feed as its own UpdateOrderConfirmed, with a fresh ExchangeOrderId marking the
         // lost priority
-        Assert.AreEqual(4, events.Count);
+        Assert.AreEqual(6, events.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-        var firstMatch = events[1] as OrdersMatched;
+        var firstMatch = events.Trades()[0];
         Assert.IsNotNull(firstMatch);
         Assert.AreEqual(5, firstMatch.Quantity);
         Assert.AreEqual(OrderId1, firstMatch.Fills[0].ClientOrderId);
@@ -100,15 +100,15 @@ public class IcebergTests
         Assert.AreEqual(7, firstMatch.Fills[0].Order.RemainingQuantity);
         Assert.AreEqual(0, firstMatch.Fills[0].Order.DisplayedQuantity); // not yet replenished
 
-        var replenish = events[2] as UpdateOrderConfirmed;
+        var replenish = events[3] as UpdateOrderConfirmed;
         Assert.IsNotNull(replenish);
         Assert.AreEqual(OrderId1, replenish.Order.ClientOrderId);
         Assert.AreEqual(5, replenish.Order.DisplayedQuantity); // replenished back to full peak
         Assert.AreNotEqual(replenish.PreviousExchangeOrderId, replenish.Order.ExchangeOrderId);
 
-        // third event: the aggressor's remaining 3 units match Company2 - not the iceberg's
+        // second trade: the aggressor's remaining 3 units match Company2 - not the iceberg's
         // freshly-replenished peak - proving the iceberg lost its queue position
-        var secondMatch = events[3] as OrdersMatched;
+        var secondMatch = events.Trades()[1];
         Assert.IsNotNull(secondMatch);
         Assert.AreEqual(3, secondMatch.Quantity);
         Assert.AreEqual(OrderId2, secondMatch.Fills[0].ClientOrderId);
@@ -137,8 +137,8 @@ public class IcebergTests
         // assert - three separate prints as the peak replenishes: 5, 5, then the 2 left over,
         // with a replenish event after each of the first two (not after the last - the
         // iceberg is fully filled at that point, nothing left to replenish)
-        Assert.AreEqual(6, events.Count);
-        var matches = events.OfType<OrdersMatched>().ToList();
+        Assert.AreEqual(9, events.Count);
+        var matches = events.Trades().ToList();
         Assert.AreEqual(3, matches.Count);
         Assert.AreEqual(5, matches[0].Quantity);
         Assert.AreEqual(5, matches[1].Quantity);
@@ -173,7 +173,7 @@ public class IcebergTests
         // aggressor's 15 is satisfied, so it replenishes one last time trailing the final
         // match too; events[^1] can't be assumed to be the match itself here.
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        var lastMatch = events.OfType<OrdersMatched>().Last();
+        var lastMatch = events.Trades().Last();
         Assert.AreEqual(OrderStatus.Filled, lastMatch.Fills[1].Order.Status);
         Assert.AreEqual(15, lastMatch.Fills[1].Order.FilledQuantity);
 
@@ -201,7 +201,7 @@ public class IcebergTests
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
         // assert
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(OrderId1B, matched.Fills[0].ClientOrderId);
     }
@@ -224,7 +224,7 @@ public class IcebergTests
         var events = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 3, 100);
 
         // assert
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);
     }
@@ -248,8 +248,8 @@ public class IcebergTests
         // remaining size, down to whatever's left at the end (3, 3, 3, then 1). The aggressor
         // itself replenishes (and loses priority) after each of the first three fills, but not
         // the last, since it's fully filled at that point.
-        Assert.AreEqual(8, events.Count);
-        var matches = events.OfType<OrdersMatched>().ToList();
+        Assert.AreEqual(12, events.Count);
+        var matches = events.Trades().ToList();
         Assert.AreEqual(4, matches.Count);
         Assert.AreEqual(3, matches[0].Quantity);
         Assert.AreEqual(3, matches[1].Quantity);

--- a/tests/Circus.Tests/Orders/ImmediateOrCancelTests.cs
+++ b/tests/Circus.Tests/Orders/ImmediateOrCancelTests.cs
@@ -61,9 +61,9 @@ public class ImmediateOrCancelTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(3, matched.Quantity);
@@ -89,14 +89,14 @@ public class ImmediateOrCancelTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(2, matched.Quantity);
 
-        var cancelled = events[2] as CancelOrderConfirmed;
+        var cancelled = events[3] as CancelOrderConfirmed;
         Assert.IsNotNull(cancelled);
         Assert.AreEqual(Gold.Symbol, cancelled.Symbol);
         Assert.AreEqual(Now2, cancelled.Time);
@@ -158,14 +158,14 @@ public class ImmediateOrCancelTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(500, matched.Price);
         Assert.AreEqual(2, matched.Quantity);
 
-        var cancelled = events[2] as CancelOrderConfirmed;
+        var cancelled = events[3] as CancelOrderConfirmed;
         Assert.IsNotNull(cancelled);
         Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
         Assert.AreEqual(OrderId2, cancelled.Order.ClientOrderId);
@@ -202,23 +202,23 @@ public class ImmediateOrCancelTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(5, events.Count);
+        Assert.AreEqual(7, events.Count);
 
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        Assert.IsInstanceOf<OrdersMatched>(events[1]);
+        Assert.IsInstanceOf<FillOrderConfirmed>(events[1]);
 
-        var triggered = events[2] as UpdateOrderConfirmed;
+        var triggered = events[3] as UpdateOrderConfirmed;
         Assert.IsNotNull(triggered);
         Assert.AreEqual(OrderId3, triggered.Order.ClientOrderId);
         Assert.AreEqual(OrderType.Limit, triggered.Order.Type);
         Assert.AreEqual(530, triggered.Order.Price);
 
-        var stopMatch = events[3] as OrdersMatched;
+        var stopMatch = events.Trades()[1];
         Assert.IsNotNull(stopMatch);
         Assert.AreEqual(530, stopMatch.Price);
         Assert.AreEqual(2, stopMatch.Quantity);
 
-        var cancelled = events[4] as CancelOrderConfirmed;
+        var cancelled = events[6] as CancelOrderConfirmed;
         Assert.IsNotNull(cancelled);
         Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
         Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
@@ -248,9 +248,9 @@ public class ImmediateOrCancelTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(5, matched.Quantity);
@@ -275,14 +275,14 @@ public class ImmediateOrCancelTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(5, events.Count);
 
-        var matched1 = events[1] as OrdersMatched;
+        var matched1 = events.Trades()[0];
         Assert.IsNotNull(matched1);
         Assert.AreEqual(100, matched1.Price);
         Assert.AreEqual(3, matched1.Quantity);
 
-        var matched2 = events[2] as OrdersMatched;
+        var matched2 = events.Trades()[1];
         Assert.IsNotNull(matched2);
         Assert.AreEqual(110, matched2.Price);
         Assert.AreEqual(2, matched2.Quantity);
@@ -349,12 +349,12 @@ public class ImmediateOrCancelTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
 
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        Assert.IsInstanceOf<OrdersMatched>(events[1]);
+        Assert.IsInstanceOf<FillOrderConfirmed>(events[1]);
 
-        var cancelled = events[2] as CancelOrderConfirmed;
+        var cancelled = events[3] as CancelOrderConfirmed;
         Assert.IsNotNull(cancelled);
         Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
         Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
@@ -406,14 +406,14 @@ public class ImmediateOrCancelTests
 
         // assert - proceeds like classic IOC once the gate is satisfied: fills what's
         // available, cancels the rest
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(3, matched.Quantity);
 
-        var cancelled = events[2] as CancelOrderConfirmed;
+        var cancelled = events[3] as CancelOrderConfirmed;
         Assert.IsNotNull(cancelled);
         Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
         Assert.AreEqual(3, cancelled.Order.FilledQuantity);
@@ -470,11 +470,11 @@ public class ImmediateOrCancelTests
 
         // assert - stop triggers, but the available 1 unit doesn't meet its MinQuantity of 2,
         // so it's cancelled directly rather than being converted to a working limit order
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        Assert.IsInstanceOf<OrdersMatched>(events[1]);
+        Assert.IsInstanceOf<FillOrderConfirmed>(events[1]);
 
-        var cancelled = events[2] as CancelOrderConfirmed;
+        var cancelled = events[3] as CancelOrderConfirmed;
         Assert.IsNotNull(cancelled);
         Assert.AreEqual(OrderId3, cancelled.Order.ClientOrderId);
         Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);

--- a/tests/Circus.Tests/Orders/MarketLimitOrderTests.cs
+++ b/tests/Circus.Tests/Orders/MarketLimitOrderTests.cs
@@ -45,14 +45,14 @@ public class MarketLimitOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
         var created = events[0] as CreateOrderConfirmed;
         Assert.IsNotNull(created);
         Assert.AreEqual(OrderType.MarketLimit, created.Order.Type);
         Assert.AreEqual(100, created.Order.Price);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(3, matched.Quantity);
@@ -75,9 +75,9 @@ public class MarketLimitOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(2, matched.Quantity);
@@ -119,15 +119,15 @@ public class MarketLimitOrderTests
         var marketLimitEvents = marketLimitBook.CreateMarketLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 5);
 
         // assert - the plain Market order sweeps both levels and fully fills
-        Assert.AreEqual(3, marketEvents.Count);
-        var finalAggressor = ((OrdersMatched) marketEvents[2]).Fills[1].Order;
+        Assert.AreEqual(5, marketEvents.Count);
+        var finalAggressor = marketEvents.Trades()[1].Fills[1].Order;
         Assert.AreEqual(OrderStatus.Filled, finalAggressor.Status);
         Assert.AreEqual(5, finalAggressor.FilledQuantity);
         Assert.AreEqual(0, finalAggressor.RemainingQuantity);
 
         // the market-limit order only touches the 500 level and rests the remainder there
-        Assert.AreEqual(2, marketLimitEvents.Count);
-        var matched = marketLimitEvents[1] as OrdersMatched;
+        Assert.AreEqual(3, marketLimitEvents.Count);
+        var matched = marketLimitEvents.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(500, matched.Price);
         Assert.AreEqual(2, matched.Quantity);
@@ -174,14 +174,14 @@ public class MarketLimitOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(2, matched.Quantity);
 
-        var cancelled = events[2] as CancelOrderConfirmed;
+        var cancelled = events[3] as CancelOrderConfirmed;
         Assert.IsNotNull(cancelled);
         Assert.AreEqual(OrderCancelledReason.ImmediateOrCancelNotFilled, cancelled.Reason);
         Assert.AreEqual(OrderType.MarketLimit, cancelled.Order.Type);

--- a/tests/Circus.Tests/Orders/SelfTradePreventionTests.cs
+++ b/tests/Circus.Tests/Orders/SelfTradePreventionTests.cs
@@ -51,7 +51,7 @@ public class SelfTradePreventionTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
 
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
@@ -62,7 +62,7 @@ public class SelfTradePreventionTests
         Assert.AreEqual(CompanyId1, cancelled.Order.CompanyId);
         Assert.AreEqual(OrderStatus.Cancelled, cancelled.Order.Status);
 
-        var matched = events[2] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(5, matched.Quantity);
@@ -154,10 +154,10 @@ public class SelfTradePreventionTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(5, matched.Quantity);
         Assert.AreEqual(OrderStatus.Filled, matched.Fills[0].Order.Status);
@@ -178,10 +178,10 @@ public class SelfTradePreventionTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(5, matched.Quantity);
     }
@@ -278,7 +278,7 @@ public class SelfTradePreventionTests
 
         // assert - accepted: the 2@100 self-match is skipped, the 5@100 behind it is enough
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
+        Assert.AreEqual(4, events.Count);
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
 
         var cancelled = events[1] as CancelOrderConfirmed;
@@ -286,7 +286,7 @@ public class SelfTradePreventionTests
         Assert.AreEqual(OrderCancelledReason.SelfMatchPrevention, cancelled.Reason);
         Assert.AreEqual(OrderId1, cancelled.Order.ClientOrderId);
 
-        var matched = events[2] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(5, matched.Quantity);
         Assert.AreEqual(OrderId2, matched.Fills[0].ClientOrderId);

--- a/tests/Circus.Tests/Orders/StopTriggerTests.cs
+++ b/tests/Circus.Tests/Orders/StopTriggerTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -69,7 +70,7 @@ public class StopTriggerTests
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Buy, 2, 510);
 
         // assert
-        var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 510);
+        var tradedAtTrigger = events.Trades().FirstOrDefault(m => m.Price == 510);
         Assert.IsNotNull(tradedAtTrigger, "expected a trade at the trigger price of 510");
 
         var triggerConversion = events.OfType<UpdateOrderConfirmed>()
@@ -81,7 +82,7 @@ public class StopTriggerTests
         Assert.IsNull(triggerConversion.PreviousPrice,
             "it was resting in the stops ladder, not the working book - this is an arrival, not a move");
 
-        var tradedAtLimit = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 520);
+        var tradedAtLimit = events.Trades().FirstOrDefault(m => m.Price == 520);
         Assert.IsNotNull(tradedAtLimit, "expected the newly triggered order to match against the resting offer at 520");
         Assert.AreEqual(5, tradedAtLimit.Quantity);
         Assert.IsTrue(tradedAtLimit.Fills.Any(f => f.Order.ClientOrderId == OrderId4 && f.Order.Status == OrderStatus.Filled));
@@ -114,7 +115,7 @@ public class StopTriggerTests
         var events = Book.CreateLimitOrder(CompanyId6, OrderId6, new OrderValidity.Day(), Side.Sell, 2, 490);
 
         // assert
-        var tradedAtTrigger = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 490);
+        var tradedAtTrigger = events.Trades().FirstOrDefault(m => m.Price == 490);
         Assert.IsNotNull(tradedAtTrigger, "expected a trade at the trigger price of 490");
 
         var triggerConversion = events.OfType<UpdateOrderConfirmed>()
@@ -124,7 +125,7 @@ public class StopTriggerTests
         Assert.AreEqual(OrderStatus.Working, triggerConversion.Order.Status);
         Assert.AreEqual(470, triggerConversion.Order.Price);
 
-        var tradedAtLimit = events.OfType<OrdersMatched>().FirstOrDefault(m => m.Price == 480);
+        var tradedAtLimit = events.Trades().FirstOrDefault(m => m.Price == 480);
         Assert.IsNotNull(tradedAtLimit, "expected the newly triggered order to match against the resting bid at 480");
         Assert.AreEqual(5, tradedAtLimit.Quantity);
         Assert.IsTrue(tradedAtLimit.Fills.Any(f => f.Order.ClientOrderId == OrderId4 && f.Order.Status == OrderStatus.Filled));
@@ -149,7 +150,7 @@ public class StopTriggerTests
         var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 490);
 
         // assert
-        Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 490));
+        Assert.IsTrue(events.Trades().Any(m => m.Price == 490));
         Assert.IsFalse(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
             "the stop order should still be pending, not triggered, since price moved away from the trigger");
 
@@ -179,7 +180,7 @@ public class StopTriggerTests
         var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Sell, 1, 510);
 
         // assert
-        Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
+        Assert.IsTrue(events.Trades().Any(m => m.Price == 510));
         Assert.IsFalse(events.OfType<UpdateOrderConfirmed>().Any(u => u.Order.ClientOrderId == OrderId3),
             "the stop order should still be pending, not triggered, since price moved away from the trigger");
 
@@ -210,7 +211,7 @@ public class StopTriggerTests
         var events = Book.CreateLimitOrder(CompanyId5, OrderId5, new OrderValidity.Day(), Side.Buy, 2, 510);
 
         // assert
-        Assert.IsTrue(events.OfType<OrdersMatched>().Any(m => m.Price == 510));
+        Assert.IsTrue(events.Trades().Any(m => m.Price == 510));
 
         var cancelled = events.OfType<CancelOrderConfirmed>().FirstOrDefault(c => c.Order.ClientOrderId == OrderId3);
         Assert.IsNotNull(cancelled, "expected the triggered stop market order to be cancelled since the book was empty");

--- a/tests/Circus.Tests/Orders/UpdateOrderTests.cs
+++ b/tests/Circus.Tests/Orders/UpdateOrderTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -491,7 +492,7 @@ public class UpdateOrderTests
 
         // a follow-up buy for the full new total should only find the 2 that remain
         var matched = Book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Buy, 6, 110)
-            .OfType<OrdersMatched>().Single();
+            .Trades().Single();
         Assert.AreEqual(2, matched.Quantity);
     }
 
@@ -510,9 +511,9 @@ public class UpdateOrderTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(2, events.Count);
+        Assert.AreEqual(3, events.Count);
 
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now3, matched.Time);

--- a/tests/Circus.Tests/Restrictions/DailyPriceLimitTests.cs
+++ b/tests/Circus.Tests/Restrictions/DailyPriceLimitTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -64,7 +65,7 @@ public class DailyPriceLimitTests
         var events = book.CreateLimitOrder(CompanyId2, "Order2", new OrderValidity.Day(), Side.Buy, 5, 150);
 
         // assert
-        var matched = events.OfType<OrdersMatched>().Single();
+        var matched = events.Trades().Single();
         Assert.AreEqual(150, matched.Price);
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
         Assert.AreEqual(0, events.OfType<LimitStateChanged>().Count(), "trading at the limit is not being stuck");
@@ -111,7 +112,7 @@ public class DailyPriceLimitTests
 
         // assert - nothing printed, and the market is neither paused nor halted
         Assert.IsInstanceOf<CreateOrderConfirmed>(events[0]);
-        Assert.AreEqual(0, events.OfType<OrdersMatched>().Count());
+        Assert.AreEqual(0, events.Trades().Count());
         Assert.AreEqual(OrderBookStatus.Open, book.Status, "a limit is not a halt");
 
         // ...and it says which way it is stuck: the blocked price is above the last trade, so
@@ -137,7 +138,7 @@ public class DailyPriceLimitTests
         var traded = book.CreateLimitOrder(CompanyId2, "Buy3", new OrderValidity.Day(), Side.Buy, 5, 140);
 
         // assert - trading again, and said so
-        Assert.AreEqual(1, traded.OfType<OrdersMatched>().Count());
+        Assert.AreEqual(1, traded.Trades().Count());
         var released = traded.OfType<LimitStateChanged>().Single();
         Assert.IsNull(released.Side);
         Assert.IsNull(released.Price);

--- a/tests/Circus.Tests/Restrictions/OrderPriceBandTests.cs
+++ b/tests/Circus.Tests/Restrictions/OrderPriceBandTests.cs
@@ -131,7 +131,7 @@ public class OrderPriceBandTests
         // act - a trade prints at 140, re-anchoring the band to [90, 190]
         book.CreateLimitOrder(CompanyId1, OrderId2, new OrderValidity.Day(), Side.Buy, 5, 140);
         var matchEvents = book.CreateLimitOrder(CompanyId3, OrderId3, new OrderValidity.Day(), Side.Sell, 5, 140);
-        Assert.IsInstanceOf<OrdersMatched>(matchEvents[^1]);
+        Assert.IsNotEmpty(matchEvents.Trades());
 
         // assert - 160 is now within the new [90, 190] band
         var afterTrade = book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 160);

--- a/tests/Circus.Tests/Restrictions/VelocityLogicTests.cs
+++ b/tests/Circus.Tests/Restrictions/VelocityLogicTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -126,7 +127,7 @@ public class VelocityLogicTests
 
         // assert
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        var matched = events.OfType<OrdersMatched>().Single();
+        var matched = events.Trades().Single();
         Assert.AreEqual(180, matched.Price);
     }
 

--- a/tests/Circus.Tests/Restrictions/VolatilityInterruptionTests.cs
+++ b/tests/Circus.Tests/Restrictions/VolatilityInterruptionTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -55,7 +56,7 @@ public class VolatilityInterruptionTests
 
         // assert - the interruption keeps running rather than resolving out there
         Assert.AreEqual(OrderBookStatus.Paused, book.Status);
-        Assert.AreEqual(0, events.OfType<OrdersMatched>().Count(), "nothing printed");
+        Assert.AreEqual(0, events.Trades().Count(), "nothing printed");
 
         var stillPaused = events.OfType<StatusChanged>().Single();
         Assert.AreEqual(OrderBookStatus.Paused, stillPaused.Status);
@@ -113,7 +114,7 @@ public class VolatilityInterruptionTests
         // assert - the interruption resolves, printing at a price the ordinary range would
         // never have allowed to trade continuously
         Assert.AreEqual(OrderBookStatus.Open, book.Status);
-        var matched = events.OfType<OrdersMatched>().Single();
+        var matched = events.Trades().Single();
         Assert.AreEqual(180, matched.Price);
         Assert.AreEqual(5, matched.Quantity);
     }

--- a/tests/Circus.Tests/Sequencing/ReplayTests.cs
+++ b/tests/Circus.Tests/Sequencing/ReplayTests.cs
@@ -3,6 +3,7 @@ using Circus.Events;
 using Circus.Sequencing;
 using Circus.Sessions;
 using Circus.Simulator;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.Sequencing;
@@ -48,7 +49,7 @@ public class ReplayTests
         // assert - every action, in the order recorded, and the book actually traded
         Assert.AreEqual(3, dispatched.Count);
         Assert.AreEqual(new long[] {1, 2, 3}, dispatched.Select(d => d.Sequence).ToArray());
-        Assert.AreEqual(1, dispatched.SelectMany(d => d.Events).OfType<OrdersMatched>().Count());
+        Assert.AreEqual(1, dispatched.SelectMany(d => d.Events).Trades().Count());
     }
 
     [Test]

--- a/tests/Circus.Tests/Sequencing/SequencerRoutingTests.cs
+++ b/tests/Circus.Tests/Sequencing/SequencerRoutingTests.cs
@@ -2,6 +2,7 @@ using Circus.Actions;
 using Circus.Events;
 using Circus.Sequencing;
 using Circus.Sessions;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.Sequencing;
@@ -85,7 +86,7 @@ public class SequencerRoutingTests
         Assert.AreEqual("Silver1", confirmed[1].Order.ClientOrderId);
 
         // nothing crossed: two resting orders in two books are not a trade
-        Assert.IsEmpty(dispatched.SelectMany(d => d.Events).OfType<OrdersMatched>());
+        Assert.IsEmpty(dispatched.SelectMany(d => d.Events).Trades());
     }
 
     [Test]
@@ -184,7 +185,7 @@ public class SequencerRoutingTests
         Assert.AreEqual(OrderBookStatus.Open, silver.Status, "silver has no band to breach");
 
         // silver printed while gold was paused, at the price that stopped gold
-        var trades = dispatched.SelectMany(d => d.Events).OfType<OrdersMatched>().ToList();
+        var trades = dispatched.SelectMany(d => d.Events).Trades().ToList();
         Assert.AreEqual(1, trades.Count);
         Assert.AreEqual(Silver.Symbol, trades[0].Symbol);
         Assert.AreEqual(200, trades[0].Price);

--- a/tests/Circus.Tests/Sequencing/SequencerTests.cs
+++ b/tests/Circus.Tests/Sequencing/SequencerTests.cs
@@ -2,6 +2,7 @@ using Circus.Actions;
 using Circus.Events;
 using Circus.Sequencing;
 using Circus.Sessions;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.Sequencing;
@@ -229,7 +230,7 @@ public class SequencerTests
         Assert.AreEqual(Deadline, resumed.Time);
 
         // and the pause resolves into one uncrossing print, stamped there too
-        var matched = tick.Events.OfType<OrdersMatched>().Single();
+        var matched = tick.Events.Trades().Single();
         Assert.AreEqual(200, matched.Price);
         Assert.AreEqual(Deadline, matched.Time);
     }

--- a/tests/Circus.Tests/Sessions/DeterminismTests.cs
+++ b/tests/Circus.Tests/Sessions/DeterminismTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Circus.Actions;
 using Circus.Events;
 using Circus.Time;
@@ -179,7 +178,13 @@ public class DeterminismTests
 
     // No clock: the trace carries the time each action happened, which is the property under
     // test. The opening action shares the first action's instant so nothing moves backwards.
-    private static List<string> Replay(IReadOnlyList<OrderBookAction> actions)
+    //
+    // Compared as events rather than rendered to strings first. That used to be impossible: the
+    // only composite event, OrdersMatched, held its fills in an IList, and a record's generated
+    // equality compares one of those by reference - so two runs producing identical trades came
+    // out unequal and had to be described in text to be compared at all. With a trade emitted as
+    // two flat FillOrderConfirmed events, every event compares by value and the rendering can go.
+    private static List<OrderBookEvent> Replay(IReadOnlyList<OrderBookAction> actions)
     {
         var book = new OrderBook(Gold);
         var events = new List<OrderBookEvent>(book.Process(
@@ -188,23 +193,7 @@ public class DeterminismTests
         foreach (var action in actions)
             events.AddRange(book.Process(action));
 
-        return events.Select(Describe).ToList();
-    }
-
-    // Rendered rather than compared directly: OrdersMatched carries its fills in an IList, and a
-    // record's generated equality compares that by reference, so two runs producing identical
-    // trades would still come out unequal. Expanding the fills here compares what they say.
-    private static string Describe(OrderBookEvent e)
-    {
-        if (e is not OrdersMatched matched)
-            return e.ToString();
-
-        var text = new StringBuilder();
-        text.Append($"OrdersMatched {{ Time = {matched.Time:O}, Price = {matched.Price}, " +
-                    $"Quantity = {matched.Quantity}, Fills = [");
-        foreach (var fill in matched.Fills)
-            text.Append(fill).Append("; ");
-        return text.Append("] }").ToString();
+        return events;
     }
 
     private static void Rest(IOrderBook book, string clientOrderId, DateTime time) =>

--- a/tests/Circus.Tests/Sessions/MultipleSessionsTests.cs
+++ b/tests/Circus.Tests/Sessions/MultipleSessionsTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -92,7 +93,7 @@ public class MultipleSessionsTests
         var events = Book.CreateLimitOrder(CompanyId2, OrderId4, new OrderValidity.Day(), Side.Sell, 5, 100);
 
         // assert - the afternoon pair traded rather than colliding with the morning pair's ids
-        var matched = events.OfType<OrdersMatched>().Single();
+        var matched = events.Trades().Single();
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(5, matched.Quantity);
     }
@@ -169,7 +170,7 @@ public class MultipleSessionsTests
         var events = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
 
         // assert
-        var matched = events.OfType<OrdersMatched>().Single();
+        var matched = events.Trades().Single();
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(5, matched.Quantity);
     }

--- a/tests/Circus.Tests/Sessions/PausedHaltedTests.cs
+++ b/tests/Circus.Tests/Sessions/PausedHaltedTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -103,7 +104,7 @@ public class PausedHaltedTests
         // and the order is genuinely still resting, not merely unexpired
         Book.UpdateStatus(OrderBookStatus.Open);
         var crossing = Book.CreateLimitOrder(CompanyId2, OrderId2, new OrderValidity.Day(), Side.Sell, 5, 100);
-        Assert.AreEqual(1, crossing.OfType<OrdersMatched>().Count());
+        Assert.AreEqual(1, crossing.Trades().Count());
     }
 
     [TestCase(OrderBookStatus.Paused)]
@@ -159,13 +160,13 @@ public class PausedHaltedTests
         var quote = crossing.OfType<IndicativePriceChanged>().Last();
         Assert.AreEqual(100, quote.Price);
         Assert.AreEqual(10, quote.Quantity);
-        Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count(), "a pause quotes, it does not trade");
+        Assert.AreEqual(0, crossing.Trades().Count(), "a pause quotes, it does not trade");
 
         // act - resuming resolves the accumulated book in one print
         var resumed = Book.UpdateStatus(OrderBookStatus.Open);
 
         // assert
-        var matched = resumed.OfType<OrdersMatched>().Single();
+        var matched = resumed.Trades().Single();
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(10, matched.Quantity);
     }
@@ -183,14 +184,14 @@ public class PausedHaltedTests
 
         // assert - withholding price discovery is what makes this a halt
         Assert.AreEqual(0, crossing.OfType<IndicativePriceChanged>().Count());
-        Assert.AreEqual(0, crossing.OfType<OrdersMatched>().Count());
+        Assert.AreEqual(0, crossing.Trades().Count());
 
         // act - no algorithm means nothing prints on the way out; the cross is resolved by
         // continuous trading once open, not by an uncrossing auction
         var resumed = Book.UpdateStatus(OrderBookStatus.Open);
 
         // assert
-        var matched = resumed.OfType<OrdersMatched>().Single();
+        var matched = resumed.Trades().Single();
         Assert.AreEqual(100, matched.Price);
         Assert.AreEqual(10, matched.Quantity);
     }

--- a/tests/Circus.Tests/Sessions/TimedResumeTests.cs
+++ b/tests/Circus.Tests/Sessions/TimedResumeTests.cs
@@ -1,6 +1,7 @@
 using Circus.Actions;
 using Circus.Events;
 using Circus.Restrictions;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -115,7 +116,7 @@ public class TimedResumeTests
         var events = book.AdvanceTime();
 
         // assert - the pause resolves into one uncrossing print rather than resuming mid-sweep
-        var matched = events.OfType<OrdersMatched>().Single();
+        var matched = events.Trades().Single();
         Assert.AreEqual(200, matched.Price);
         Assert.AreEqual(5, matched.Quantity);
     }
@@ -169,7 +170,7 @@ public class TimedResumeTests
 
         // assert - the auction uncrosses against the book as of the deadline, and the print says
         // so rather than claiming the trade happened three quarters of an hour later
-        var matched = events.OfType<OrdersMatched>().Single();
+        var matched = events.Trades().Single();
         Assert.AreEqual(200, matched.Price);
         Assert.AreEqual(Now1 + PauseFor, matched.Time);
     }

--- a/tests/Circus.Tests/Sessions/UpdateStateTests.cs
+++ b/tests/Circus.Tests/Sessions/UpdateStateTests.cs
@@ -1,5 +1,6 @@
 using Circus.Actions;
 using Circus.Events;
+using Circus.Tests.Helpers;
 using Circus.Time;
 using NUnit.Framework;
 
@@ -67,11 +68,11 @@ public class UpdateStateTests
 
         // assert
         Assert.IsNotNull(events);
-        Assert.AreEqual(3, events.Count);
-        var withdrawn = events[2] as IndicativePriceChanged;
+        Assert.AreEqual(4, events.Count);
+        var withdrawn = events[3] as IndicativePriceChanged;
         Assert.IsNotNull(withdrawn);
         Assert.IsNull(withdrawn.Price, "the auction it was quoting has printed");
-        var matched = events[1] as OrdersMatched;
+        var matched = events.Trades()[0];
         Assert.IsNotNull(matched);
         Assert.AreEqual(Gold.Symbol, matched.Symbol);
         Assert.AreEqual(Now3, matched.Time);


### PR DESCRIPTION
A participant must see its own fills and not its counterparty's, and `OrdersMatched` could not express that: it carried no `CompanyId` of its own and held a fill for both sides, so filtering on company either dropped a participant's own fills or handed them the other side's `Order` — their client order id, their remaining quantity, their company. Every other event was already scoped to one participant.

A trade is now two top-level `FillOrderConfirmed` events, resting side first, sharing a `TradeId`. A participant's feed becomes a filter and nothing more.

Prerequisite to the fake-venue work planned in #80.

## The trade id

Follows the conventions the order id already set: per book, its own counter, seeded from the session date and only ever moving forwards via `Math.Max`, so the venue-wide identity of a trade is the pair `(Instrument, TradeId)`. Separate from the order counter because they are different namespaces — a trade and an order may both be `5` without ambiguity.

## What moved

**Nothing is lost.** `Symbol`, `Time`, `Price` and `Quantity` were already on every fill.

- `TradeDataProducer` is the one consumer that gains work: it derives the single public print a venue broadcasts from the pair, emitting when the trade id changes. Keyed on the id rather than on `IsResting` — the two would pick the same event today, but one print per distinct trade is what is meant, and it stays true if a trade ever involves more than two sides.
- `LevelDataProducer`, `FullBookDataProducer` and `OrderFlowSimulator` each lose a loop over `Fills` and handle the fill directly.
- `OrderBook.ApplyTrade` emits two events instead of one wrapping two.

That is six references across five files; the engine change is small.

## It retires a workaround

`DeterminismTests` rendered `OrdersMatched` to text rather than comparing it:

> a record's generated equality compares that by reference, so two runs producing identical trades would still come out unequal

With no composite event left, every event compares by value and the rendering is gone. That is what the golden-file testing planned for the venue harness rests on, so it is worth more than the tidiness.

## The tests

~100 references across 21 files. Trade-level assertions go through a `Trade` test helper that reassembles the pair — that is what a consumer does, and it kept the call sites honest rather than rewritten. `FillEventShapeTests` pins the shape the helper otherwise hides:

- one trade emits exactly two fills, resting first, sharing one id
- separate trades get separate ids
- ids carry the session date
- `TradeDataProducer` publishes one print per trade, not one per fill
- **filtering by company gives a participant their own fill and nothing of the counterparty** — the reason the wrapper had to go

Positional assertions were the fiddly part, since one `OrdersMatched` becomes two events: every `events.Count` in a trading method moves by the number of trades, and every index after a trade shifts. Those were done per method rather than mechanically.

## Testing

**I could not build or run the tests.** This environment has no .NET SDK and the network policy blocks the build servers, so CI is the first real verification. The engine changes I am confident in; the index arithmetic in the migrated tests is the part worth a sceptical eye, and it will surface as assertion failures rather than compile errors. Happy to drive it to green — tell me if you would rather take the test migration locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8NsmnuK5HdsBEYnoMKYSX)_