### PR TITLE
Add LiquidityAgent: a seeded participant that quotes, churns and crosses

### DIFF
--- a/src/Circus.Agents/LiquidityAgent.cs
+++ b/src/Circus.Agents/LiquidityAgent.cs
@@ -1,0 +1,327 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.MarketData;
+
+namespace Circus.Agents;
+
+// The seeded workhorse: quotes a ladder each side of where it thinks the market is, lets it decay,
+// and occasionally crosses. Give it a seed and it produces the same flow every time, which is what
+// a benchmark baseline or a failing test wants; leave the seed out and every run differs, which is
+// what fuzzing wants.
+//
+// It reaches for nothing but its own MarketView and OrderTracker - the feed it subscribed to and
+// the events for its own orders. There is no book here, shadow or otherwise, so the agent cannot
+// know something the venue has not told it and cannot disagree with the venue about what it is
+// holding.
+//
+// Each tick, per instrument, in this order:
+//
+//     churn   retire one live order, and move one to a fresh rung
+//     cross   with probability Aggression, take the other side
+//     quote   fill whichever rungs of its ladder are empty
+//
+// Everything each step decides is read from the tracker, which holds what the venue has confirmed
+// and not what this tick has just written. So a rung freed by this tick's cancel is refilled on
+// the next tick rather than this one, and an order this tick crossed with is still counted as
+// resting until the fill comes back. That lag is the honest one: it is exactly what a participant
+// knows at the moment it decides.
+//
+// One Random for the whole agent rather than one per instrument. Draws therefore interleave across
+// instruments, so a trace covering several is not the same as several traces laid side by side -
+// which is exactly what the simulator did too, and what a single participant trading a book of
+// products actually looks like.
+public sealed class LiquidityAgent : IAgent
+{
+    // A fixed order, so which side is considered first is a property of the code rather than of
+    // however an enum happened to be iterated.
+    private static readonly Side[] Sides = {Side.Buy, Side.Sell};
+
+    // The book allows 20 characters for a client order id, and the rest is a counter. Eleven
+    // leaves room for more orders than any run will produce.
+    private const int MaxPrefixLength = 11;
+
+    private readonly LiquidityAgentOptions _options;
+    private readonly Random _random;
+    private readonly Dictionary<string, Instrument> _instruments;
+    private readonly string[] _symbols;
+    private readonly string _idPrefix;
+    private readonly OrderValidity _validity;
+    private readonly SelfMatchPrevention? _selfMatchPrevention;
+
+    // Cleared at the start of every Act. Two actions on one order within a tick share an instant
+    // and dispatch in the order they were written, so the second would name an order the first
+    // had just retired or renamed - a rejection the agent brought on itself.
+    private readonly HashSet<string> _touched = new();
+
+    // Reset each Act, and counted alongside what the tracker already holds: orders written this
+    // tick are not live yet, but they are about to be, and a limit that ignored them would be
+    // exceeded by every tick that wrote more than one.
+    private int _written;
+
+    private long _nextId = 1;
+
+    public LiquidityAgent(string companyId, IReadOnlyList<Instrument> instruments,
+        LiquidityAgentOptions? options = null, int? seed = null, string? clientOrderIdPrefix = null)
+    {
+        ArgumentNullException.ThrowIfNull(instruments);
+
+        if (string.IsNullOrEmpty(companyId))
+            throw new ArgumentException("a company id is required", nameof(companyId));
+        if (instruments.Count == 0)
+            throw new ArgumentException("at least one instrument is required", nameof(instruments));
+
+        _options = options ?? new LiquidityAgentOptions();
+        _options.Validate();
+
+        Seed = seed ?? Random.Shared.Next();
+        _random = new Random(Seed);
+
+        CompanyId = companyId;
+        _instruments = instruments.ToDictionary(i => i.Symbol);
+        _symbols = instruments.Select(i => i.Symbol).ToArray();
+
+        // Ids need only be unique within a company, since that is how the book keys them - so a
+        // counter is enough for one agent, and the prefix is what keeps two agents sharing a
+        // company from writing the same id.
+        _idPrefix = clientOrderIdPrefix ?? companyId;
+        if (_idPrefix.Length > MaxPrefixLength)
+            throw new ArgumentException(
+                $"a client order id prefix of at most {MaxPrefixLength} characters leaves room for the " +
+                "counter within the book's 20-character limit. Pass a shorter clientOrderIdPrefix.",
+                nameof(clientOrderIdPrefix));
+
+        _validity = _options.Validity ?? new OrderValidity.GoodTilCanceled();
+
+        _selfMatchPrevention = _options.SelfMatchPrevention is { } instruction
+            ? new SelfMatchPrevention {Id = companyId, Instruction = instruction}
+            : null;
+    }
+
+    public string CompanyId { get; }
+
+    public IReadOnlyList<string> Symbols => _symbols;
+
+    // What the run can be reproduced from, whether it was given or drawn.
+    public int Seed { get; }
+
+    public OrderTracker Orders { get; } = new();
+
+    public MarketView Market { get; } = new();
+
+    public void OnMarketData(MarketDataEvent data) => Market.Apply(data);
+
+    public void OnOwnEvent(OrderBookEvent ev) => Orders.Apply(ev);
+
+    public IReadOnlyList<OrderBookAction> Act(DateTime now)
+    {
+        List<OrderBookAction>? actions = null;
+
+        _touched.Clear();
+        _written = 0;
+
+        foreach (var symbol in _symbols)
+        {
+            var view = Market.Of(symbol);
+
+            // Only while the instrument is trading continuously. Pre-open, a pause and a halt all
+            // take order actions too, but quoting into an auction is a different job with
+            // different risk, and an agent doing it by default would be making that call for
+            // whoever built it.
+            if (!view.IsOpen) continue;
+
+            if (_random.NextDouble() >= _options.ActProbability) continue;
+
+            var instrument = _instruments[symbol];
+            var reference = Reference(instrument, view);
+
+            Churn(ref actions, instrument, reference);
+            Cross(ref actions, instrument, view);
+            Quote(ref actions, instrument, reference);
+        }
+
+        return actions ?? (IReadOnlyList<OrderBookAction>) Array.Empty<OrderBookAction>();
+    }
+
+    // Where the agent thinks the market is: the mid if both sides are quoting, else the last
+    // print, else what it was told to assume. Its own orders are part of that mid, which is
+    // correct - a participant reading the feed cannot see which of the depth is its own, and
+    // should not be pricing off a view nobody else has.
+    private decimal Reference(Instrument instrument, InstrumentView view) =>
+        AlignToTick(instrument, view.Mid ?? view.LastTradePrice ?? _options.ReferencePrice);
+
+    private void Churn(ref List<OrderBookAction>? actions, Instrument instrument, decimal reference)
+    {
+        var live = LiveIn(instrument.Symbol);
+        if (live.Count == 0) return;
+
+        if (_random.NextDouble() < _options.CancelProbability)
+        {
+            var order = live[_random.Next(live.Count)];
+
+            if (_touched.Add(order.ClientOrderId))
+                Add(ref actions, new CancelOrder
+                {
+                    Symbol = instrument.Symbol, CompanyId = CompanyId, ClientOrderId = NextClientOrderId(),
+                    PreviousClientOrderId = order.ClientOrderId
+                });
+        }
+
+        if (_random.NextDouble() < _options.ReplaceProbability)
+        {
+            var order = live[_random.Next(live.Count)];
+            var price = RungPrice(instrument, reference, order.Side, _random.Next(_options.Depth));
+
+            // An update that changes nothing is refused, and so is one naming an order this tick
+            // has already retired. Both are the agent's own doing, so both are checked here
+            // rather than heard about from the venue.
+            if (price > 0 && price != order.Price && _touched.Add(order.ClientOrderId))
+                Add(ref actions, new UpdateOrder
+                {
+                    Symbol = instrument.Symbol, CompanyId = CompanyId, ClientOrderId = NextClientOrderId(),
+                    PreviousClientOrderId = order.ClientOrderId, Price = price
+                });
+        }
+    }
+
+    private void Cross(ref List<OrderBookAction>? actions, Instrument instrument, InstrumentView view)
+    {
+        if (_random.NextDouble() >= _options.Aggression) return;
+        if (AtOrderLimit) return;
+
+        if (PickSide(instrument.Symbol) is not { } side) return;
+
+        // Nothing to take. A market order here would be refused for the same reason, so neither
+        // kind is written.
+        var touch = side == Side.Buy ? view.BestOffer : view.BestBid;
+        if (touch is not { } best) return;
+
+        var quantity = NextQuantity();
+
+        if (_random.NextDouble() < _options.MarketOrderProbability)
+        {
+            Add(ref actions, new CreateMarketOrder
+            {
+                Symbol = instrument.Symbol, CompanyId = CompanyId, ClientOrderId = NextClientOrderId(),
+                OrderValidity = _validity, Side = side, Quantity = quantity,
+                SelfMatchPrevention = _selfMatchPrevention, MaxVisibleQuantity = VisibleQuantity(quantity)
+            });
+        }
+        else
+        {
+            var through = _options.SweepTicks * instrument.TickSize;
+            var price = side == Side.Buy ? best + through : best - through;
+
+            if (price <= 0) return;
+
+            Add(ref actions, new CreateLimitOrder
+            {
+                Symbol = instrument.Symbol, CompanyId = CompanyId, ClientOrderId = NextClientOrderId(),
+                OrderValidity = _validity, Side = side, Quantity = quantity, Price = price,
+                SelfMatchPrevention = _selfMatchPrevention, MaxVisibleQuantity = VisibleQuantity(quantity)
+            });
+        }
+
+        _written++;
+    }
+
+    private void Quote(ref List<OrderBookAction>? actions, Instrument instrument, decimal reference)
+    {
+        foreach (var side in Sides)
+        {
+            if (!CanAdd(instrument.Symbol, side)) continue;
+
+            for (var rung = 0; rung < _options.Depth; rung++)
+            {
+                if (AtOrderLimit) return;
+
+                var price = RungPrice(instrument, reference, side, rung);
+
+                // A rung the agent is already standing on needs nothing, and a rung that has
+                // walked down to zero is not a price.
+                if (price <= 0 || HasOrderAt(instrument.Symbol, side, price)) continue;
+
+                var quantity = NextQuantity();
+
+                Add(ref actions, new CreateLimitOrder
+                {
+                    Symbol = instrument.Symbol, CompanyId = CompanyId, ClientOrderId = NextClientOrderId(),
+                    OrderValidity = _validity, Side = side, Quantity = quantity, Price = price,
+                    SelfMatchPrevention = _selfMatchPrevention, MaxVisibleQuantity = VisibleQuantity(quantity)
+                });
+
+                _written++;
+            }
+        }
+    }
+
+    // Rung 0 is one spacing off the reference rather than on it, so the agent's own bid and offer
+    // are always a rung apart and it never quotes itself into a trade.
+    private decimal RungPrice(Instrument instrument, decimal reference, Side side, int rung)
+    {
+        var offset = (rung + 1) * _options.LevelSpacingTicks * instrument.TickSize;
+        return side == Side.Buy ? reference - offset : reference + offset;
+    }
+
+    private bool AtOrderLimit => Orders.LiveCount + _written >= _options.MaxLiveOrders;
+
+    // Which side to take, given what the position limit still allows. A draw is consumed only
+    // when both sides are open, so a limited agent's remaining choices stay reproducible.
+    private Side? PickSide(string symbol)
+    {
+        var canBuy = CanAdd(symbol, Side.Buy);
+        var canSell = CanAdd(symbol, Side.Sell);
+
+        if (canBuy && canSell) return _random.Next(2) == 0 ? Side.Buy : Side.Sell;
+        if (canBuy) return Side.Buy;
+        if (canSell) return Side.Sell;
+
+        return null;
+    }
+
+    private bool CanAdd(string symbol, Side side)
+    {
+        if (_options.MaxPosition is not { } max) return true;
+
+        var position = Orders.Position(symbol);
+        return side == Side.Buy ? position < max : position > -max;
+    }
+
+    private bool HasOrderAt(string symbol, Side side, decimal price)
+    {
+        foreach (var order in Orders.LiveOrders)
+        {
+            if (order.Symbol == symbol && order.Side == side && order.Price == price)
+                return true;
+        }
+
+        return false;
+    }
+
+    private List<LiveOrder> LiveIn(string symbol)
+    {
+        var live = new List<LiveOrder>();
+
+        foreach (var order in Orders.LiveOrders)
+        {
+            if (order.Symbol == symbol)
+                live.Add(order);
+        }
+
+        return live;
+    }
+
+    private int NextQuantity() => _random.Next(_options.MinQuantity, _options.MaxQuantity + 1);
+
+    // A peak larger than the order itself is refused, so an agent quoting small and showing
+    // large shows all of it instead.
+    private int? VisibleQuantity(int quantity) =>
+        _options.MaxVisibleQuantity is { } visible ? Math.Min(visible, quantity) : null;
+
+    private string NextClientOrderId() => $"{_idPrefix}{_nextId++}";
+
+    private static decimal AlignToTick(Instrument instrument, decimal price) =>
+        Math.Round(price / instrument.TickSize) * instrument.TickSize;
+
+    private static void Add(ref List<OrderBookAction>? actions, OrderBookAction action) =>
+        (actions ??= new List<OrderBookAction>()).Add(action);
+}

--- a/src/Circus.Agents/LiquidityAgentOptions.cs
+++ b/src/Circus.Agents/LiquidityAgentOptions.cs
@@ -1,0 +1,102 @@
+namespace Circus.Agents;
+
+// How a LiquidityAgent behaves. Every field is a dial rather than a switch, so a venue can be
+// populated with agents that differ only in their numbers - a patient one quoting deep and wide,
+// an impatient one churning at the touch - without any of them being a different type.
+//
+// The probabilities are independent draws, not weights that share a budget: a tick can cancel,
+// reprice, cross and quote, or do none of those. That is the opposite of how SimulatorOptions
+// read, where the weights were cut-offs carving up a single roll, and it is the more useful shape
+// here because the behaviours are not alternatives to each other.
+public record LiquidityAgentOptions(
+    // Where to quote around before the market has said anything - no mid, no last trade. Aligned
+    // to the instrument's tick before use.
+    decimal ReferencePrice = 1000m,
+
+    // Levels quoted each side. Rung 0 sits one spacing off the reference, so the agent's own bid
+    // and offer never meet however deep it quotes.
+    int Depth = 3,
+    int LevelSpacingTicks = 1,
+
+    int MinQuantity = 1,
+    int MaxQuantity = 10,
+
+    // A cap across every instrument the agent trades, checked before each order is written. It
+    // bounds what the agent is holding, not what it is worth.
+    int MaxLiveOrders = 20,
+
+    // Chance of doing anything at all in an instrument on a given tick. The rest of the
+    // probabilities are drawn only once this one has passed, so halving this halves everything.
+    double ActProbability = 0.5,
+
+    // Chance of crossing the spread rather than adding to it. The one dial that turns a pure
+    // liquidity provider into something that trades: at 0 the agent never takes.
+    double Aggression = 0.05,
+
+    // How far through the opposite touch a crossing order is priced. 0 takes the touch and
+    // stops there; higher clears several levels in one print.
+    int SweepTicks = 0,
+
+    // Chance that a crossing order is a market order rather than a marketable limit. Drawn only
+    // when the agent has already decided to cross, because a market order is aggression - and
+    // only sent when the other side is quoting, since a market order with nothing to match is
+    // refused rather than rested.
+    double MarketOrderProbability = 0.0,
+
+    // Chance of retiring one live order, and of moving one to a fresh rung. Drawn separately, so
+    // a tick can do both - to different orders, never the same one twice.
+    double CancelProbability = 0.1,
+    double ReplaceProbability = 0.2,
+
+    // Stops the agent adding to whichever side would grow its position past this. It bounds what
+    // the agent will send, not what it can end up holding: orders already resting go on filling,
+    // so a position can overshoot and then be worked back rather than being clamped outright.
+    int? MaxPosition = null,
+
+    // Set to show only part of each order to the market. Clamped to the order's own quantity,
+    // since a peak larger than the order is refused.
+    int? MaxVisibleQuantity = null,
+
+    // Defaults to GoodTilCanceled when left null, so a run spanning a close keeps its book.
+    OrderValidity? Validity = null,
+
+    // Carried on every order, under the agent's company id, so an aggressive order that would
+    // trade against the agent's own resting one is prevented rather than washed. Null turns it
+    // off, and a lone agent in a venue will then trade with itself.
+    //
+    // Qualified because the parameter shares its name with a type, which is one of the places
+    // a default value reads as ambiguous.
+    SelfMatchPreventionInstruction? SelfMatchPrevention = Circus.SelfMatchPreventionInstruction.CancelResting
+)
+{
+    // Checked once, where the numbers arrive, rather than by each thing that reads them. Every
+    // one of these produces flow the venue would refuse or an agent that silently does nothing,
+    // and both are worse to debug than an exception naming the field.
+    public void Validate()
+    {
+        if (Depth < 1) throw new ArgumentException("Depth must be at least 1", nameof(Depth));
+        if (LevelSpacingTicks < 1)
+            throw new ArgumentException("LevelSpacingTicks must be at least 1", nameof(LevelSpacingTicks));
+        if (MinQuantity < 1) throw new ArgumentException("MinQuantity must be at least 1", nameof(MinQuantity));
+        if (MaxQuantity < MinQuantity)
+            throw new ArgumentException("MaxQuantity must be at least MinQuantity", nameof(MaxQuantity));
+        if (MaxLiveOrders < 1)
+            throw new ArgumentException("MaxLiveOrders must be at least 1", nameof(MaxLiveOrders));
+        if (SweepTicks < 0) throw new ArgumentException("SweepTicks cannot be negative", nameof(SweepTicks));
+        if (MaxPosition is < 0) throw new ArgumentException("MaxPosition cannot be negative", nameof(MaxPosition));
+        if (MaxVisibleQuantity is < 1)
+            throw new ArgumentException("MaxVisibleQuantity must be at least 1", nameof(MaxVisibleQuantity));
+
+        Probability(ActProbability, nameof(ActProbability));
+        Probability(Aggression, nameof(Aggression));
+        Probability(MarketOrderProbability, nameof(MarketOrderProbability));
+        Probability(CancelProbability, nameof(CancelProbability));
+        Probability(ReplaceProbability, nameof(ReplaceProbability));
+    }
+
+    private static void Probability(double value, string name)
+    {
+        if (value is < 0 or > 1 || double.IsNaN(value))
+            throw new ArgumentException($"{name} must be a probability between 0 and 1", name);
+    }
+}

--- a/tests/Circus.Tests/Agents/LiquidityAgentTests.cs
+++ b/tests/Circus.Tests/Agents/LiquidityAgentTests.cs
@@ -1,0 +1,419 @@
+using Circus.Actions;
+using Circus.Agents;
+using Circus.Events;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Time;
+using NUnit.Framework;
+
+namespace Circus.Tests.Agents;
+
+// What is worth pinning about a seeded agent is that a seed reproduces a run exactly, that every
+// parameter does what it says, and that the agent never sends the venue something the venue has to
+// refuse - the last being the whole reason the shadow book existed.
+[TestFixture]
+public class LiquidityAgentTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly Instrument Silver = new("SIZ6", 10, 10);
+
+    private static readonly DateTime Day = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime BeforeTheDay = Day.AddHours(7);
+    private static readonly DateTime Trading = Day.AddHours(9);
+
+    private static readonly TimeSpan Step = TimeSpan.FromMilliseconds(1);
+
+    private static MarketSchedule OpenThroughout() =>
+        new(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(17, 0, 0));
+
+    // Never opens within a run that starts at 09:00, so an agent watching it has nothing to
+    // quote into.
+    private static MarketSchedule Overnight() =>
+        new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
+
+    // The venue an agent trades at, wired the way a host wires one. The swarm builds none of it.
+    private sealed class Venue
+    {
+        public Venue(MarketSchedule schedule, params Instrument[] instruments)
+        {
+            Clock = new ManualClock(BeforeTheDay);
+            Group = new InstrumentGroup(Clock.GetCurrentTime());
+
+            foreach (var instrument in instruments)
+                Group.Add(instrument, schedule);
+
+            Driver = new LiveDriver(Group.Sequencer, Clock);
+            Swarm = new AgentSwarm(Group, Driver);
+        }
+
+        public Venue(params Instrument[] instruments) : this(OpenThroughout(), instruments)
+        {
+        }
+
+        public ManualClock Clock { get; }
+        public InstrumentGroup Group { get; }
+        public LiveDriver Driver { get; }
+        public AgentSwarm Swarm { get; }
+
+        public List<ChannelMessage> Published { get; } = new();
+
+        // Starts the run at a point where the schedule has already put the books into their
+        // session, then steps a millisecond at a time.
+        public void Run(int ticks)
+        {
+            if (Clock.GetCurrentTime() < Trading)
+                Clock.SetCurrentTime(Trading);
+
+            AgentSwarm.Run(Swarm, Clock, Step, ticks, Published.Add);
+        }
+
+        public LevelsDataEvent LastLevels(string symbol) =>
+            Published.Select(m => m.Data).OfType<LevelsDataEvent>().LastOrDefault(l => l.Symbol == symbol);
+
+        public int Trades => Published.Select(m => m.Data).OfType<TradeDataEvent>().Count();
+    }
+
+    // Wraps an agent to keep what the venue sent it and what it sent back. Kept here rather than
+    // on LiquidityAgent, which has no reason to carry a log of its own life around in production.
+    private sealed class Recording : IAgent
+    {
+        private readonly IAgent _inner;
+        private readonly List<OrderBookEvent> _ownEvents = new();
+        private readonly List<OrderBookAction> _sent = new();
+
+        public Recording(IAgent inner)
+        {
+            _inner = inner;
+        }
+
+        public string CompanyId => _inner.CompanyId;
+        public IReadOnlyList<string> Symbols => _inner.Symbols;
+
+        public IReadOnlyList<OrderBookEvent> OwnEvents => _ownEvents;
+        public IReadOnlyList<OrderBookAction> Sent => _sent;
+
+        public void OnMarketData(MarketDataEvent data) => _inner.OnMarketData(data);
+
+        public void OnOwnEvent(OrderBookEvent ev)
+        {
+            _ownEvents.Add(ev);
+            _inner.OnOwnEvent(ev);
+        }
+
+        public IReadOnlyList<OrderBookAction> Act(DateTime now)
+        {
+            var actions = _inner.Act(now);
+            _sent.AddRange(actions);
+            return actions;
+        }
+    }
+
+    private static LiquidityAgent Agent(string companyId, LiquidityAgentOptions options, int seed,
+        params Instrument[] instruments) =>
+        new(companyId, instruments, options, seed);
+
+    [Test]
+    public void SameSeed_SameRun()
+    {
+        Assert.That(Render(7), Is.EqualTo(Render(7)));
+        Assert.That(Render(7), Is.Not.Empty);
+    }
+
+    [Test]
+    public void DifferentSeeds_DifferentRuns()
+    {
+        Assert.That(Render(1), Is.Not.EqualTo(Render(2)));
+    }
+
+    private static List<string> Render(int seed)
+    {
+        var venue = new Venue(Gold, Silver);
+        venue.Swarm.Add(Agent("MM", new LiquidityAgentOptions(), seed, Gold, Silver));
+        venue.Run(200);
+
+        return venue.Published
+            .Select(m => $"{m.Sequence} {m.Data.Symbol} {Describe(m.Data)}")
+            .ToList();
+    }
+
+    [Test]
+    public void Quotes_BothSidesOfWhereItThinksTheMarketIs()
+    {
+        var venue = new Venue(Gold);
+        venue.Swarm.Add(Agent("MM", new LiquidityAgentOptions(Aggression: 0), 11, Gold));
+        venue.Run(100);
+
+        var levels = venue.LastLevels(Gold.Symbol);
+        Assert.That(levels, Is.Not.Null);
+        Assert.That(levels.Bids, Is.Not.Empty);
+        Assert.That(levels.Offers, Is.Not.Empty);
+
+        // rung 0 sits one spacing off the reference rather than on it, so the agent's own bid and
+        // offer are always a rung apart and it never quotes itself into a trade
+        Assert.That(levels.Bids[0].Price, Is.LessThan(levels.Offers[0].Price));
+
+        // and it quoted around what it was told to assume, the book having said nothing first
+        Assert.That(levels.Bids[0].Price, Is.LessThan(1000));
+        Assert.That(levels.Offers[0].Price, Is.GreaterThan(1000));
+    }
+
+    [Test]
+    public void ALoneAgent_IsNeverRefusedAnything()
+    {
+        // No other participant, so nothing can race it: every action it sends is one the venue
+        // should accept. This is the property the simulator's shadow book existed to provide,
+        // now checked against the real venue rather than assumed.
+        var venue = new Venue(Gold);
+        var agent = new Recording(Agent("MM", new LiquidityAgentOptions(), 3, Gold));
+        venue.Swarm.Add(agent);
+
+        venue.Run(400);
+
+        var rejected = agent.OwnEvents.OfType<OrderRejectedEvent>().ToList();
+        Assert.That(rejected, Is.Empty,
+            $"refused: {string.Join(", ", rejected.Select(r => $"{r.GetType().Name}/{r.Reason}"))}");
+
+        // and it did enough for that to mean something
+        Assert.That(agent.Sent, Is.Not.Empty);
+    }
+
+    [Test]
+    public void CancelsAndUpdates_OnlyEverNameOrdersItCreated()
+    {
+        // Two agents crossing each other, so orders do get filled out from under one another -
+        // the case where a participant tracking its own state badly would start naming orders
+        // that are no longer there.
+        var venue = new Venue(Gold);
+
+        var first = new Recording(Agent("MM1", new LiquidityAgentOptions(Aggression: 0.3), 5, Gold));
+        var second = new Recording(Agent("MM2", new LiquidityAgentOptions(Aggression: 0.3), 6, Gold));
+
+        venue.Swarm.Add(first);
+        venue.Swarm.Add(second);
+        venue.Run(400);
+
+        foreach (var agent in new[] {first, second})
+        {
+            var known = new HashSet<string>();
+
+            foreach (var action in agent.Sent)
+            {
+                switch (action)
+                {
+                    case CreateOrder create:
+                        known.Add(create.ClientOrderId);
+                        break;
+                    case UpdateOrder update:
+                        Assert.That(known, Does.Contain(update.PreviousClientOrderId));
+                        known.Add(update.ClientOrderId);
+                        break;
+                    case CancelOrder cancel:
+                        Assert.That(known, Does.Contain(cancel.PreviousClientOrderId));
+                        break;
+                }
+            }
+        }
+
+        Assert.That(venue.Trades, Is.GreaterThan(0), "expected the two of them to trade");
+    }
+
+    [Test]
+    public void Aggression_Zero_QuotesWithoutEverTrading()
+    {
+        var venue = new Venue(Gold);
+        venue.Swarm.Add(Agent("MM1", new LiquidityAgentOptions(Aggression: 0), 8, Gold));
+        venue.Swarm.Add(Agent("MM2", new LiquidityAgentOptions(Aggression: 0), 9, Gold));
+        venue.Run(300);
+
+        Assert.That(venue.LastLevels(Gold.Symbol).Bids, Is.Not.Empty, "expected it to be quoting");
+        Assert.That(venue.Trades, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Aggression_Crosses()
+    {
+        var venue = new Venue(Gold);
+        venue.Swarm.Add(Agent("MM1", new LiquidityAgentOptions(Aggression: 0.5), 8, Gold));
+        venue.Swarm.Add(Agent("MM2", new LiquidityAgentOptions(Aggression: 0.5), 9, Gold));
+        venue.Run(300);
+
+        Assert.That(venue.Trades, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void Depth_DecidesHowManyLevelsItQuotes()
+    {
+        Assert.That(BidLevels(depth: 1), Is.EqualTo(1));
+        Assert.That(BidLevels(depth: 4), Is.GreaterThan(1));
+
+        static int BidLevels(int depth)
+        {
+            var venue = new Venue(Gold);
+            venue.Swarm.Add(Agent("MM",
+                new LiquidityAgentOptions(Depth: depth, Aggression: 0, CancelProbability: 0,
+                    ReplaceProbability: 0), 4, Gold));
+            venue.Run(100);
+
+            return venue.LastLevels(Gold.Symbol).Bids.Count;
+        }
+    }
+
+    [Test]
+    public void LevelSpacing_WidensTheLadder()
+    {
+        var venue = new Venue(Gold);
+        venue.Swarm.Add(Agent("MM",
+            new LiquidityAgentOptions(Depth: 2, LevelSpacingTicks: 3, Aggression: 0, CancelProbability: 0,
+                ReplaceProbability: 0), 12, Gold));
+        venue.Run(100);
+
+        var levels = venue.LastLevels(Gold.Symbol);
+
+        // three ticks of 10 between the reference and the first rung, and between rungs
+        Assert.That(levels.Bids[0].Price, Is.EqualTo(970));
+        Assert.That(levels.Offers[0].Price, Is.EqualTo(1030));
+    }
+
+    [Test]
+    public void MaxLiveOrders_IsNeverExceeded()
+    {
+        var venue = new Venue(Gold, Silver);
+        var agent = Agent("MM", new LiquidityAgentOptions(Depth: 8, MaxLiveOrders: 5), 13, Gold, Silver);
+        venue.Swarm.Add(agent);
+
+        venue.Clock.SetCurrentTime(Trading);
+
+        // checked every tick rather than at the end, since a limit only breached in the middle
+        // is still breached
+        for (var i = 0; i < 200; i++)
+        {
+            AgentSwarm.Run(venue.Swarm, venue.Clock, Step, 1);
+            Assert.That(agent.Orders.LiveCount, Is.LessThanOrEqualTo(5));
+        }
+
+        Assert.That(agent.Orders.LiveCount, Is.GreaterThan(0), "expected it to have quoted something");
+    }
+
+    [Test]
+    public void ActProbability_Zero_SendsNothing()
+    {
+        var venue = new Venue(Gold);
+        var agent = new Recording(Agent("MM", new LiquidityAgentOptions(ActProbability: 0), 1, Gold));
+        venue.Swarm.Add(agent);
+
+        venue.Run(200);
+
+        Assert.That(agent.Sent, Is.Empty);
+    }
+
+    [Test]
+    public void AClosedBook_IsNotQuotedInto()
+    {
+        var venue = new Venue(Overnight(), Gold);
+        var agent = new Recording(Agent("MM", new LiquidityAgentOptions(), 1, Gold));
+        venue.Swarm.Add(agent);
+
+        venue.Run(200);
+
+        // the schedule never opens within the run, and an agent that quoted anyway would have
+        // every order refused
+        Assert.That(agent.Sent, Is.Empty);
+    }
+
+    [Test]
+    public void MaxPosition_Zero_LeavesNoSideItIsWillingToAddTo()
+    {
+        var venue = new Venue(Gold);
+        var agent = new Recording(Agent("MM", new LiquidityAgentOptions(MaxPosition: 0), 1, Gold));
+        venue.Swarm.Add(agent);
+
+        venue.Run(200);
+
+        // flat, and neither side would move it back towards flat
+        Assert.That(agent.Sent, Is.Empty);
+    }
+
+    [Test]
+    public void MaxVisibleQuantity_ShowsOnlyThePeak()
+    {
+        var venue = new Venue(Gold);
+        var agent = Agent("MM",
+            new LiquidityAgentOptions(MinQuantity: 5, MaxQuantity: 10, MaxVisibleQuantity: 2, Aggression: 0),
+            14, Gold);
+        venue.Swarm.Add(agent);
+
+        venue.Run(100);
+
+        Assert.That(agent.Orders.LiveOrders, Is.Not.Empty);
+        foreach (var order in agent.Orders.LiveOrders)
+            Assert.That(order.DisplayedQuantity, Is.LessThanOrEqualTo(2));
+    }
+
+    [Test]
+    public void SeveralInstruments_AreAllQuoted()
+    {
+        var venue = new Venue(Gold, Silver);
+        venue.Swarm.Add(Agent("MM", new LiquidityAgentOptions(Aggression: 0), 15, Gold, Silver));
+        venue.Run(200);
+
+        Assert.That(venue.LastLevels(Gold.Symbol).Bids, Is.Not.Empty);
+        Assert.That(venue.LastLevels(Silver.Symbol).Bids, Is.Not.Empty);
+    }
+
+    [Test]
+    public void ASeedIsReportedWhetherGivenOrDrawn()
+    {
+        Assert.That(new LiquidityAgent("MM", new[] {Gold}, seed: 42).Seed, Is.EqualTo(42));
+
+        // drawn rather than given, and still reported, so a fuzzing run that finds something can
+        // be replayed
+        var drawn = new LiquidityAgent("MM", new[] {Gold});
+        Assert.That(new LiquidityAgent("MM", new[] {Gold}, seed: drawn.Seed).Seed, Is.EqualTo(drawn.Seed));
+    }
+
+    [Test]
+    public void NoInstruments_Refused()
+    {
+        Assert.Throws<ArgumentException>(() => new LiquidityAgent("MM", Array.Empty<Instrument>()));
+    }
+
+    [Test]
+    public void ALongClientOrderIdPrefix_Refused()
+    {
+        // the book allows 20 characters for a client order id, and the counter needs the rest
+        Assert.Throws<ArgumentException>(
+            () => new LiquidityAgent("a-very-long-company-id", new[] {Gold}));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void ADepthBelowOne_Refused(int depth)
+    {
+        Assert.Throws<ArgumentException>(() => new LiquidityAgentOptions(Depth: depth).Validate());
+    }
+
+    [TestCase(-0.1)]
+    [TestCase(1.1)]
+    public void AProbabilityOutsideZeroToOne_Refused(double probability)
+    {
+        Assert.Throws<ArgumentException>(
+            () => new LiquidityAgentOptions(Aggression: probability).Validate());
+    }
+
+    [Test]
+    public void AMaxQuantityBelowMinQuantity_Refused()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new LiquidityAgentOptions(MinQuantity: 5, MaxQuantity: 4).Validate());
+    }
+
+    // Rendered rather than compared directly: LevelsDataEvent holds its ladders in lists, and a
+    // record's generated equality compares those by reference.
+    private static string Describe(MarketDataEvent data) => data switch
+    {
+        LevelsDataEvent levels =>
+            $"Levels {levels.Time:O} [{string.Join(",", levels.Bids)}] [{string.Join(",", levels.Offers)}]",
+        _ => data.ToString()
+    };
+}


### PR DESCRIPTION
Step 2 of replacing `OrderFlowSimulator` — see `docs/agents-plan.md` for the sequence. Adds only new files; nothing existing changes, and the simulator still generates every trace it did before.

## What it does

Each tick, per instrument, in this order:

| | |
| --- | --- |
| **churn** | retire one live order, and move one to a fresh rung |
| **cross** | with probability `Aggression`, take the other side |
| **quote** | fill whichever rungs of its ladder are empty |

It reaches for nothing but its own `MarketView` and `OrderTracker` — the feed it subscribed to, and the events for its own orders. There is no book here, shadow or otherwise, so it cannot know something the venue has not told it.

Everything it decides is read from what the venue has **confirmed**, not from what the same tick has just written. So a rung freed by this tick's cancel is refilled on the next tick, and an order it just crossed with still counts as resting until the fill comes back. That lag is the honest one — it is exactly what a participant knows at the moment it decides.

## The dials

`LiquidityAgentOptions` is all numbers and no switches, so a venue can be populated with agents that differ only in their options rather than in their type: `Depth`, `LevelSpacingTicks`, `MinQuantity`/`MaxQuantity`, `MaxLiveOrders`, `ActProbability`, `Aggression`, `SweepTicks`, `MarketOrderProbability`, `CancelProbability`, `ReplaceProbability`, `MaxPosition`, `MaxVisibleQuantity`, `Validity`, `SelfMatchPrevention`.

The probabilities are independent draws rather than weights sharing a budget — a tick can cancel, reprice, cross and quote, or do none of those. That is the opposite of how `SimulatorOptions` reads, where the weights were cut-offs carving up one roll, and it is the more useful shape here because the behaviours are not alternatives to each other. `Validate()` runs once in the constructor, so a bad number names its own field instead of producing an agent that silently does nothing.

Two details that keep the agent out of trouble with itself:

- **Rung 0 sits one spacing off the reference, never on it**, so the agent's own bid and offer are always a rung apart however deep it quotes — it cannot quote itself into a trade.
- **Self-match prevention is carried on every order** under the company id, so a lone agent crossing its own resting quote is prevented rather than washed. Set it to null to turn that off.

## Tests

- **A seed reproduces a run exactly**; different seeds diverge.
- **A lone agent is never refused anything.** No other participant, so nothing can race it — every action it sends is one the venue should accept. This is the property the shadow book existed to provide, now checked against the real venue rather than assumed, and the failure message prints the reasons.
- **Two agents crossing each other only ever cancel and update orders they created**, with orders genuinely being filled out from under one another.
- **Each parameter does what it says**: `Aggression: 0` quotes without ever trading and non-zero trades; `Depth` decides the level count; `LevelSpacingTicks` widens the ladder; `MaxLiveOrders` is checked every tick, not just at the end; `ActProbability: 0`, `MaxPosition: 0` and a closed book each send nothing; `MaxVisibleQuantity` shows only the peak.

`Recording` (an `IAgent` decorator) lives in the test rather than on the agent — production code has no reason to carry a log of its own life around.

## Note

Same as last time: I cannot build or run tests in this environment (the network policy denies `builds.dotnet.microsoft.com` and no SDK is preinstalled), so CI is the first thing to compile this. I will drive it to green.

One deviation from the plan doc worth flagging: it described `Aggression` as both the probability of crossing and how deep the sweep goes. Those are now two dials — `Aggression` is purely the probability, `SweepTicks` is how far through the touch — because overloading one scalar made neither legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q374B1uy3jQDCnsazkUC5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q374B1uy3jQDCnsazkUC5a)_