### PR TITLE
Remove unused _completedOrders dictionary from OrderBook

### DIFF
--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -118,7 +118,6 @@ public class OrderBook : IOrderBook
 
     // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
     private readonly Dictionary<long, InternalOrder> _orders = new();
-    private readonly Dictionary<long, InternalOrder> _completedOrders = new();
 
     // every (companyId, clientOrderId) pair ever assigned by a client, permanently reserved -
     // used for per-client uniqueness checks, ownership enforcement, and Update/Cancel lookups
@@ -649,7 +648,6 @@ public class OrderBook : IOrderBook
     private void FinishOrder(InternalOrder order)
     {
         _orders.Remove(order.InternalId);
-        _completedOrders.Add(order.InternalId, order);
     }
 
     // Called immediately after order.Fill(...). Snapshot the order for FillOrderConfirmed
@@ -1018,9 +1016,9 @@ public class OrderBook : IOrderBook
             // forwards: a second session on the same date computes a seed the counter has
             // already passed and so continues from where it was. Restarting it would re-issue
             // ids that orders surviving the previous session (GTC, or GTD not yet due) still
-            // hold, and _orders/_completedOrders are keyed on exactly that. Math.Max is also
-            // what keeps a replay whose clock moves backwards from colliding - a run of ids
-            // that no longer encodes its date beats one that repeats itself.
+            // hold, and _orders is keyed on exactly that. Math.Max is also what keeps a replay
+            // whose clock moves backwards from colliding - a run of ids that no longer encodes
+            // its date beats one that repeats itself.
             var seed = ((time.Year * 10000) + (time.Month * 100) + time.Day) * 10000000000L;
             _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
 

--- a/tests/Circus.Tests/Sessions/MultipleSessionsTests.cs
+++ b/tests/Circus.Tests/Sessions/MultipleSessionsTests.cs
@@ -9,7 +9,7 @@ namespace Circus.Tests.Sessions;
 // A trading day can hold more than one session. Sequence numbers are seeded from the date, so
 // the thing to prove is that a second session on the same date carries on issuing ids rather
 // than restarting - orders surviving the break still hold the ids a restart would hand out
-// again, and both _orders and _completedOrders are keyed on exactly those.
+// again, and _orders is keyed on exactly those.
 [TestFixture]
 public class MultipleSessionsTests
 {


### PR DESCRIPTION
## Summary
- `OrderBook._completedOrders` was populated in `FinishOrder` on every completed order but never read anywhere - no lookups, no iteration, no exposure.
- Removed the field and the `Add` call, and updated the two comments that referenced it (in `OrderBook.cs` and `MultipleSessionsTests.cs`) to reflect that only `_orders` is keyed by `InternalId` now.

## Test plan
- [ ] `dotnet test` (not runnable in this environment - no dotnet SDK installed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WEDeY2djt8gjzczCuiCE7n)_