### PR TITLE
Publish a snapshot feed, so a subscriber can join or recover

### DIFF
--- a/src/Circus/Actions/OrderBookAction.cs
+++ b/src/Circus/Actions/OrderBookAction.cs
@@ -47,6 +47,16 @@ public sealed record HaltTrading : OrderBookAction;
 // why it declares no members of its own.
 public sealed record AdvanceTime : OrderBookAction;
 
+// Report the current state of the book, as a snapshot feed does on its cycle. Changes nothing:
+// the book answers with a BookSnapshot describing where it already is, which is the one thing a
+// subscriber joining mid-session cannot derive from a stream it did not hear the start of.
+//
+// An action rather than a query, for the reason everything else here is one - it goes through the
+// sequencer like any other, so a snapshot lands at a defined point in the dispatch order and a
+// replay of the action stream reproduces the snapshot feed along with everything else. Carries
+// nothing but the Time every action carries.
+public sealed record PublishSnapshot : OrderBookAction;
+
 public abstract record OrderAction : OrderBookAction
 {
     public required string CompanyId { get; init; }

--- a/src/Circus/Events/OrderBookEvent.cs
+++ b/src/Circus/Events/OrderBookEvent.cs
@@ -1,3 +1,5 @@
+using Circus.MarketData;
+
 namespace Circus.Events;
 
 public record OrderBookEvent(string Symbol, DateTime Time);
@@ -163,4 +165,45 @@ public record LevelsChanged(string Symbol, DateTime Time, IReadOnlyList<LevelCha
     public override string ToString() =>
         $"{nameof(LevelsChanged)} {{ Symbol = {Symbol}, Time = {Time:O}, " +
         $"Changes = [{string.Join(", ", Changes)}] }}";
+}
+
+// Where the book is right now, rather than what just changed about it - the answer to a
+// PublishSnapshot, and the only event here that describes state instead of a transition.
+//
+// It exists because some of what a subscriber holds cannot be derived from a stream it joined
+// late. Aggregated depth is the obvious part; the instrument's status is the subtler one, since a
+// status change and a limit lock arrive as separate events and a joiner has heard neither. Both
+// are carried here, so a snapshot feed can republish them and a subscriber can start from
+// something true. That is what CME's snapshot does, carrying instrument status alongside the book.
+//
+// Levels are the published window, ten deep, in displayed size - the same aggregate LevelsChanged
+// reports moves to.
+public record BookSnapshot(string Symbol, DateTime Time, IReadOnlyList<Level> Bids,
+        IReadOnlyList<Level> Offers, OrderBookStatus Status, OrderBookStatusChangeReason StatusReason,
+        DateTime? ResumesAt, Side? LimitState, decimal? IndicativePrice, int IndicativeQuantity)
+    : OrderBookEvent(Symbol, Time)
+{
+    // Spelled out for the reason LevelsChanged spells them out: a record's generated equality
+    // compares a list member by reference, and DeterminismTests asserts a replay reproduces every
+    // event by value.
+    public virtual bool Equals(BookSnapshot? other) =>
+        other is not null
+        && EqualityContract == other.EqualityContract
+        && Symbol == other.Symbol
+        && Time == other.Time
+        && Status == other.Status
+        && StatusReason == other.StatusReason
+        && ResumesAt == other.ResumesAt
+        && LimitState == other.LimitState
+        && IndicativePrice == other.IndicativePrice
+        && IndicativeQuantity == other.IndicativeQuantity
+        && Bids.SequenceEqual(other.Bids)
+        && Offers.SequenceEqual(other.Offers);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Symbol, Time, Status, Bids.Count, Offers.Count, IndicativePrice);
+
+    public override string ToString() =>
+        $"{nameof(BookSnapshot)} {{ Symbol = {Symbol}, Time = {Time:O}, Status = {Status}, " +
+        $"Bids = [{string.Join(", ", Bids)}], Offers = [{string.Join(", ", Offers)}] }}";
 }

--- a/src/Circus/MarketData/ChannelMessage.cs
+++ b/src/Circus/MarketData/ChannelMessage.cs
@@ -1,6 +1,14 @@
 namespace Circus.MarketData;
 
-// One message as it leaves a channel. Sequence is that channel's own contiguous count, so a
-// subscriber that sees it skip has missed something - which is the only reason to number
-// messages at all.
-public readonly record struct ChannelMessage(long Sequence, MarketDataEvent Data);
+// One message as it leaves a channel. Sequence is that stream's own contiguous count, so a
+// subscriber that sees it skip has missed something - which is the only reason to number messages
+// at all.
+//
+// AsOfSequence is what makes the two streams reconcilable, and is the whole mechanism rather than
+// a convenience: it is the incremental sequence a snapshot is consistent as of - CME carries it as
+// LastMsgSeqNumProcessed - so a subscriber joining mid-session buffers the incremental stream,
+// waits for a snapshot, applies it, discards the buffered messages up to and including that
+// number, then applies the rest and stops reading snapshots. Zero on an incremental message, which
+// is consistent as of itself.
+public readonly record struct ChannelMessage(long Sequence, MarketDataEvent Data,
+    ChannelStream Stream = ChannelStream.Incremental, long AsOfSequence = 0);

--- a/src/Circus/MarketData/ChannelStream.cs
+++ b/src/Circus/MarketData/ChannelStream.cs
@@ -1,0 +1,14 @@
+namespace Circus.MarketData;
+
+// Which of a channel's two streams a message belongs to. They are numbered independently, because
+// a subscriber in sync reads only the first and would otherwise see its sequence jump every cycle
+// - and a gap it cannot tell from a loss is worth nothing.
+public enum ChannelStream
+{
+    // What changed. Contiguous, and the stream a subscriber counts to know it has missed nothing.
+    Incremental,
+
+    // Where the book is. Published on the venue's snapshot cycle, and read only by a subscriber
+    // joining or recovering.
+    Snapshot
+}

--- a/src/Circus/MarketData/InstrumentFeed.cs
+++ b/src/Circus/MarketData/InstrumentFeed.cs
@@ -25,6 +25,13 @@ public sealed class InstrumentFeed
     private readonly IndicativePriceDataProducer _indicative = new();
     private readonly InstrumentStatusDataProducer _status = new();
 
+    // The other half of what a venue publishes, on its own stream: where the book is, rather than
+    // what changed about it. Each republishes the same message type its incremental counterpart
+    // does, so a subscriber applies a snapshot the same way it applies an update.
+    private readonly MarketByPriceSnapshotProducer _levelsSnapshot = new();
+    private readonly InstrumentStatusSnapshotProducer _statusSnapshot = new();
+    private readonly IndicativePriceSnapshotProducer _indicativeSnapshot = new();
+
     public InstrumentFeed(string symbol)
     {
         Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
@@ -48,6 +55,26 @@ public sealed class InstrumentFeed
         Collect(ref output, _levels.Process(events));
         Collect(ref output, _orderByOrder.Process(events));
         Collect(ref output, _indicative.Process(events));
+
+        return output ?? (IReadOnlyList<MarketDataEvent>) Array.Empty<MarketDataEvent>();
+    }
+
+    // The snapshot half, kept a separate call rather than a second return value because the two
+    // streams are numbered separately and published independently - a subscriber in sync reads
+    // only the incremental one, and a channel is free to carry no snapshot feed at all.
+    //
+    // A dispatch that is not a snapshot tick produces nothing here, so the common path costs three
+    // scans that find nothing rather than a branch the caller has to know to take.
+    public IReadOnlyList<MarketDataEvent> Snapshot(IReadOnlyList<OrderBookEvent> events)
+    {
+        if (events.Count == 0)
+            return Array.Empty<MarketDataEvent>();
+
+        List<MarketDataEvent>? output = null;
+
+        Collect(ref output, _statusSnapshot.Process(events));
+        Collect(ref output, _levelsSnapshot.Process(events));
+        Collect(ref output, _indicativeSnapshot.Process(events));
 
         return output ?? (IReadOnlyList<MarketDataEvent>) Array.Empty<MarketDataEvent>();
     }

--- a/src/Circus/MarketData/LevelBook.cs
+++ b/src/Circus/MarketData/LevelBook.cs
@@ -38,6 +38,30 @@ public sealed class LevelBook
     // consistent state to another, and applying it a level at a time would leave anything reading
     // this between them looking at a book that never existed - a swept level gone with the
     // aggressor's remainder not yet arrived.
+    // Starts again from a snapshot, discarding whatever was here. This is how a subscriber joins
+    // mid-session or comes back from a gap: it cannot patch its way to the truth from a stream it
+    // did not hear the start of, so it takes the image whole and applies the incrementals that
+    // follow it.
+    //
+    // Replaces rather than merges, and that is the point - a level this held and the snapshot does
+    // not is a level that is gone, not one the snapshot forgot to mention. Merging would leave a
+    // recovering subscriber holding whatever it was wrong about.
+    public void Reset(LevelsDataEvent snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        _bids.Clear();
+        _offers.Clear();
+
+        foreach (var level in snapshot.Bids)
+            _bids[level.Price] = (level.Quantity, level.Count);
+        foreach (var level in snapshot.Offers)
+            _offers[level.Price] = (level.Quantity, level.Count);
+
+        _bidLevels = Materialize(_bids);
+        _offerLevels = Materialize(_offers);
+    }
+
     public void Apply(MarketByPriceDeltaEvent message)
     {
         ArgumentNullException.ThrowIfNull(message);

--- a/src/Circus/MarketData/MarketDataChannel.cs
+++ b/src/Circus/MarketData/MarketDataChannel.cs
@@ -28,9 +28,16 @@ public sealed class MarketDataChannel
     private readonly Dictionary<string, InstrumentFeed> _feeds = new();
 
     private long _sequence;
+    private long _snapshotSequence;
 
     // What a subscriber has seen so far, so a caller resuming one can say where it got to.
     public long Sequence => _sequence;
+
+    // The snapshot stream's own count, numbered apart from the incremental one. A subscriber in
+    // sync never reads it, and would otherwise watch its sequence jump by a cycle's worth of
+    // messages it deliberately ignored - a gap indistinguishable from a loss, which is the one
+    // thing numbering is for.
+    public long SnapshotSequence => _snapshotSequence;
 
     public void Add(InstrumentFeed feed)
     {
@@ -64,6 +71,17 @@ public sealed class MarketDataChannel
             {
                 output ??= new List<ChannelMessage>();
                 output.Add(new ChannelMessage(++_sequence, data));
+            }
+
+            // After the incrementals of the same dispatch, and stamped with the incremental
+            // sequence as it stands once they are published. That number is the whole mechanism:
+            // it is what a joining subscriber discards its buffer up to, and it can only be right
+            // if the snapshot is numbered after everything it already reflects.
+            foreach (var data in feed.Snapshot(forInstrument))
+            {
+                output ??= new List<ChannelMessage>();
+                output.Add(new ChannelMessage(++_snapshotSequence, data, ChannelStream.Snapshot,
+                    _sequence));
             }
         }
 

--- a/src/Circus/MarketData/SnapshotProducers.cs
+++ b/src/Circus/MarketData/SnapshotProducers.cs
@@ -1,0 +1,79 @@
+using Circus.Events;
+
+namespace Circus.MarketData;
+
+// The snapshot feed, as a translation of the BookSnapshot the book answers a snapshot tick with.
+//
+// Each of these republishes exactly the message type its incremental counterpart publishes, so a
+// subscriber applies a snapshot the same way it applies an update and needs no second code path -
+// the difference is which stream it arrived on and the sequence it declares itself consistent as
+// of, both of which the channel carries. CME draws it the same way: the snapshot is a different
+// message on a different feed, carrying the same fields.
+//
+// One class per product rather than one producing all three, because a channel carrying only
+// depth should be able to leave the rest out - the same reason InstrumentFeed is a bundle of
+// producers rather than one that does everything.
+public class MarketByPriceSnapshotProducer : IIncrementalProducer<LevelsDataEvent>
+{
+    public IList<LevelsDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    {
+        List<LevelsDataEvent>? output = null;
+
+        foreach (var ev in events)
+        {
+            if (ev is not BookSnapshot snapshot)
+                continue;
+
+            output ??= new List<LevelsDataEvent>();
+            output.Add(new LevelsDataEvent(snapshot.Symbol, snapshot.Time, snapshot.Bids, snapshot.Offers));
+        }
+
+        return output ?? (IList<LevelsDataEvent>) Array.Empty<LevelsDataEvent>();
+    }
+}
+
+// The composite a joiner cannot rebuild: a status change and a limit lock arrive as separate
+// events at separate times, so a subscriber that heard neither has no way to assemble them. This
+// is what makes InstrumentStatusDataProducer's accumulator recoverable rather than merely stateful.
+public class InstrumentStatusSnapshotProducer : IIncrementalProducer<InstrumentStatusDataEvent>
+{
+    public IList<InstrumentStatusDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    {
+        List<InstrumentStatusDataEvent>? output = null;
+
+        foreach (var ev in events)
+        {
+            if (ev is not BookSnapshot snapshot)
+                continue;
+
+            output ??= new List<InstrumentStatusDataEvent>();
+            output.Add(new InstrumentStatusDataEvent(snapshot.Symbol, snapshot.Time, snapshot.Status,
+                snapshot.StatusReason, snapshot.ResumesAt, snapshot.LimitState));
+        }
+
+        return output ?? (IList<InstrumentStatusDataEvent>) Array.Empty<InstrumentStatusDataEvent>();
+    }
+}
+
+// Published on the cycle even when there is no quote, so a null price restates that the book is
+// not crossing rather than leaving a joiner to assume it. The incremental feed says the same thing
+// by emitting a withdrawal, which is a message a late subscriber never heard.
+public class IndicativePriceSnapshotProducer : IIncrementalProducer<IndicativePriceDataEvent>
+{
+    public IList<IndicativePriceDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    {
+        List<IndicativePriceDataEvent>? output = null;
+
+        foreach (var ev in events)
+        {
+            if (ev is not BookSnapshot snapshot)
+                continue;
+
+            output ??= new List<IndicativePriceDataEvent>();
+            output.Add(new IndicativePriceDataEvent(snapshot.Symbol, snapshot.Time,
+                snapshot.IndicativePrice, snapshot.IndicativeQuantity));
+        }
+
+        return output ?? (IList<IndicativePriceDataEvent>) Array.Empty<IndicativePriceDataEvent>();
+    }
+}

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -20,6 +20,11 @@ public class OrderBook : IOrderBook
 
     private OrderBookStatus _status = OrderBookStatus.Closed;
 
+    // Why the book is in that status, kept beside it so a snapshot can restate the whole composite
+    // rather than the half of it a status alone carries. Starts where a book starts: closed
+    // because nobody has opened it yet, which is a request rather than anything having happened.
+    private OrderBookStatusChangeReason _statusReason = OrderBookStatusChangeReason.Requested;
+
     // The last action's stamp, kept only to refuse one that moves time backwards. Set from the
     // first action, so a book has no opinion about what time it is until something tells it.
     private DateTime _lastActionTime;
@@ -265,6 +270,12 @@ public class OrderBook : IOrderBook
             // Carries nothing and does nothing: the work is the due-interruption check every
             // Process already runs, and this is how a caller with no order flow reaches it.
             AdvanceTime => new List<OrderBookEvent>(),
+
+            // Changes nothing either - it reports where the action stream has already left the
+            // book. Note this runs after ResumeIfDue in Process, so a snapshot tick arriving past
+            // a resume deadline describes the resumed book rather than the paused one, and the
+            // resumption itself is reported ahead of it as an ordinary status change.
+            PublishSnapshot => new List<OrderBookEvent> {Snapshot(time)},
             _ => throw new ArgumentException("Unknown order book action")
         };
     }
@@ -427,6 +438,20 @@ public class OrderBook : IOrderBook
     }
 
     private decimal ToDecimal(long ticks) => ticks * _instrument.TickSize;
+
+    // Everything a subscriber joining mid-session cannot derive from a stream it did not hear the
+    // start of: the published depth, and the composite the book assembles from separate events -
+    // status with its reason and any pending resumption, the limit state, the auction quote.
+    //
+    // Not the trades. A print is a thing that happened rather than a state the book is in, and a
+    // joiner does not need the last one to be correct from here on; it simply starts hearing them.
+    // The same goes for order-by-order, which gets a snapshot of its own once it has one to give.
+    private BookSnapshot Snapshot(DateTime time) =>
+        new(_instrument.Symbol, time,
+            GetLevels(Side.Buy, PublishedDepth), GetLevels(Side.Sell, PublishedDepth),
+            _status, _statusReason, _resumeAt, _limitState,
+            _indicativeQuote is { } quote ? ToDecimal(quote.PriceTicks) : null,
+            _indicativeQuote?.Quantity ?? 0);
 
     private void CaptureWindow(List<(long Tick, int Quantity, int Count)> into, Side side) =>
         _matcher.Working[side].CopyLevelsFromBest(PublishedDepth, into);
@@ -963,7 +988,8 @@ public class OrderBook : IOrderBook
                     ? OrderBookStatus.Halted
                     : OrderBookStatus.Paused;
                 _resumeAt = breach.ResumeAfter.HasValue ? time + breach.ResumeAfter.Value : null;
-                events.Add(new StatusChanged(_instrument.Symbol, time, _status, OrderBookStatusChangeReason.PriceRestriction,
+                _statusReason = OrderBookStatusChangeReason.PriceRestriction;
+                events.Add(new StatusChanged(_instrument.Symbol, time, _status, _statusReason,
                     _resumeAt));
                 break;
 
@@ -1143,8 +1169,9 @@ public class OrderBook : IOrderBook
             // is unchanged and re-reported: what a subscriber needs to know is that the
             // interruption is still running and why, which is the same thing a fresh one says.
             _resumeAt = extension.Value.ResumeAfter.HasValue ? time + extension.Value.ResumeAfter.Value : null;
+            _statusReason = OrderBookStatusChangeReason.PriceRestriction;
             return new List<OrderBookEvent>
-                {new StatusChanged(_instrument.Symbol, time, _status, OrderBookStatusChangeReason.PriceRestriction, _resumeAt)};
+                {new StatusChanged(_instrument.Symbol, time, _status, _statusReason, _resumeAt)};
         }
 
         // Any transition supersedes a pending one, so a session closing over a running pause
@@ -1176,6 +1203,7 @@ public class OrderBook : IOrderBook
 
         // _resumeAt was cleared above, so this reports nothing pending - which is what an
         // explicit transition means, having just superseded whatever was.
+        _statusReason = reason;
         var events = new List<OrderBookEvent> {new StatusChanged(_instrument.Symbol, time, _status, reason, _resumeAt)};
 
         // A quoting phase has been accumulating orders for a print, and leaving it is where

--- a/src/Circus/Sequencing/DispatchKind.cs
+++ b/src/Circus/Sequencing/DispatchKind.cs
@@ -17,5 +17,10 @@ internal enum DispatchKind
     InterruptionTick,
 
     // Last, ordered among itself by submission counter.
-    ClientFlow
+    ClientFlow,
+
+    // After client flow at the same instant, because a snapshot describes where an instant left
+    // the book rather than where it found it - an order stamped exactly on the cycle belongs in
+    // the snapshot that follows it, not the one before.
+    SnapshotTick
 }

--- a/src/Circus/Sequencing/InstrumentGroup.cs
+++ b/src/Circus/Sequencing/InstrumentGroup.cs
@@ -18,9 +18,12 @@ public sealed class InstrumentGroup
     private readonly MarketDataChannel _channel;
     private readonly List<string> _symbols = new();
 
-    public InstrumentGroup(DateTime start)
+    // snapshotInterval is how often each book restates itself on the channel's snapshot stream.
+    // Null publishes no snapshot feed, which leaves a subscriber unable to join mid-session or
+    // recover from a gap - the position everything here was in before there was one.
+    public InstrumentGroup(DateTime start, TimeSpan? snapshotInterval = null)
     {
-        _sequencer = new Sequencer(start);
+        _sequencer = new Sequencer(start, snapshotInterval);
         _channel = new MarketDataChannel();
     }
 

--- a/src/Circus/Sequencing/Sequencer.cs
+++ b/src/Circus/Sequencing/Sequencer.cs
@@ -53,9 +53,19 @@ public sealed class Sequencer
     private long _sequence;
     private DateTime _now;
 
-    public Sequencer(DateTime start)
+    // How often each book is asked to describe itself, or null for a venue that publishes no
+    // snapshot feed. Logical, never wall-clock: a replay reproduces the snapshots along with
+    // everything else because the ticks come from the same queue as every other action.
+    private readonly TimeSpan? _snapshotInterval;
+
+    public Sequencer(DateTime start, TimeSpan? snapshotInterval = null)
     {
+        if (snapshotInterval is { } interval && interval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(snapshotInterval), interval,
+                "a snapshot cycle must move forward");
+
         _now = start;
+        _snapshotInterval = snapshotInterval;
     }
 
     // Everything at or before this instant has been dispatched, so nothing may be inserted there
@@ -77,6 +87,7 @@ public sealed class Sequencer
                 $"a book is already registered for {book.Symbol}", nameof(book));
 
         QueueNextTransition(book.Symbol, schedule, _now);
+        QueueNextSnapshot(book.Symbol, _now);
     }
 
     // Queues client flow at its own stamp.
@@ -138,6 +149,11 @@ public sealed class Sequencer
             if (next.Kind == DispatchKind.ScheduleTransition)
                 QueueNextTransition(action.Symbol, schedule, next.Time);
 
+            // Queued one ahead, like a schedule boundary, so the queue holds a single pending tick
+            // per book however long the run.
+            if (next.Kind == DispatchKind.SnapshotTick)
+                QueueNextSnapshot(action.Symbol, next.Time);
+
             QueueInterruptionTicks(events, next.Time);
         }
 
@@ -169,6 +185,18 @@ public sealed class Sequencer
                 Enqueue(new AdvanceTime {Symbol = status.Symbol, Time = resumesAt},
                     DispatchKind.InterruptionTick);
         }
+    }
+
+    // Every book on its own interval from where it was registered, all of them due together on a
+    // shared start. A real venue rotates instead, spreading its instruments across the cycle to
+    // flatten the bandwidth of a feed nobody in sync is reading - which is a wire concern this has
+    // no equivalent of, and rotating here would only make the cycle harder to reason about.
+    private void QueueNextSnapshot(string symbol, DateTime after)
+    {
+        if (_snapshotInterval is not { } interval) return;
+
+        Enqueue(new PublishSnapshot {Symbol = symbol, Time = after + interval},
+            DispatchKind.SnapshotTick);
     }
 
     private void QueueNextTransition(string symbol, MarketSchedule schedule, DateTime after)

--- a/tests/Circus.Tests/MarketData/SnapshotRecoveryTests.cs
+++ b/tests/Circus.Tests/MarketData/SnapshotRecoveryTests.cs
@@ -1,0 +1,185 @@
+using Circus.Actions;
+using Circus.Agents;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using NUnit.Framework;
+
+namespace Circus.Tests.MarketData;
+
+// What the snapshot feed is for. Every producer here holds either nothing or a composite it cannot
+// rebuild, so the only answer to a subscriber that joined late or missed a message is a feed that
+// periodically restates the truth. These assert it actually works, rather than that the messages
+// have the right shape - which is the easy half.
+//
+// Driven off a recorded agent run rather than a hand-built sequence: recovery has to hold against
+// churn it was not written for - repricing, icebergs replenishing, levels leaving the window and
+// coming back - and a scripted trace only ever tests the cases someone thought of.
+public class SnapshotRecoveryTests
+{
+    private static readonly Instrument Bench = new("BENCH", TickSize: 1);
+
+    // Out of the way of a trace that starts at 09:00, so no session boundary lands inside the run.
+    private static readonly MarketSchedule OutOfTheWay =
+        new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
+
+    private static IReadOnlyList<ChannelMessage> Run(TimeSpan? snapshotInterval, int actions = 400)
+    {
+        var trace = AgentTrace.Record(Bench, actions, seed: 4242);
+
+        var group = new InstrumentGroup(trace[0].Time, snapshotInterval);
+        group.Add(Bench, OutOfTheWay);
+        group.Submit(new OpenTrading {Symbol = Bench.Symbol, Time = trace[0].Time});
+
+        return Replay.Run(group, trace);
+    }
+
+    private static List<ChannelMessage> Of(IEnumerable<ChannelMessage> messages, ChannelStream stream) =>
+        messages.Where(m => m.Stream == stream).ToList();
+
+    [Test]
+    public void NoInterval_PublishesNoSnapshots()
+    {
+        var messages = Run(snapshotInterval: null);
+
+        Assert.IsNotEmpty(Of(messages, ChannelStream.Incremental), "the feed still runs");
+        Assert.IsEmpty(Of(messages, ChannelStream.Snapshot),
+            "a venue that publishes no snapshot feed publishes none");
+    }
+
+    [Test]
+    public void EachStream_IsNumberedContiguouslyAndOnItsOwn()
+    {
+        var messages = Run(TimeSpan.FromMilliseconds(50));
+
+        var incremental = Of(messages, ChannelStream.Incremental).Select(m => m.Sequence).ToList();
+        var snapshots = Of(messages, ChannelStream.Snapshot).Select(m => m.Sequence).ToList();
+
+        Assert.IsNotEmpty(snapshots, "the cycle should have come round during the run");
+        Assert.AreEqual(Enumerable.Range(1, incremental.Count).Select(i => (long) i).ToList(), incremental,
+            "a subscriber counting the incremental stream must see no gap");
+        Assert.AreEqual(Enumerable.Range(1, snapshots.Count).Select(i => (long) i).ToList(), snapshots,
+            "and the snapshot stream is numbered apart, not carved out of the same run");
+    }
+
+    [Test]
+    public void ASnapshot_IsConsistentAsOfAnIncrementalAlreadyPublished()
+    {
+        var messages = Run(TimeSpan.FromMilliseconds(50));
+
+        var publishedSoFar = 0L;
+        var checkedAny = false;
+
+        foreach (var message in messages)
+        {
+            if (message.Stream == ChannelStream.Incremental)
+            {
+                publishedSoFar = message.Sequence;
+                continue;
+            }
+
+            checkedAny = true;
+            Assert.AreEqual(publishedSoFar, message.AsOfSequence,
+                "a snapshot must declare itself consistent as of everything published before it, " +
+                "or a subscriber discarding its buffer up to that number drops messages it needs");
+        }
+
+        Assert.IsTrue(checkedAny);
+    }
+
+    // The whole mechanism, end to end. A subscriber that starts late buffers the incremental
+    // stream, waits for a snapshot, applies it, discards the buffered messages up to and including
+    // the sequence that snapshot declares, applies the rest, and carries on. If that is right it
+    // ends up holding exactly what a subscriber who heard the whole session holds.
+    [TestCase(0.25)]
+    [TestCase(0.5)]
+    [TestCase(0.75)]
+    public void ASubscriberJoiningLate_RecoversToWhatEveryoneElseHolds(double joinFraction)
+    {
+        var messages = Run(TimeSpan.FromMilliseconds(50));
+        var joinAt = (int) (messages.Count * joinFraction);
+
+        // Heard everything: incrementals alone, which is what being in sync means.
+        var everything = new LevelBook();
+        foreach (var message in Of(messages, ChannelStream.Incremental))
+            Apply(everything, message);
+
+        // Joined at joinAt, hearing nothing before it.
+        var late = new LevelBook();
+        var buffered = new List<ChannelMessage>();
+        var synced = false;
+
+        foreach (var message in messages.Skip(joinAt))
+        {
+            if (message.Stream == ChannelStream.Snapshot)
+            {
+                if (synced || message.Data is not LevelsDataEvent image)
+                    continue;
+
+                late.Reset(image);
+
+                // Everything the snapshot already reflects is dropped; the rest is replayed onto
+                // it, in order.
+                foreach (var pending in buffered.Where(m => m.Sequence > message.AsOfSequence))
+                    Apply(late, pending);
+
+                buffered.Clear();
+                synced = true;
+                continue;
+            }
+
+            if (synced)
+                Apply(late, message);
+            else
+                buffered.Add(message);
+        }
+
+        Assert.IsTrue(synced, "a snapshot should have come round after the join point");
+        Assert.AreEqual(everything.Bids, late.Bids,
+            "a recovered subscriber holds a different book from one that heard everything (bids)");
+        Assert.AreEqual(everything.Offers, late.Offers,
+            "a recovered subscriber holds a different book from one that heard everything (offers)");
+        Assert.IsNotEmpty(everything.Bids, "and the comparison is not of two empty books");
+    }
+
+    // The composite no incremental message carries whole: a joiner never heard the StatusChanged
+    // that opened the book, and learns the status from the snapshot instead.
+    [Test]
+    public void ASnapshot_RestatesTheStatusAJoinerNeverHeard()
+    {
+        var messages = Run(TimeSpan.FromMilliseconds(50));
+
+        var firstStatusIncremental = Of(messages, ChannelStream.Incremental)
+            .Select(m => m.Data).OfType<InstrumentStatusDataEvent>().First();
+        var statusFromSnapshot = Of(messages, ChannelStream.Snapshot)
+            .Select(m => m.Data).OfType<InstrumentStatusDataEvent>().ToList();
+
+        Assert.IsNotEmpty(statusFromSnapshot,
+            "the snapshot stream carries the status composite, not only depth");
+        Assert.AreEqual(OrderBookStatus.Open, firstStatusIncremental.Status);
+        Assert.IsTrue(statusFromSnapshot.All(s => s.Status == OrderBookStatus.Open),
+            "and it restates where the book actually is, so a joiner does not have to guess");
+    }
+
+    // Snapshots are dispatched actions like everything else, so a replay of the same trace
+    // produces the same feed - the property that would have been lost had a snapshot been built by
+    // asking the book instead of by going through the stream.
+    [Test]
+    public void ReplayingATrace_ReproducesTheSnapshotFeedToo()
+    {
+        var first = Run(TimeSpan.FromMilliseconds(50));
+        var second = Run(TimeSpan.FromMilliseconds(50));
+
+        Assert.IsNotEmpty(Of(first, ChannelStream.Snapshot));
+        Assert.AreEqual(Render(first), Render(second));
+    }
+
+    private static void Apply(LevelBook book, ChannelMessage message)
+    {
+        if (message.Data is MarketByPriceDeltaEvent delta)
+            book.Apply(delta);
+    }
+
+    private static List<string> Render(IEnumerable<ChannelMessage> messages) =>
+        messages.Select(m => $"{m.Stream} {m.Sequence} {m.AsOfSequence} {m.Data}").ToList();
+}


### PR DESCRIPTION
Phase 6, and the piece the whole restructure has been building toward. Every producer until now could be handed a stream it didn't hear the start of and had no way back; this is what makes them recoverable.

## A snapshot is an action, not a query

The sequencer queues `PublishSnapshot` per book on a fixed logical interval. The book answers with a `BookSnapshot` describing where it already is. Snapshot producers translate that into **the same message types their incremental counterparts publish**, so a subscriber applies a snapshot the same way it applies an update — no second code path.

That shape is the one settled in #86 when `IBookView` was dropped, and it pays off here: because the snapshot goes through the action stream, replaying a trace reproduces the snapshot feed along with everything else. A snapshot built by querying the book would leave no trace in the stream and couldn't be replayed. There's a test for exactly that.

## What it carries

Exactly what a joiner can't derive from a stream it joined late:

- the published depth
- the composite the book assembles from separate events — status with its reason, any pending resumption, the limit state, the auction quote

**Not the trades.** A print is something that happened rather than a state the book is in; a late subscriber simply starts hearing them.

`OrderBook` now keeps `_statusReason` beside `_status`, since a status alone is half the composite. That composite is what finally makes `InstrumentStatusDataProducer`'s accumulator recoverable rather than merely stateful.

## Two streams, numbered apart

`ChannelMessage` gains `Stream` and `AsOfSequence`. A subscriber in sync reads only the incremental stream and would otherwise watch its sequence jump by a cycle's worth of messages it deliberately ignored — a gap indistinguishable from a loss, which is the one thing numbering is for.

`AsOfSequence` is the incremental sequence a snapshot is consistent as of, stamped *after* the incrementals of its own dispatch. That's CME's `LastMsgSeqNumProcessed`, and it's what a joining subscriber discards its buffer up to.

## The gap the tests found

Writing the join protocol found what it was written to find: **`LevelBook` could apply deltas but had no way to start from an image**, so the feed was publishable and unconsumable. `Reset` takes one whole, replacing rather than merging — a level the subscriber held that the snapshot doesn't mention is gone, not forgotten, and merging would leave a recovering subscriber holding exactly what it was wrong about.

The central test drives a recorded agent run through a channel with a snapshot cycle, then has a subscriber join a quarter, half and three-quarters of the way through, follow the protocol, and end up holding exactly the book a subscriber who heard the whole session holds.

Off a recorded run rather than a scripted one because recovery has to hold against churn nobody wrote it for — repricing, peaks replenishing, levels leaving the window and coming back — and a hand-built trace only covers the cases someone thought of.

## Deliberate divergences

- **No rotation.** Every book is due together. A real venue staggers instruments to flatten the bandwidth of a feed nobody in sync is reading — a wire concern with no equivalent here, and rotating would only make the cycle harder to reason about.
- **Off by default.** No interval, no snapshot feed, and the venue behaves exactly as before.
- **`SnapshotTick` sorts after client flow** at the same instant: a snapshot describes where an instant left the book, so an order stamped exactly on the cycle belongs in the snapshot that follows it.

## Not in this PR

`MarketByOrderSnapshotProducer`, which lands with the by-order work — it now has the machinery it was waiting for.