### PR TITLE
Stage 1: gate the free early-outs on the allocation-reduction plan

### DIFF
--- a/src/Circus/Matching/AuctionMatchingAlgorithm.cs
+++ b/src/Circus/Matching/AuctionMatchingAlgorithm.cs
@@ -46,13 +46,19 @@ internal sealed class AuctionMatchingAlgorithm : IMatchingAlgorithm
         priceTicks = 0;
         quantity = 0;
 
+        // Uncrossed - or one-sided, which TryGetBest failing covers - declines here, off the
+        // ladders' own best-price cache rather than after materialising every level on both
+        // sides. Worth the extra check: this runs on every action a pre-open session sees, and
+        // an uncrossed book is the common state for most of it.
+        if (!working[Side.Buy].TryGetBest(out var bestBid, out _) ||
+            !working[Side.Sell].TryGetBest(out var bestAsk, out _) ||
+            bestBid < bestAsk)
+            return false;
+
         var buyLevels = working[Side.Buy].EnumerateFromBest()
             .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
         var sellLevels = working[Side.Sell].EnumerateFromBest()
             .Select(x => (Tick: x.Tick, Qty: SumRemaining(x.First))).ToList();
-
-        if (buyLevels.Count == 0 || sellLevels.Count == 0 || buyLevels[0].Tick < sellLevels[0].Tick)
-            return false;
 
         var candidates = buyLevels.Select(l => l.Tick).Concat(sellLevels.Select(l => l.Tick)).Distinct();
 

--- a/src/Circus/Matching/Matcher.cs
+++ b/src/Circus/Matching/Matcher.cs
@@ -147,28 +147,40 @@ internal sealed class Matcher
     // every trade, even repeatedly at one price, since an order an earlier StopsTriggered
     // already removed is not found again. Buy stops fire as price rises to their level and
     // sell stops as it falls, which is the direction each ladder is already ordered in.
+    //
+    // Gated on TryGetBest before enumerating either ladder: a single array read says whether
+    // that side's nearest stop is even in reach, and it almost never is - most trades touch
+    // nothing standing in either stop ladder, so the common case pays for two reads and no
+    // iterator rather than walking (and allocating an enumerator over) a ladder with nothing
+    // to find.
     private List<InternalOrder>? GatherTriggeredStops(long priceTicks)
     {
         SortedDictionary<long, InternalOrder>? triggered = null;
 
-        foreach (var (tick, first, _) in _stops[Side.Buy].EnumerateFromBest())
+        if (_stops[Side.Buy].TryGetBest(out var bestBuyStop, out _) && bestBuyStop <= priceTicks)
         {
-            if (tick > priceTicks)
-                break;
+            foreach (var (tick, first, _) in _stops[Side.Buy].EnumerateFromBest())
+            {
+                if (tick > priceTicks)
+                    break;
 
-            triggered ??= new SortedDictionary<long, InternalOrder>();
-            for (var order = first; order != null; order = order.LevelNext)
-                triggered.Add(order.SequenceNumber, order);
+                triggered ??= new SortedDictionary<long, InternalOrder>();
+                for (var order = first; order != null; order = order.LevelNext)
+                    triggered.Add(order.SequenceNumber, order);
+            }
         }
 
-        foreach (var (tick, first, _) in _stops[Side.Sell].EnumerateFromBest())
+        if (_stops[Side.Sell].TryGetBest(out var bestSellStop, out _) && bestSellStop >= priceTicks)
         {
-            if (tick < priceTicks)
-                break;
+            foreach (var (tick, first, _) in _stops[Side.Sell].EnumerateFromBest())
+            {
+                if (tick < priceTicks)
+                    break;
 
-            triggered ??= new SortedDictionary<long, InternalOrder>();
-            for (var order = first; order != null; order = order.LevelNext)
-                triggered.Add(order.SequenceNumber, order);
+                triggered ??= new SortedDictionary<long, InternalOrder>();
+                for (var order = first; order != null; order = order.LevelNext)
+                    triggered.Add(order.SequenceNumber, order);
+            }
         }
 
         return triggered?.Values.ToList();

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -52,6 +52,11 @@ public class OrderBook : IOrderBook
     // self-match verdicts) that read them.
     private readonly Matcher _matcher = new();
 
+    // Scratch space for Match, reused rather than allocated per call: a book processes one
+    // action at a time and Match never re-enters itself within that, so one buffer per book is
+    // enough. Cleared at the top of every call rather than left to grow unbounded across them.
+    private readonly List<InternalOrder> _pendingImmediateOrCancelStops = new();
+
     // Nothing outside this table names a status - the rest of the book reads the current phase
     // and acts on what it says. Pre-open's auction instance is also what prints on the way out
     // of it, so the opening print is the quote it had been publishing.
@@ -692,18 +697,18 @@ public class OrderBook : IOrderBook
 
         var continuous = phase.Algorithm ??
             throw new InvalidOperationException("a phase that matches continuously needs an algorithm");
-        var pendingImmediateOrCancelStops = new List<InternalOrder>();
+        _pendingImmediateOrCancelStops.Clear();
 
         // Closed over the action's instant rather than passed as a method group, so a sweep
         // judges every price it touches against the same moment the events it emits are stamped
         // with. A restriction reading a clock here instead would drift within a single action.
         foreach (var outcome in _matcher.Run(algorithm ?? continuous, continuous,
                      priceTicks => CheckTradeRestrictionBreach(priceTicks, time)))
-            Apply(outcome, events, time, pendingImmediateOrCancelStops);
+            Apply(outcome, events, time, _pendingImmediateOrCancelStops);
 
         // Deferred until the sweep is done: the loop only exits once nothing crosses anywhere,
         // so "did it fill" cannot be answered any earlier.
-        foreach (var order in pendingImmediateOrCancelStops)
+        foreach (var order in _pendingImmediateOrCancelStops)
         {
             if (order.RemainingQuantity > 0)
                 events.Add(CancelRemainder(order, OrderCancelledReason.ImmediateOrCancelNotFilled, time));

--- a/src/Circus/Sequencing/Sequencer.cs
+++ b/src/Circus/Sequencing/Sequencer.cs
@@ -155,8 +155,14 @@ public sealed class Sequencer
     // The book's own resume time stays the authority throughout. This only pokes it on time.
     private void QueueInterruptionTicks(IReadOnlyList<OrderBookEvent> events, DateTime dispatchedAt)
     {
-        foreach (var status in events.OfType<StatusChanged>())
+        // Indexed rather than events.OfType<StatusChanged>(): a StatusChanged is present in a
+        // small fraction of dispatches, so this avoids an iterator allocation to find one that
+        // usually is not there.
+        for (var i = 0; i < events.Count; i++)
         {
+            if (events[i] is not StatusChanged status)
+                continue;
+
             // Strictly ahead: a deadline that has already arrived was served by the action that
             // set it, and a poke queued at the instant being dispatched would only spin.
             if (status.ResumesAt is { } resumesAt && resumesAt > dispatchedAt)


### PR DESCRIPTION
## Summary

Stage 1 of the allocation-reduction plan (full plan on a separate branch, not yet merged — see `docs/reducing-allocations.md` on `claude/allocation-reduction-plan-qnp3yh`). Four sites that were doing work, and allocating to do it, for an answer that is "no" almost every time. No contract changes, no behavioural changes — each site reaches the same decision the same way, minus the object it used to cost:

- `Matcher.GatherTriggeredStops` checks `TryGetBest` on each stop ladder before enumerating it. A trade touches nothing in either stop ladder far more often than not, so this trades two array reads for the iterator `EnumerateFromBest` would otherwise allocate over a ladder with nothing to find.
- `AuctionMatchingAlgorithm.TryQuoteIndicative` checks the working ladders' cached best price before materialising both sides into lists. An uncrossed book — the common state through most of a pre-open session, where this runs on every action — now declines without touching either ladder's contents.
- `Sequencer.QueueInterruptionTicks` walks events by index instead of `events.OfType<StatusChanged>()`, which allocated an iterator to look for something present in a small fraction of dispatches.
- `OrderBook.Match`'s `pendingImmediateOrCancelStops` list is now a field, cleared per call instead of allocated per call. Safe because `Match` never re-enters itself within a single `Process` call — a book handles one action at a time.

## Test plan

- [ ] CI build + test (I could not run `dotnet build`/`dotnet test` locally — no .NET SDK reachable from this sandbox; `builds.dotnet.microsoft.com` is proxy-blocked)
- [ ] `DeterminismTests` passes, confirming the event stream is unchanged
- [ ] Existing stop-trigger, pre-open/auction, and sequencer interruption tests pass unmodified

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKTKPrCF6xRR4KtTpWdd28)_