### PR TITLE
Record traces from agents, and feed the trace consumers on them

### DIFF
--- a/benchmarks/Circus.Benchmarks/Circus.Benchmarks.csproj
+++ b/benchmarks/Circus.Benchmarks/Circus.Benchmarks.csproj
@@ -12,7 +12,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Circus\Circus.csproj" />
-        <ProjectReference Include="..\..\src\Circus.Simulator\Circus.Simulator.csproj" />
+
+        <!-- The trace the throughput benchmark replays is recorded from agents. -->
+        <ProjectReference Include="..\..\src\Circus.Agents\Circus.Agents.csproj" />
     </ItemGroup>
 
 </Project>

--- a/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
+++ b/benchmarks/Circus.Benchmarks/OrderBookThroughputBenchmarks.cs
@@ -1,8 +1,8 @@
 using BenchmarkDotNet.Attributes;
 using Circus.Actions;
+using Circus.Agents;
 using Circus.Sequencing;
 using Circus.Sessions;
-using Circus.Simulator;
 
 namespace Circus.Benchmarks;
 
@@ -15,19 +15,31 @@ public class OrderBookThroughputBenchmarks
     [Params(1_000, 10_000, 100_000)]
     public int ActionCount;
 
-    private Instrument _instrument = null!;
+    private static readonly Instrument Bench = new("BENCH", 1m, 10);
+
     private IReadOnlyList<OrderBookAction> _trace = null!;
 
     // The trace runs from 09:00, so an evening session never comes due within it.
     private static readonly MarketSchedule OutOfTheWay =
         new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
 
+    // Recorded once for the longest run, and taken as a prefix for the shorter ones. A trace is
+    // sequential from its seed, so the first thousand actions of the hundred-thousand recording
+    // are the same thousand a run of that length would have produced - which is what the shorter
+    // parameters used to be, back when each of them recorded its own.
+    //
+    // Recorded rather than stored, and so a function of the agents that wrote it: this number
+    // moves when their behaviour does. That is the price of not carrying a serialization format
+    // and a multi-megabyte blob around for a benchmark.
+    private static readonly IReadOnlyList<OrderBookAction> Recorded =
+        AgentTrace.Record(Bench, 100_000, seed: 12345);
+
+    // Outside the measured region, which is where the recording belongs: what is being timed is a
+    // book replaying a fixed list, not the agents that wrote the list.
     [GlobalSetup]
     public void Setup()
     {
-        _instrument = new Instrument("BENCH", 1m, 10);
-        var simulator = new OrderFlowSimulator(_instrument, seed: 12345);
-        _trace = simulator.Generate(ActionCount);
+        _trace = Recorded.Take(ActionCount).ToList();
     }
 
     [Benchmark(Baseline = true)]
@@ -36,8 +48,8 @@ public class OrderBookThroughputBenchmarks
         // No clock: the trace carries the time each action happened, so replaying it is the
         // whole job. Opening is stamped at the first action's instant - the book refuses time
         // running backwards, and equal stamps are fine.
-        var book = new OrderBook(_instrument);
-        book.Process(new OpenTrading {Symbol = _instrument.Symbol, Time = _trace[0].Time});
+        var book = new OrderBook(Bench);
+        book.Process(new OpenTrading {Symbol = Bench.Symbol, Time = _trace[0].Time});
 
         var eventCount = 0;
         foreach (var action in _trace)
@@ -56,14 +68,14 @@ public class OrderBookThroughputBenchmarks
     [Benchmark]
     public int ReplayTraceThroughSequencer()
     {
-        var book = new OrderBook(_instrument);
+        var book = new OrderBook(Bench);
         var sequencer = new Sequencer(_trace[0].Time);
 
         // A schedule whose boundaries fall outside the trace, so what is measured is the queue
         // rather than transitions the baseline never dispatched. Opening is submitted instead,
         // matching the baseline action for action.
         sequencer.Add(book, OutOfTheWay);
-        sequencer.Submit(new OpenTrading {Symbol = _instrument.Symbol, Time = _trace[0].Time});
+        sequencer.Submit(new OpenTrading {Symbol = Bench.Symbol, Time = _trace[0].Time});
 
         var eventCount = 0;
         Replay.Run(sequencer, _trace, d => eventCount += d.Events.Count);

--- a/samples/Circus.Examples/Circus.Examples.csproj
+++ b/samples/Circus.Examples/Circus.Examples.csproj
@@ -8,7 +8,9 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Circus\Circus.csproj" />
-      <ProjectReference Include="..\..\src\Circus.Simulator\Circus.Simulator.csproj" />
+
+      <!-- ReplayExample stands a recorded agent run in for a capture of real venue flow. -->
+      <ProjectReference Include="..\..\src\Circus.Agents\Circus.Agents.csproj" />
     </ItemGroup>
 
 </Project>

--- a/samples/Circus.Examples/ReplayExample.cs
+++ b/samples/Circus.Examples/ReplayExample.cs
@@ -1,25 +1,29 @@
 using Circus.Actions;
+using Circus.Agents;
 using Circus.MarketData;
 using Circus.Sequencing;
 using Circus.Sessions;
-using Circus.Simulator;
 
 namespace Circus.Examples;
 
 // The backtest shape: a recorded trace in, the market data a subscriber would have seen out.
 //
-// This is the seam a capture of real venue flow arrives through. OrderFlowSimulator stands in
+// This is the seam a capture of real venue flow arrives through. A recorded agent run stands in
 // for that capture here, but Replay does not care where the actions came from - only that each
 // one carries the instant it happened at. No clock is read anywhere in the run, which is what
 // makes a replay reproduce a session rather than merely resemble it: a seed gives the same
 // trace, and a trace gives the same events, however many times it is run.
+//
+// The recording is a venue too - agents quoting into real books, watching the feed and being
+// told about their own fills. It is only that once it has been written down, nothing of that
+// survives except the actions, which is exactly what a capture off the wire would be.
 public static class ReplayExample
 {
     private static readonly Instrument Bench = new("BENCH", TickSize: 1);
 
-    // The simulator's trace starts at 09:00 and steps a millisecond an action, so an evening
-    // session never comes due within it. The schedule is here because a book must have one, not
-    // because this sample is about what it does - MarketDataExample covers that.
+    // A recorded trace starts at 09:00, so an evening session never comes due within it. The
+    // schedule is here because a book must have one, not because this sample is about what it
+    // does - MarketDataExample covers that.
     private static readonly MarketSchedule OutOfTheWay =
         new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
 
@@ -27,7 +31,7 @@ public static class ReplayExample
     {
         // Seeded, so this is the same trace every run. Leaving the seed out gives a fresh one
         // each time, which is what fuzzing wants.
-        var trace = new OrderFlowSimulator(Bench, seed: 12345).Generate(2_000);
+        var trace = AgentTrace.Record(Bench, 2_000, seed: 12345);
 
         var group = new InstrumentGroup(trace[0].Time);
         group.Add(Bench, OutOfTheWay);

--- a/src/Circus.Agents/AgentTrace.cs
+++ b/src/Circus.Agents/AgentTrace.cs
@@ -1,0 +1,160 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Time;
+
+namespace Circus.Agents;
+
+// Records what a swarm of seeded agents sent, as a trace that can be replayed into a fresh venue.
+//
+// Agents produce flow in a closed loop - they have to see what the venue did before deciding what
+// to send next - and a replay wants the opposite: a list of actions with nothing in the loop at
+// all. This is the adapter between the two, and it is what a benchmark measuring the book rather
+// than the agents needs, and what a test of Replay needs by definition, since you cannot check
+// that a recording reproduces a run using something that regenerates its input.
+//
+// What comes back is client flow and only client flow. The venue's own opening is not recorded and
+// neither are schedule transitions, because how a consumer's books come to be open is its own
+// decision - the same one every caller of this already makes for itself.
+//
+// Pass a seed for a trace that reproduces exactly. Leave it out for a fresh one each run, which is
+// what fuzzing wants - though a fuzzing caller should draw its own seed and pass it in, so that
+// when something falls over it can say which seed did it.
+public static class AgentTrace
+{
+    // The instant the first recorded action lands on. Fixed rather than read from a clock, since a
+    // trace is supposed to reproduce from its seed alone - and it is the same 09:00 the simulator
+    // used, so the schedules its consumers built around it still hold.
+    private static readonly DateTime Epoch = new(2000, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    private static readonly TimeSpan Step = TimeSpan.FromMilliseconds(1);
+
+    // The recording venue's own schedule, kept where the trace will never reach it: the books are
+    // opened directly instead, so the agents have somewhere to quote from the first tick.
+    private static readonly MarketSchedule OutOfTheWay =
+        new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
+
+    // Agents that never act would otherwise spin here forever waiting for an action count that
+    // cannot arrive.
+    private const int MaxSilentTicks = 10_000;
+
+    // Chosen for coverage rather than for realism, which is the difference between a trace
+    // generator and a market maker. A trace wants every kind of action in it - and in particular
+    // wants prints and market orders, which a patient quoting agent would produce very few of.
+    private static readonly LiquidityAgentOptions ForTraces = new(
+        ActProbability: 0.8,
+        Aggression: 0.15,
+        MarketOrderProbability: 0.2,
+        CancelProbability: 0.15,
+        ReplaceProbability: 0.2);
+
+    // Two agents by default, because one alone mostly trades with itself and is prevented from
+    // doing so. Their seeds are drawn from the run's, so the whole trace still follows from one
+    // number.
+    public static IReadOnlyList<OrderBookAction> Record(IReadOnlyList<Instrument> instruments,
+        int actionCount, int? seed = null, LiquidityAgentOptions? options = null, int agents = 2)
+    {
+        ArgumentNullException.ThrowIfNull(instruments);
+        ArgumentOutOfRangeException.ThrowIfNegative(actionCount);
+
+        if (instruments.Count == 0)
+            throw new ArgumentException("at least one instrument is required", nameof(instruments));
+        if (agents < 1)
+            throw new ArgumentException("at least one agent is required", nameof(agents));
+
+        var trace = new List<OrderBookAction>(actionCount);
+        if (actionCount == 0) return trace;
+
+        // A step behind the epoch, so the first tick lands on it and the first recorded action is
+        // stamped there.
+        var clock = new ManualClock(Epoch - Step);
+        var group = new InstrumentGroup(clock.GetCurrentTime());
+
+        foreach (var instrument in instruments)
+            group.Add(instrument, OutOfTheWay);
+
+        var driver = new LiveDriver(group.Sequencer, clock);
+        var swarm = new AgentSwarm(group, driver);
+
+        var seeds = new Random(seed ?? Random.Shared.Next());
+        for (var i = 0; i < agents; i++)
+        {
+            var agent = new LiquidityAgent($"A{i}", instruments, options ?? ForTraces, seeds.Next());
+            swarm.Add(new Recorded(agent, trace));
+        }
+
+        // Submitted rather than left to the schedule, and not recorded: it is the venue putting
+        // itself where the agents can trade, not a participant doing anything.
+        foreach (var instrument in instruments)
+            driver.Submit(new OpenTrading {Symbol = instrument.Symbol});
+
+        var silent = 0;
+        while (trace.Count < actionCount)
+        {
+            var before = trace.Count;
+            AgentSwarm.Run(swarm, clock, Step, 1);
+
+            if (trace.Count > before)
+            {
+                silent = 0;
+                continue;
+            }
+
+            if (++silent > MaxSilentTicks)
+                throw new InvalidOperationException(
+                    $"the agents produced {trace.Count} of the {actionCount} actions asked for and then " +
+                    $"went quiet for {MaxSilentTicks} ticks. An agent that never acts - ActProbability " +
+                    "of zero, a position limit leaving it no side to add to, or a book it never sees " +
+                    "open - cannot fill a trace.");
+        }
+
+        // A tick writes as many actions as it likes, so the last one usually overshoots. Trimming
+        // from the end is always safe: everything an action refers to was written before it.
+        if (trace.Count > actionCount)
+            trace.RemoveRange(actionCount, trace.Count - actionCount);
+
+        return trace;
+    }
+
+    public static IReadOnlyList<OrderBookAction> Record(Instrument instrument, int actionCount,
+        int? seed = null, LiquidityAgentOptions? options = null, int agents = 2) =>
+        Record(new[] {instrument}, actionCount, seed, options, agents);
+
+    // Keeps what an agent sent, stamped with the instant the venue is about to stamp it with.
+    //
+    // Stamped here rather than recorded raw, because a sequencer refuses an action with no time on
+    // it - an unstamped recording would be a trace that cannot be replayed. The driver reads the
+    // same manual clock at the same instant, so this is the stamp the venue gives it and not a
+    // guess at one.
+    private sealed class Recorded : IAgent
+    {
+        private readonly IAgent _inner;
+        private readonly List<OrderBookAction> _trace;
+
+        public Recorded(IAgent inner, List<OrderBookAction> trace)
+        {
+            _inner = inner;
+            _trace = trace;
+        }
+
+        public string CompanyId => _inner.CompanyId;
+
+        public IReadOnlyList<string> Symbols => _inner.Symbols;
+
+        public void OnMarketData(MarketDataEvent data) => _inner.OnMarketData(data);
+
+        public void OnOwnEvent(OrderBookEvent ev) => _inner.OnOwnEvent(ev);
+
+        public IReadOnlyList<OrderBookAction> Act(DateTime now)
+        {
+            var actions = _inner.Act(now);
+
+            foreach (var action in actions)
+                _trace.Add(action with {Time = now});
+
+            return actions;
+        }
+    }
+}

--- a/tests/Circus.Tests/Agents/AgentTraceTests.cs
+++ b/tests/Circus.Tests/Agents/AgentTraceTests.cs
@@ -1,0 +1,248 @@
+using System.Security.Cryptography;
+using System.Text;
+using Circus.Actions;
+using Circus.Agents;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using NUnit.Framework;
+
+namespace Circus.Tests.Agents;
+
+// A recording is what the rest of the suite and the benchmarks are fed on, so what is worth
+// pinning is that a seed reproduces one exactly, that it is replayable at all - every action
+// stamped, in order, naming orders that exist - and that replaying it into a fresh venue
+// reproduces the run rather than merely resembling it.
+[TestFixture]
+public class AgentTraceTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly Instrument Silver = new("SIZ6", 10, 10);
+    private static readonly Instrument Copper = new("HGZ6", 10, 10);
+
+    private static readonly DateTime Day = new(2000, 1, 1);
+
+    private static MarketSchedule OpenThroughout() =>
+        new(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(17, 0, 0));
+
+    [Test]
+    public void SameSeed_SameTrace()
+    {
+        var first = AgentTrace.Record(new[] {Gold, Silver}, 200, seed: 123);
+        var second = AgentTrace.Record(new[] {Gold, Silver}, 200, seed: 123);
+
+        Assert.That(Describe(first), Is.EqualTo(Describe(second)));
+    }
+
+    [Test]
+    public void DifferentSeeds_DifferentTraces()
+    {
+        var first = AgentTrace.Record(new[] {Gold, Silver}, 200, seed: 1);
+        var second = AgentTrace.Record(new[] {Gold, Silver}, 200, seed: 2);
+
+        Assert.That(Describe(first), Is.Not.EqualTo(Describe(second)));
+    }
+
+    [TestCase(1)]
+    [TestCase(7)]
+    [TestCase(200)]
+    [TestCase(1_001)]
+    public void ReturnsExactlyWhatWasAskedFor(int actionCount)
+    {
+        // a tick writes as many actions as it likes, so all but the roundest counts land mid-tick
+        // and are trimmed back
+        Assert.That(AgentTrace.Record(new[] {Gold, Silver}, actionCount, seed: 5),
+            Has.Count.EqualTo(actionCount));
+    }
+
+    [Test]
+    public void NoActions_EmptyTrace()
+    {
+        Assert.That(AgentTrace.Record(Gold, 0, seed: 5), Is.Empty);
+    }
+
+    [Test]
+    public void EveryActionIsStamped()
+    {
+        // a sequencer refuses an action with no time on it, so an unstamped recording would be a
+        // trace that cannot be replayed
+        foreach (var action in AgentTrace.Record(new[] {Gold, Silver}, 300, seed: 6))
+            Assert.That(action.Time, Is.Not.EqualTo(default(DateTime)));
+    }
+
+    [Test]
+    public void TimeNeverRunsBackwards()
+    {
+        var times = AgentTrace.Record(new[] {Gold, Silver}, 300, seed: 7).Select(a => a.Time).ToList();
+
+        // one clock across every instrument, so a trace is already in the order a sequencer would
+        // put it in. Equal stamps are expected rather than avoided: a tick writes everything it
+        // writes at one instant, which is the tie the sequencer exists to settle.
+        Assert.That(times, Is.EqualTo(times.OrderBy(t => t).ToList()));
+        Assert.That(times.Distinct().Count(), Is.LessThan(times.Count));
+    }
+
+    [Test]
+    public void SeveralInstruments_AreInterleavedInOneTrace()
+    {
+        var trace = AgentTrace.Record(new[] {Gold, Silver, Copper}, 600, seed: 8);
+
+        var symbols = trace.Select(a => a.Symbol).ToList();
+        Assert.That(symbols.Distinct().OrderBy(s => s),
+            Is.EqualTo(new[] {Gold.Symbol, Silver.Symbol, Copper.Symbol}.OrderBy(s => s)));
+
+        var switches = symbols.Zip(symbols.Skip(1)).Count(pair => pair.First != pair.Second);
+        Assert.That(switches, Is.GreaterThan(10), "expected the instruments to be interleaved, not blocked");
+    }
+
+    [Test]
+    public void EveryUpdateAndCancelNamesAnOrderTheSameCompanyCreatedInThatInstrument()
+    {
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 600, seed: 9);
+
+        // an update or cancel naming an order that never existed would be routed to the book and
+        // refused - which is what the simulator kept a shadow book to avoid, and what an agent
+        // avoids by tracking its own events
+        var known = new HashSet<(string Symbol, string CompanyId, string ClientOrderId)>();
+
+        foreach (var action in trace)
+        {
+            switch (action)
+            {
+                case CreateOrder create:
+                    known.Add((create.Symbol, create.CompanyId, create.ClientOrderId));
+                    break;
+                case UpdateOrder update:
+                    Assert.That(known, Does.Contain((update.Symbol, update.CompanyId, update.PreviousClientOrderId)));
+                    known.Add((update.Symbol, update.CompanyId, update.ClientOrderId));
+                    break;
+                case CancelOrder cancel:
+                    Assert.That(known, Does.Contain((cancel.Symbol, cancel.CompanyId, cancel.PreviousClientOrderId)));
+                    break;
+            }
+        }
+    }
+
+    [Test]
+    public void ClientOrderIdsAreUniqueWithinACompany()
+    {
+        var trace = AgentTrace.Record(new[] {Gold, Silver, Copper}, 600, seed: 10);
+
+        // a book keys orders by (CompanyId, ClientOrderId), so that is the pair that has to be
+        // unique - two agents each numbering from one is fine, and is what lets an agent mint ids
+        // without a counter shared across the venue
+        var created = trace.OfType<CreateOrder>().Select(c => (c.CompanyId, c.ClientOrderId)).ToList();
+        Assert.That(created.Distinct().Count(), Is.EqualTo(created.Count));
+    }
+
+    [Test]
+    public void ItCarriesMoreThanOneCompany()
+    {
+        var trace = AgentTrace.Record(Gold, 400, seed: 11);
+
+        // the simulator minted a fresh company for every order, which put self-match prevention,
+        // inventory and anything else about a participant out of reach. A recording carries the
+        // agents that wrote it.
+        Assert.That(trace.OfType<OrderAction>().Select(a => a.CompanyId).Distinct().Count(),
+            Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ItCarriesTheWholeVocabulary()
+    {
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 2_000, seed: 12);
+
+        // the defaults are chosen for coverage rather than realism, so a trace exercises the book
+        // rather than one corner of it
+        Assert.That(trace.OfType<CreateLimitOrder>(), Is.Not.Empty);
+        Assert.That(trace.OfType<CreateMarketOrder>(), Is.Not.Empty);
+        Assert.That(trace.OfType<UpdateOrder>(), Is.Not.Empty);
+        Assert.That(trace.OfType<CancelOrder>(), Is.Not.Empty);
+    }
+
+    [Test]
+    public void ReplayingARecording_ReproducesTheRun()
+    {
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 600, seed: 13);
+
+        var first = Publish(trace);
+        var second = Publish(trace);
+
+        // market data is a function of the dispatch stream, which is a function of the trace - so
+        // a feed can be rebuilt from a recording rather than having to have been recorded itself
+        Assert.That(first, Is.EqualTo(second));
+        Assert.That(first, Is.Not.Empty);
+
+        // and the recording was rich enough to have traded
+        Assert.That(first.Count(m => m.Contains(nameof(TradeDataEvent))), Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void AgentsThatNeverAct_SayWhyRatherThanSpinning()
+    {
+        var idle = new LiquidityAgentOptions(ActProbability: 0);
+
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => AgentTrace.Record(Gold, 10, seed: 14, options: idle));
+
+        Assert.That(thrown.Message, Does.Contain("ActProbability"));
+    }
+
+    [Test]
+    public void NoInstruments_Refused()
+    {
+        Assert.Throws<ArgumentException>(() => AgentTrace.Record(Array.Empty<Instrument>(), 10));
+    }
+
+    [Test]
+    public void NoAgents_Refused()
+    {
+        Assert.Throws<ArgumentException>(() => AgentTrace.Record(Gold, 10, agents: 0));
+    }
+
+    // A committed fingerprint of one seeded recording. It asserts nothing about what good flow
+    // looks like - only that this seed still produces the trace it produced when the value below
+    // was taken, so a change to how agents behave has to be a deliberate one that updates this
+    // rather than a quiet one nobody notices.
+    //
+    // Recompute and replace the constant when agent behaviour changes on purpose; the failure
+    // message carries the new value.
+    [Test]
+    public void AFixedSeed_StillProducesTheTraceItAlwaysHas()
+    {
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 500, seed: 12345);
+        var actual = Fingerprint(trace);
+
+        Assert.That(actual, Is.EqualTo("REPLACE_WITH_THE_VALUE_IN_THE_FAILURE_MESSAGE"),
+            $"the recording for this seed has changed. If that was deliberate, the new fingerprint is {actual}");
+    }
+
+    private static string Fingerprint(IReadOnlyList<OrderBookAction> trace)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(string.Join("\n", Describe(trace))));
+        return Convert.ToHexString(bytes);
+    }
+
+    // Rendered rather than compared directly: an action is a record, and the ones carrying an
+    // OrderValidity compare it by reference.
+    private static List<string> Describe(IReadOnlyList<OrderBookAction> trace) =>
+        trace.Select(a => FormattableString.Invariant($"{a.Symbol} {a.Time:O} {a}")).ToList();
+
+    private static List<string> Publish(IReadOnlyList<OrderBookAction> trace)
+    {
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+        group.Add(Silver, OpenThroughout());
+
+        return Replay.Run(group, trace)
+            .Select(m => FormattableString.Invariant($"{m.Sequence} {m.Data.Symbol} {Render(m.Data)}"))
+            .ToList();
+    }
+
+    private static string Render(MarketDataEvent data) => data switch
+    {
+        LevelsDataEvent levels =>
+            $"{nameof(LevelsDataEvent)} [{string.Join(",", levels.Bids)}] [{string.Join(",", levels.Offers)}]",
+        _ => data.ToString()
+    };
+}

--- a/tests/Circus.Tests/Agents/AgentTraceTests.cs
+++ b/tests/Circus.Tests/Agents/AgentTraceTests.cs
@@ -213,7 +213,7 @@ public class AgentTraceTests
         var trace = AgentTrace.Record(new[] {Gold, Silver}, 500, seed: 12345);
         var actual = Fingerprint(trace);
 
-        Assert.That(actual, Is.EqualTo("REPLACE_WITH_THE_VALUE_IN_THE_FAILURE_MESSAGE"),
+        Assert.That(actual, Is.EqualTo("8E13AAF0E66FBAC5E31DBE74B066BD80F879D226A6C1105D96853F905334BAE5"),
             $"the recording for this seed has changed. If that was deliberate, the new fingerprint is {actual}");
     }
 

--- a/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
+++ b/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
@@ -1,8 +1,8 @@
 using Circus.Actions;
+using Circus.Agents;
 using Circus.MarketData;
 using Circus.Sequencing;
 using Circus.Sessions;
-using Circus.Simulator;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;
@@ -34,7 +34,7 @@ public class ChannelFromDispatchTests
         group.Add(Gold, OpenThroughout());
         group.Add(Silver, OpenThroughout());
 
-        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 21).Generate(400);
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 400, seed: 21);
 
         // act - the group wires sequencer dispatch to channel publish automatically
         var published = Replay.Run(group, trace);
@@ -72,7 +72,7 @@ public class ChannelFromDispatchTests
         var silverChannel = new MarketDataChannel();
         silverChannel.Add(new InstrumentFeed(Silver.Symbol, maxLevels: 10));
 
-        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 22).Generate(400);
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 400, seed: 22);
 
         // act
         var goldMessages = new List<ChannelMessage>();
@@ -105,7 +105,7 @@ public class ChannelFromDispatchTests
     [Test]
     public void ReplayingTheSameTrace_PublishesTheSameMessages()
     {
-        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 23).Generate(400);
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 400, seed: 23);
 
         var first = PublishAll(trace);
         var second = PublishAll(trace);

--- a/tests/Circus.Tests/Sequencing/InstrumentGroupTests.cs
+++ b/tests/Circus.Tests/Sequencing/InstrumentGroupTests.cs
@@ -1,8 +1,8 @@
 using Circus.Actions;
+using Circus.Agents;
 using Circus.MarketData;
 using Circus.Sequencing;
 using Circus.Sessions;
-using Circus.Simulator;
 using NUnit.Framework;
 
 namespace Circus.Tests.Sequencing;
@@ -116,7 +116,7 @@ public class InstrumentGroupTests
     [Test]
     public void Replay_Run_Convenience_ProducesSameResultAsManualWiring()
     {
-        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 42).Generate(200);
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 200, seed: 42);
 
         // Manual wiring
         var manual = new InstrumentGroup(Day);

--- a/tests/Circus.Tests/Sequencing/ReplayTests.cs
+++ b/tests/Circus.Tests/Sequencing/ReplayTests.cs
@@ -1,8 +1,8 @@
 using Circus.Actions;
+using Circus.Agents;
 using Circus.Events;
 using Circus.Sequencing;
 using Circus.Sessions;
-using Circus.Simulator;
 using Circus.Tests.Helpers;
 using NUnit.Framework;
 
@@ -57,15 +57,15 @@ public class ReplayTests
     {
         // arrange - a trace long enough, and mixed enough, that a difference in tie-breaking
         // would show up somewhere in it
-        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 99).Generate(400);
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 400, seed: 99);
 
         // act
         var streamed = new List<string>();
-        var streamedSequencer = Venue();
+        var streamedSequencer = Venue(trace);
         Replay.Run(streamedSequencer, trace, d => streamed.Add(Describe(d)));
 
         var upFront = new List<string>();
-        var upFrontSequencer = Venue();
+        var upFrontSequencer = Venue(trace);
         foreach (var action in trace)
             upFrontSequencer.Submit(action);
         foreach (var d in upFrontSequencer.AdvanceTo(trace[^1].Time))
@@ -83,14 +83,14 @@ public class ReplayTests
     public void Run_TwiceOverTheSameTrace_ReproducesItExactly()
     {
         // arrange
-        var trace = new OrderFlowSimulator(new[] {Gold, Silver}, seed: 4).Generate(400);
+        var trace = AgentTrace.Record(new[] {Gold, Silver}, 400, seed: 4);
 
         // act
         var first = new List<string>();
-        Replay.Run(Venue(), trace, d => first.Add(Describe(d)));
+        Replay.Run(Venue(trace), trace, d => first.Add(Describe(d)));
 
         var second = new List<string>();
-        Replay.Run(Venue(), trace, d => second.Add(Describe(d)));
+        Replay.Run(Venue(trace), trace, d => second.Add(Describe(d)));
 
         // assert - the same events, timestamps included, which is what a journal of the trace
         // would be worth
@@ -160,16 +160,23 @@ public class ReplayTests
         Assert.AreEqual(At(12, 0), sequencer.LogicalNow);
     }
 
-    // A simulator trace steps a millisecond per action, so 400 of them span 400ms and an ordinary
-    // day's boundaries would leave only the pre-open falling inside it. Compressed so all three
-    // land in the middle of the flow instead: a transition sharing an instant with client flow is
-    // the tie the ordering has to get right, and one at the very start barely tests it.
-    private static Sequencer Venue()
+    // A day compressed into the trace's own span, so all three boundaries fall among the client
+    // flow rather than either side of it. That interleaving is the whole point of these two tests:
+    // a schedule transition tying with an action is exactly where streaming and submitting up
+    // front could disagree.
+    //
+    // Derived from the trace rather than written as fixed instants, because how long a trace of n
+    // actions lasts is a property of whatever produced it - agents write as many actions in a
+    // millisecond as they feel like, where the simulator wrote exactly one.
+    private static Sequencer Venue(IReadOnlyList<OrderBookAction> trace)
     {
+        var start = trace[0].Time;
+        var span = trace[^1].Time - start;
+
         var compressed = new MarketSchedule(
-            new TimeSpan(0, 0, 9, 0, 50),
-            new TimeSpan(0, 0, 9, 0, 150),
-            new TimeSpan(0, 0, 9, 0, 300));
+            (start + span * 0.25).TimeOfDay,
+            (start + span * 0.5).TimeOfDay,
+            (start + span * 0.9).TimeOfDay);
 
         var sequencer = new Sequencer(Day);
         sequencer.Add(new OrderBook(Gold), compressed);


### PR DESCRIPTION
Step 3 of replacing `OrderFlowSimulator`. This is the one that makes the simulator unused — step 4 deletes it.

## Why an adapter is needed at all

Agents produce flow in a **closed loop**: they have to see what the venue did before deciding what to send next. Every consumer of a trace wants the **opposite** — a list of actions with nothing in the loop at all. `AgentTrace.Record` is the adapter between the two.

That's not incidental for two of them. The benchmark measures the book, not the agents, so the recording has to happen outside the measured region. And `ReplayTests`/`ChannelFromDispatchTests` test `Replay` itself — you cannot check that a recording reproduces a run using something that regenerates its input.

## What it records

Client flow and only client flow. The venue's own opening isn't recorded and neither are schedule transitions, because **how a consumer's books come to be open is its own decision** — the one every caller already makes for itself today.

Actions are stamped with the instant the driver is about to stamp them with. This matters: a sequencer refuses an action with no time on it, so recording the raw return value would produce a trace that cannot be replayed.

Defaults are chosen for **coverage rather than realism** — the difference between a trace generator and a market maker. A trace wants prints and market orders in it, which a patient quoting agent produces very few of.

## Two call sites needed more than a swap

**The benchmark** records once for the longest run and takes prefixes for the shorter ones. This is not a change in what's measured: a trace is sequential from its seed, so today's `Generate(1_000)` is already the prefix of `Generate(10_000)`. What changes is that we no longer record 111k actions to measure 111k.

**`ReplayTests`** compressed a trading day into fixed instants — `09:00:00.050`, `.150`, `.300` — chosen so the boundaries fell inside a trace that stepped exactly a millisecond per action. Agents write as many actions in a millisecond as they like, so those instants would now fall past the end of the trace and the interleaving the test exists for would quietly stop happening. The boundaries are derived from the trace's own span instead, which is what the test meant all along and no longer depends on the cadence of whatever wrote the trace.

## Tests

`AgentTraceTests` covers: a seed reproduces a recording; exact action counts including ones landing mid-tick; every action stamped; time never runs backwards (and repeated instants are *expected* now — that's the tie the sequencer exists to settle); instruments interleaved; every update and cancel names an order that company created in that instrument; ids unique per `(CompanyId, ClientOrderId)`; more than one company in the trace at all (the simulator minted one per order); the full action vocabulary present; and a replayed recording reproducing identical market data with trades in it.

## One deliberate red run

The fingerprint test — pinning one seed's recording so behaviour changes have to be deliberate — needs a golden hash I can't compute here (no .NET SDK in this environment; the network policy denies the download). It's committed with a placeholder that **will fail on the first CI run and print the real value**, which I'll then commit. One red run, on purpose, then green.

Benchmark numbers move: different flow, different depth, different fill rate. Expected and already flagged in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q374B1uy3jQDCnsazkUC5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q374B1uy3jQDCnsazkUC5a)_