### PR TITLE
Split what a book tells a participant from what it broadcasts

### DIFF
--- a/src/Circus/Events/OrderBookEvent.cs
+++ b/src/Circus/Events/OrderBookEvent.cs
@@ -4,6 +4,20 @@ namespace Circus.Events;
 
 public record OrderBookEvent(string Symbol, DateTime Time);
 
+// Everything a venue may broadcast, and the half of the book's output that carries no client
+// identity. A market data producer is handed these and only these, so a CompanyId reaching a
+// public feed is a compile error rather than something a reflection test has to go looking for.
+//
+// The other half is OrderEvent below: what happened to one participant's order, addressed to that
+// participant. Real venues keep the two apart at the protocol level - CME answers order entry on
+// iLink and publishes market data on MDP, Eurex uses ETI and EMDI/EOBI - and the distinction here
+// is the same one, drawn in the type system rather than across a wire.
+//
+// Both travel in one stream out of Process. That is deliberate: their interleaving is meaningful,
+// since when a participant learns of its own fill relative to when the market learns of the print
+// is exactly the sort of thing a venue simulator exists to answer.
+public abstract record MarketEvent(string Symbol, DateTime Time) : OrderBookEvent(Symbol, Time);
+
 // Reason defaults to Requested, which is what every externally driven transition is.
 //
 // ResumesAt is when a timed interruption is due to end, and is null for everything else - which
@@ -11,8 +25,12 @@ public record OrderBookEvent(string Symbol, DateTime Time);
 // transition, since an explicit one supersedes whatever was pending.
 public record StatusChanged(string Symbol, DateTime Time, OrderBookStatus Status,
         OrderBookStatusChangeReason Reason = OrderBookStatusChangeReason.Requested, DateTime? ResumesAt = null)
-    : OrderBookEvent(Symbol, Time);
+    : MarketEvent(Symbol, Time);
 
+// Addressed to one participant, and never broadcast: CompanyId and ClientOrderId identify who
+// sent the order, which is the participant's business and nobody else's. Everything private the
+// book emits descends from this, so "not a MarketEvent" and "carries client identity" are the
+// same statement.
 public record OrderEvent(string Symbol, DateTime Time, string CompanyId, string ClientOrderId,
         string? ExchangeOrderId)
     : OrderBookEvent(Symbol, Time);
@@ -98,7 +116,7 @@ public record CancelOrderRejected(string Symbol, DateTime Time, string CompanyId
 // stopped crossing, or the phase quoting it has ended. A phase that trades continuously has
 // no such price and so publishes none.
 public record IndicativePriceChanged(string Symbol, DateTime Time, decimal? Price, int Quantity)
-    : OrderBookEvent(Symbol, Time);
+    : MarketEvent(Symbol, Time);
 
 // The market has reached a daily price limit and cannot trade through it, or has come back
 // inside one. Side is which way it is stuck: Buy for limit up, where buyers cannot push higher,
@@ -109,7 +127,7 @@ public record IndicativePriceChanged(string Symbol, DateTime Time, decimal? Pric
 // is the whole difference between a limit and a circuit breaker, so it gets an event of its own
 // rather than a status that would claim otherwise. Emitted only on a change.
 public record LimitStateChanged(string Symbol, DateTime Time, Side? Side, decimal? Price)
-    : OrderBookEvent(Symbol, Time);
+    : MarketEvent(Symbol, Time);
 // One aggregated price level of the working book, as carried inside a LevelsChanged.
 //
 // Quantity is displayed size, never remaining: an iceberg's hidden reserve is not on the book.
@@ -146,7 +164,7 @@ public record LevelChange(Side Side, int LevelIndex, decimal Price, int Quantity
 //
 // Changes are ordered best price outward within a side, arrivals and changes before departures.
 public record LevelsChanged(string Symbol, DateTime Time, IReadOnlyList<LevelChange> Changes)
-    : OrderBookEvent(Symbol, Time)
+    : MarketEvent(Symbol, Time)
 {
     // Spelled out because a record's generated equality compares a list member by reference, and
     // two runs of the same trace build different list instances. DeterminismTests asserts that a
@@ -183,7 +201,7 @@ public record BookSnapshot(string Symbol, DateTime Time, IReadOnlyList<Level> Bi
         IReadOnlyList<Level> Offers, IReadOnlyList<RestingOrder> Orders, OrderBookStatus Status,
         OrderBookStatusChangeReason StatusReason, DateTime? ResumesAt, Side? LimitState,
         decimal? IndicativePrice, int IndicativeQuantity)
-    : OrderBookEvent(Symbol, Time)
+    : MarketEvent(Symbol, Time)
 {
     // Spelled out for the reason LevelsChanged spells them out: a record's generated equality
     // compares a list member by reference, and DeterminismTests asserts a replay reproduces every
@@ -210,3 +228,47 @@ public record BookSnapshot(string Symbol, DateTime Time, IReadOnlyList<Level> Bi
         $"{nameof(BookSnapshot)} {{ Symbol = {Symbol}, Time = {Time:O}, Status = {Status}, " +
         $"Bids = [{string.Join(", ", Bids)}], Offers = [{string.Join(", ", Offers)}] }}";
 }
+
+// One change to one displayed order, as carried inside an OrdersChanged.
+//
+// TradeId is set only on Filled, and pairs the two sides of one trade.
+public record OrderChange(Side Side, string ExchangeOrderId, decimal Price, int Quantity,
+    OrderChangeAction Action, string? TradeId = null);
+
+// Every change to the displayed order book one action made - the order-by-order counterpart of
+// LevelsChanged, and the public view of what the private order confirmations above did.
+//
+// Not a redaction of those confirmations, which is why it is its own event rather than a filter
+// over them. The two do not correspond one to one: a stop order created still hidden produces a
+// confirmation and nothing here; an update that lost time priority produces one confirmation and
+// two changes here, the old id leaving and a new one arriving at the back of the queue. Working
+// out which of those happened needs to know what the book did to its own queue, which is why it
+// is the book that says so.
+//
+// Quantity is displayed size for Added and Modified, what left for Removed, and what traded for
+// Filled. An iceberg's hidden reserve is never here.
+public record OrdersChanged(string Symbol, DateTime Time, IReadOnlyList<OrderChange> Changes)
+    : MarketEvent(Symbol, Time)
+{
+    public virtual bool Equals(OrdersChanged? other) =>
+        other is not null
+        && EqualityContract == other.EqualityContract
+        && Symbol == other.Symbol
+        && Time == other.Time
+        && Changes.SequenceEqual(other.Changes);
+
+    public override int GetHashCode() => HashCode.Combine(Symbol, Time, Changes.Count);
+
+    public override string ToString() =>
+        $"{nameof(OrdersChanged)} {{ Symbol = {Symbol}, Time = {Time:O}, " +
+        $"Changes = [{string.Join(", ", Changes)}] }}";
+}
+
+// The public print: one per trade, whatever it took to fill. The private half is the pair of
+// FillOrderConfirmed events sharing this TradeId, one per participant.
+//
+// Emitted by the book rather than derived by a producer from those fills, because a producer only
+// sees what a venue broadcasts and a fill is not that - it belongs to the participant whose order
+// filled. The pairing the derivation relied on is still here, in the id.
+public record TradePrinted(string Symbol, DateTime Time, string TradeId, decimal Price, int Quantity)
+    : MarketEvent(Symbol, Time);

--- a/src/Circus/Events/OrderChangeAction.cs
+++ b/src/Circus/Events/OrderChangeAction.cs
@@ -1,0 +1,18 @@
+namespace Circus.Events;
+
+public enum OrderChangeAction
+{
+    // An order now displayed that was not before - newly rested, a stop that triggered into the
+    // working book, or the far side of a requeue.
+    Added,
+
+    // A displayed order whose price or size moved without losing its place in the queue.
+    Modified,
+
+    // An order no longer displayed - cancelled, expired, fully filled, or the near side of a
+    // requeue.
+    Removed,
+
+    // Quantity that traded against a displayed order. The order may still be displayed after it.
+    Filled
+}

--- a/src/Circus/MarketData/IIncrementalProducer.cs
+++ b/src/Circus/MarketData/IIncrementalProducer.cs
@@ -7,6 +7,11 @@ namespace Circus.MarketData;
 // from the events rather than queried back out of it - which is also what lets market data be
 // rebuilt from a journal of those events, with no books involved at all.
 //
+// Handed MarketEvent and nothing else. The book's other half - what happened to one participant's
+// order, carrying the CompanyId and ClientOrderId that say whose it was - is addressed to that
+// participant and never broadcast, and a producer that cannot see it cannot leak it. That used to
+// be a rule each producer kept and a reflection test checked; it is the signature now.
+//
 // That holds for snapshots too, which is why there is no second interface here for them. A
 // snapshot is a statement of current state, and the temptation is to build one by reading the
 // book - but a snapshot produced that way leaves no trace in the event stream and so cannot be
@@ -29,5 +34,5 @@ namespace Circus.MarketData;
 // channel is what knows its own sequence.
 public interface IIncrementalProducer<T> where T : MarketDataEvent
 {
-    IList<T> Process(IReadOnlyList<OrderBookEvent> events);
+    IList<T> Process(IReadOnlyList<MarketEvent> events);
 }

--- a/src/Circus/MarketData/IndicativePriceDataProducer.cs
+++ b/src/Circus/MarketData/IndicativePriceDataProducer.cs
@@ -11,7 +11,7 @@ namespace Circus.MarketData;
 // subscriber must publish as such rather than leaving the last price standing.
 public class IndicativePriceDataProducer : IIncrementalProducer<IndicativePriceDataEvent>
 {
-    public IList<IndicativePriceDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<IndicativePriceDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<IndicativePriceDataEvent>? output = null;
 

--- a/src/Circus/MarketData/InstrumentFeed.cs
+++ b/src/Circus/MarketData/InstrumentFeed.cs
@@ -44,8 +44,9 @@ public sealed class InstrumentFeed
     // by time: every event in a single dispatch shares an instant, so there is no time order
     // among them to preserve. Across calls it is the order the venue dispatched them in, which is
     // the ordering that actually carries meaning.
-    public IReadOnlyList<MarketDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IReadOnlyList<MarketDataEvent> Process(IReadOnlyList<OrderBookEvent> bookEvents)
     {
+        var events = PublicHalf(bookEvents);
         if (events.Count == 0)
             return Array.Empty<MarketDataEvent>();
 
@@ -66,8 +67,9 @@ public sealed class InstrumentFeed
     //
     // A dispatch that is not a snapshot tick produces nothing here, so the common path costs three
     // scans that find nothing rather than a branch the caller has to know to take.
-    public IReadOnlyList<MarketDataEvent> Snapshot(IReadOnlyList<OrderBookEvent> events)
+    public IReadOnlyList<MarketDataEvent> Snapshot(IReadOnlyList<OrderBookEvent> bookEvents)
     {
+        var events = PublicHalf(bookEvents);
         if (events.Count == 0)
             return Array.Empty<MarketDataEvent>();
 
@@ -79,6 +81,23 @@ public sealed class InstrumentFeed
         Collect(ref output, _indicativeSnapshot.Process(events));
 
         return output ?? (IReadOnlyList<MarketDataEvent>) Array.Empty<MarketDataEvent>();
+    }
+
+    // The boundary where a book's output becomes a venue's. What a participant is told about its
+    // own order stops here: producers are typed to MarketEvent, so this is the only place the two
+    // halves are told apart, and it is a filter rather than a redaction because the public events
+    // are their own events rather than copies with fields removed.
+    private static IReadOnlyList<MarketEvent> PublicHalf(IReadOnlyList<OrderBookEvent> bookEvents)
+    {
+        List<MarketEvent>? publicEvents = null;
+
+        for (var i = 0; i < bookEvents.Count; i++)
+        {
+            if (bookEvents[i] is MarketEvent marketEvent)
+                (publicEvents ??= new List<MarketEvent>(bookEvents.Count)).Add(marketEvent);
+        }
+
+        return publicEvents ?? (IReadOnlyList<MarketEvent>) Array.Empty<MarketEvent>();
     }
 
     private static void Collect<T>(ref List<MarketDataEvent>? output, IList<T> produced)

--- a/src/Circus/MarketData/InstrumentStatusDataProducer.cs
+++ b/src/Circus/MarketData/InstrumentStatusDataProducer.cs
@@ -30,7 +30,7 @@ public class InstrumentStatusDataProducer : IIncrementalProducer<InstrumentStatu
     private DateTime? _resumesAt;
     private Side? _limitState;
 
-    public IList<InstrumentStatusDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<InstrumentStatusDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<InstrumentStatusDataEvent>? output = null;
 

--- a/src/Circus/MarketData/MarketByOrderIncrementalProducer.cs
+++ b/src/Circus/MarketData/MarketByOrderIncrementalProducer.cs
@@ -2,104 +2,54 @@ using Circus.Events;
 
 namespace Circus.MarketData;
 
-// Full order-by-order (L3) view of the working book, derived purely from the
-// OrderConfirmedEvent stream - no IOrderBook access, no snapshotting. A consumer replays the
-// returned deltas in order onto its own mirrored book, same as a real incremental feed.
+// The by-order incremental feed, and nothing more than a translation: the book already worked out
+// what changed about the displayed book and reported it as one update.
 //
-// Stop orders (still Hidden) are excluded entirely, same as a real market's undisplayed
-// contingent orders - a stop activating into a working limit order is reported as Added, not
-// Modified, since it has no prior presence in the working book to "move" from.
+// It used to derive that itself, from the private order confirmations - including the rule that an
+// update losing time priority is the old id leaving and a new one arriving rather than a modify in
+// place. That rule is about a requeue the book performed, reconstructed a step later by reading
+// PreviousExchangeOrderId off a confirmation addressed to someone else. It lives in the book now,
+// for the reason the depth derivation moved there: the book is where the queue actually moved, and
+// a producer reading a participant's confirmations is reading something no subscriber is entitled
+// to see.
 //
-// Quantity is always DisplayedQuantity, never RemainingQuantity - an iceberg's hidden reserve
-// must never appear on a public depth feed.
-//
-// An update that lost time priority (a reprice, a quantity increase, or an iceberg peak
-// refilling from its hidden reserve - see UpdateOrderConfirmed.PreviousExchangeOrderId) is
-// reported as Removed(old id) + Added(new id), not Modified - a real order-by-order feed
-// shows this as the old id leaving the book and a new one arriving at the back of the queue,
-// since a consumer reconstructing time priority needs to see that, not just a quantity/price
-// change against an id that kept its place.
-//
-// Everything one action did goes out as a single message, the way the by-price feed does: a
-// sweep across several orders is one book update rather than several, so a consumer never reads
-// a half-applied one and every sequence number marks a coherent book.
+// A dispatch is one action's events, and the book emits at most one OrdersChanged for it, so the
+// loop below normally runs once. It is a loop rather than a lookup because a dispatch spanning
+// instruments would carry one per book, and each has to become its own message.
 public class MarketByOrderIncrementalProducer : IIncrementalProducer<MarketByOrderDeltaEvent>
 {
-    public IList<MarketByOrderDeltaEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<MarketByOrderDeltaEvent> Process(IReadOnlyList<MarketEvent> events)
     {
-        List<MarketByOrderDelta>? changes = null;
+        List<MarketByOrderDeltaEvent>? output = null;
 
         foreach (var ev in events)
         {
-            // One per side of a trade, arriving as two top-level events rather than one wrapping
-            // both, so each becomes its own entry - paired by the TradeId they share.
-            if (ev is FillOrderConfirmed fill)
-            {
-                Add(ref changes, new MarketByOrderDelta(fill.Order.Side, fill.Order.ExchangeOrderId,
-                    fill.Order.Price!.Value, fill.Quantity, MarketByOrderDeltaAction.Filled, fill.TradeId));
+            if (ev is not OrdersChanged orders)
                 continue;
+
+            var changes = new List<MarketByOrderDelta>(orders.Changes.Count);
+            foreach (var change in orders.Changes)
+            {
+                changes.Add(new MarketByOrderDelta(change.Side, change.ExchangeOrderId, change.Price,
+                    change.Quantity, ToAction(change.Action), change.TradeId));
             }
 
-            if (ev is UpdateOrderConfirmed {PreviousPrice: {} movedFromPrice} moved)
-            {
-                if (moved.PreviousExchangeOrderId != moved.Order.ExchangeOrderId)
-                {
-                    Add(ref changes, new MarketByOrderDelta(moved.Order.Side, moved.PreviousExchangeOrderId,
-                        movedFromPrice, moved.PreviousQuantity, MarketByOrderDeltaAction.Removed));
-                    Add(ref changes, new MarketByOrderDelta(moved.Order.Side, moved.Order.ExchangeOrderId,
-                        moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
-                        MarketByOrderDeltaAction.Added));
-                }
-                else
-                {
-                    Add(ref changes, new MarketByOrderDelta(moved.Order.Side, moved.Order.ExchangeOrderId,
-                        moved.Order.Price!.Value, moved.Order.DisplayedQuantity,
-                        MarketByOrderDeltaAction.Modified));
-                }
-
-                continue;
-            }
-
-            MarketByOrderDelta? delta = ev switch
-            {
-                CreateOrderConfirmed {Order.Status: not OrderStatus.Hidden} create =>
-                    new MarketByOrderDelta(create.Order.Side, create.Order.ExchangeOrderId,
-                        create.Order.Price!.Value, create.Order.DisplayedQuantity,
-                        MarketByOrderDeltaAction.Added),
-
-                UpdateOrderConfirmed {PreviousPrice: null, Order.Status: OrderStatus.Hidden} => null,
-
-                UpdateOrderConfirmed {PreviousPrice: null} update =>
-                    new MarketByOrderDelta(update.Order.Side, update.Order.ExchangeOrderId,
-                        update.Order.Price!.Value, update.Order.DisplayedQuantity,
-                        MarketByOrderDeltaAction.Added),
-
-                CancelOrderConfirmed {PreviousPrice: {} previousPrice} cancel =>
-                    new MarketByOrderDelta(cancel.Order.Side, cancel.Order.ExchangeOrderId,
-                        previousPrice, cancel.PreviousQuantity, MarketByOrderDeltaAction.Removed),
-
-                ExpireOrderConfirmed {PreviousPrice: {} previousPrice} expire =>
-                    new MarketByOrderDelta(expire.Order.Side, expire.Order.ExchangeOrderId,
-                        previousPrice, expire.PreviousQuantity, MarketByOrderDeltaAction.Removed),
-
-                _ => null
-            };
-
-            if (delta != null)
-                Add(ref changes, delta);
+            output ??= new List<MarketByOrderDeltaEvent>();
+            output.Add(new MarketByOrderDeltaEvent(orders.Symbol, orders.Time, changes));
         }
 
-        if (changes == null)
-            return Array.Empty<MarketByOrderDeltaEvent>();
-
-        // Both carried by every event in the batch: one dispatch is one instrument at one instant.
-        var first = events[0];
-        return new[] {new MarketByOrderDeltaEvent(first.Symbol, first.Time, changes)};
+        return output ?? (IList<MarketByOrderDeltaEvent>) Array.Empty<MarketByOrderDeltaEvent>();
     }
 
-    private static void Add(ref List<MarketByOrderDelta>? changes, MarketByOrderDelta delta)
+    // The two enums stay separate for the reason the by-price pair do: what a book says about
+    // itself and what a subscriber is told are different vocabularies, and a change to one should
+    // not be forced on the other.
+    private static MarketByOrderDeltaAction ToAction(OrderChangeAction action) => action switch
     {
-        changes ??= new List<MarketByOrderDelta>();
-        changes.Add(delta);
-    }
+        OrderChangeAction.Added => MarketByOrderDeltaAction.Added,
+        OrderChangeAction.Modified => MarketByOrderDeltaAction.Modified,
+        OrderChangeAction.Removed => MarketByOrderDeltaAction.Removed,
+        OrderChangeAction.Filled => MarketByOrderDeltaAction.Filled,
+        _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+    };
 }

--- a/src/Circus/MarketData/MarketByPriceIncrementalProducer.cs
+++ b/src/Circus/MarketData/MarketByPriceIncrementalProducer.cs
@@ -15,7 +15,7 @@ namespace Circus.MarketData;
 // instruments would carry one per book, and each has to become its own message.
 public class MarketByPriceIncrementalProducer : IIncrementalProducer<MarketByPriceDeltaEvent>
 {
-    public IList<MarketByPriceDeltaEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<MarketByPriceDeltaEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<MarketByPriceDeltaEvent>? output = null;
 

--- a/src/Circus/MarketData/SnapshotProducers.cs
+++ b/src/Circus/MarketData/SnapshotProducers.cs
@@ -15,7 +15,7 @@ namespace Circus.MarketData;
 // producers rather than one that does everything.
 public class MarketByPriceSnapshotProducer : IIncrementalProducer<LevelsDataEvent>
 {
-    public IList<LevelsDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<LevelsDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<LevelsDataEvent>? output = null;
 
@@ -37,7 +37,7 @@ public class MarketByPriceSnapshotProducer : IIncrementalProducer<LevelsDataEven
 // is what makes InstrumentStatusDataProducer's accumulator recoverable rather than merely stateful.
 public class InstrumentStatusSnapshotProducer : IIncrementalProducer<InstrumentStatusDataEvent>
 {
-    public IList<InstrumentStatusDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<InstrumentStatusDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<InstrumentStatusDataEvent>? output = null;
 
@@ -60,7 +60,7 @@ public class InstrumentStatusSnapshotProducer : IIncrementalProducer<InstrumentS
 // by emitting a withdrawal, which is a message a late subscriber never heard.
 public class IndicativePriceSnapshotProducer : IIncrementalProducer<IndicativePriceDataEvent>
 {
-    public IList<IndicativePriceDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<IndicativePriceDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<IndicativePriceDataEvent>? output = null;
 
@@ -82,7 +82,7 @@ public class IndicativePriceSnapshotProducer : IIncrementalProducer<IndicativePr
 // heaviest message this venue publishes, and the reason a real snapshot feed cycles slowly.
 public class MarketByOrderSnapshotProducer : IIncrementalProducer<OrdersDataEvent>
 {
-    public IList<OrdersDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<OrdersDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<OrdersDataEvent>? output = null;
 

--- a/src/Circus/MarketData/TradeDataProducer.cs
+++ b/src/Circus/MarketData/TradeDataProducer.cs
@@ -2,34 +2,26 @@ using Circus.Events;
 
 namespace Circus.MarketData;
 
-// The public print, derived from the private fills. A trade produces two FillOrderConfirmed
-// events sharing a TradeId, and a venue broadcasts one message for the pair - so this emits on
-// the first fill of each trade and skips the second.
+// The public print, and nothing more than a translation of the one the book publishes.
 //
-// Keyed on the id changing rather than on IsResting, which today would pick out the same event:
-// one print per distinct trade is what is meant, and it stays true if a trade ever involves more
-// than the two sides it does now. The two fills of a trade are emitted adjacent, so remembering
-// the last id seen is enough and no set is needed.
-//
-// The last id is remembered within a call and not across them. Both fills of a trade are emitted
-// adjacent and in the same dispatch, so a batch is the whole of what needs deduplicating; keeping
-// it in a field only ever mattered for a trade id repeating across consecutive batches, which the
-// book's forward-only numbering rules out. Nothing survives a call, so nothing can go stale in it.
+// It used to derive the print itself, pairing the two FillOrderConfirmed events of a trade by the
+// id they share and taking the first of each pair. That worked, but a fill belongs to the
+// participant whose order filled and carries their CompanyId - so deriving a broadcast message
+// from it meant a producer reading something no subscriber is entitled to. The book publishes
+// TradePrinted for the same pair now, and the pairing lives where the trade happened.
 public class TradeDataProducer : IIncrementalProducer<TradeDataEvent>
 {
-    public IList<TradeDataEvent> Process(IReadOnlyList<OrderBookEvent> events)
+    public IList<TradeDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<TradeDataEvent>? output = null;
-        string? lastTradeId = null;
 
         foreach (var ev in events)
         {
-            if (ev is not FillOrderConfirmed fill || fill.TradeId == lastTradeId)
+            if (ev is not TradePrinted trade)
                 continue;
 
-            lastTradeId = fill.TradeId;
             output ??= new List<TradeDataEvent>();
-            output.Add(new TradeDataEvent(fill.Symbol, fill.Time, fill.Price, fill.Quantity));
+            output.Add(new TradeDataEvent(trade.Symbol, trade.Time, trade.Price, trade.Quantity));
         }
 
         return output ?? (IList<TradeDataEvent>) Array.Empty<TradeDataEvent>();

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -240,6 +240,8 @@ public class OrderBook : IOrderBook
         // not one per fill along the way. That is the shape of a real incremental refresh, which
         // carries every level a single matching-engine event moved.
         AppendLevelChanges(events, time);
+        AppendOrderChanges(events, time);
+        AppendTradePrints(events, time);
 
         return events;
     }
@@ -475,6 +477,108 @@ public class OrderBook : IOrderBook
         }
 
         return orders;
+    }
+
+    // The displayed book's own view of what the confirmations above did, read back off them.
+    //
+    // Derived here rather than at each mutation site because the confirmations already carry
+    // exactly what it takes - PreviousExchangeOrderId to tell a requeue from an in-place modify,
+    // PreviousPrice to tell an arrival from a move, PreviousQuantity for what left a level. Those
+    // fields exist for this, and reading them once at the end costs a walk of a list the action
+    // just built rather than a hook in six places.
+    //
+    // Only the count of events read is scanned, so an action that touched no order says nothing.
+    private void AppendOrderChanges(List<OrderBookEvent> events, DateTime time)
+    {
+        List<OrderChange>? changes = null;
+
+        // Snapshot the count first: this appends to the same list it is reading.
+        var count = events.Count;
+        for (var i = 0; i < count; i++)
+        {
+            switch (events[i])
+            {
+                // One per side of a trade, each its own change, paired by the id they share.
+                case FillOrderConfirmed fill:
+                    Add(ref changes, new OrderChange(fill.Order.Side, fill.Order.ExchangeOrderId,
+                        fill.Price, fill.Quantity, OrderChangeAction.Filled, fill.TradeId));
+                    break;
+
+                // A move between levels. Losing time priority mints a fresh ExchangeOrderId, and a
+                // consumer rebuilding the queue needs to see the old id leave and a new one arrive
+                // at the back rather than a price change against an id that kept its place.
+                case UpdateOrderConfirmed {PreviousPrice: { } movedFrom} moved:
+                    if (moved.PreviousExchangeOrderId != moved.Order.ExchangeOrderId)
+                    {
+                        Add(ref changes, new OrderChange(moved.Order.Side, moved.PreviousExchangeOrderId,
+                            movedFrom, moved.PreviousQuantity, OrderChangeAction.Removed));
+                        Add(ref changes, new OrderChange(moved.Order.Side, moved.Order.ExchangeOrderId,
+                            moved.Order.Price!.Value, moved.Order.DisplayedQuantity, OrderChangeAction.Added));
+                    }
+                    else
+                    {
+                        Add(ref changes, new OrderChange(moved.Order.Side, moved.Order.ExchangeOrderId,
+                            moved.Order.Price!.Value, moved.Order.DisplayedQuantity, OrderChangeAction.Modified));
+                    }
+
+                    break;
+
+                // A stop still hidden is not on the displayed book, so it says nothing here.
+                case CreateOrderConfirmed {Order.Status: not OrderStatus.Hidden} create:
+                    Add(ref changes, new OrderChange(create.Order.Side, create.Order.ExchangeOrderId,
+                        create.Order.Price!.Value, create.Order.DisplayedQuantity, OrderChangeAction.Added));
+                    break;
+
+                // No previous price means it was not on the displayed book before - a stop
+                // triggering into it, which is an arrival rather than a move. Still hidden, and it
+                // has not arrived yet.
+                case UpdateOrderConfirmed {PreviousPrice: null, Order.Status: OrderStatus.Hidden}:
+                    break;
+
+                case UpdateOrderConfirmed {PreviousPrice: null} update:
+                    Add(ref changes, new OrderChange(update.Order.Side, update.Order.ExchangeOrderId,
+                        update.Order.Price!.Value, update.Order.DisplayedQuantity, OrderChangeAction.Added));
+                    break;
+
+                case CancelOrderConfirmed {PreviousPrice: { } cancelledAt} cancel:
+                    Add(ref changes, new OrderChange(cancel.Order.Side, cancel.Order.ExchangeOrderId,
+                        cancelledAt, cancel.PreviousQuantity, OrderChangeAction.Removed));
+                    break;
+
+                case ExpireOrderConfirmed {PreviousPrice: { } expiredAt} expire:
+                    Add(ref changes, new OrderChange(expire.Order.Side, expire.Order.ExchangeOrderId,
+                        expiredAt, expire.PreviousQuantity, OrderChangeAction.Removed));
+                    break;
+            }
+        }
+
+        if (changes != null)
+            events.Add(new OrdersChanged(_instrument.Symbol, time, changes));
+    }
+
+    private static void Add(ref List<OrderChange>? changes, OrderChange change) =>
+        (changes ??= new List<OrderChange>()).Add(change);
+
+    // One print per trade, from the pair of fills that share its id. The fills arrive adjacent, so
+    // remembering the last id seen is enough to take the first of each pair and skip the second.
+    private void AppendTradePrints(List<OrderBookEvent> events, DateTime time)
+    {
+        List<OrderBookEvent>? prints = null;
+        string? lastTradeId = null;
+
+        var count = events.Count;
+        for (var i = 0; i < count; i++)
+        {
+            if (events[i] is not FillOrderConfirmed fill || fill.TradeId == lastTradeId)
+                continue;
+
+            lastTradeId = fill.TradeId;
+            (prints ??= new List<OrderBookEvent>()).Add(
+                new TradePrinted(_instrument.Symbol, time, fill.TradeId, fill.Price, fill.Quantity));
+        }
+
+        if (prints != null)
+            events.AddRange(prints);
     }
 
     private void CaptureWindow(List<(long Tick, int Quantity, int Count)> into, Side side) =>

--- a/tests/Circus.Tests/Helpers/OrderFlowEvents.cs
+++ b/tests/Circus.Tests/Helpers/OrderFlowEvents.cs
@@ -4,17 +4,26 @@ namespace Circus.Tests.Helpers;
 
 internal static class OrderFlowEvents
 {
-    // Everything an action produced except the aggregated-depth reports.
+    // Everything an action produced except the book's own reports of what it left behind.
     //
-    // A book emits two different kinds of thing: what happened to orders, and what that left the
-    // published book looking like. Most tests are about the first - "this order rested, that one
-    // filled, this one was rejected" - and counting the raw list makes those assertions depend on
-    // how many price levels happened to move, which is a different subject and one the by-price
-    // tests already cover.
+    // A book emits two different kinds of thing: what happened to orders, and what that did to the
+    // displayed book. Most tests are about the first - "this order rested, that one filled, this
+    // one was rejected" - and counting the raw list makes those assertions depend on how many
+    // price levels moved or how the queue was rearranged, which is a different subject and one the
+    // by-price and by-order tests already cover.
+    //
+    // Status, limit and indicative changes are not filtered: those are things that happened, not
+    // reports of where the action left the book, and a session test counting them is asking a fair
+    // question about order flow.
     //
     // So an order-flow test asserts against this rather than the whole list, the same way it
-    // asserts trades through Trades() rather than by grouping fills at every site. A test that is
-    // about the depth reports reads them directly.
+    // asserts trades through Trades() rather than by grouping fills at every site.
     public static IReadOnlyList<OrderBookEvent> OrderFlow(this IEnumerable<OrderBookEvent> events) =>
-        events.Where(e => e is not LevelsChanged).ToList();
+        events.Where(e => e is not (LevelsChanged or OrdersChanged or TradePrinted or BookSnapshot))
+            .ToList();
+
+    // The half of a book's output a venue may broadcast, for a test driving a producer straight
+    // off a book rather than through a feed.
+    public static IReadOnlyList<MarketEvent> Market(this IEnumerable<OrderBookEvent> events) =>
+        events.OfType<MarketEvent>().ToList();
 }

--- a/tests/Circus.Tests/Helpers/ProducerInput.cs
+++ b/tests/Circus.Tests/Helpers/ProducerInput.cs
@@ -1,0 +1,21 @@
+using Circus.Events;
+using Circus.MarketData;
+
+namespace Circus.Tests.Helpers;
+
+internal static class ProducerInput
+{
+    // A book's whole output handed to a producer, filtered to the half a venue broadcasts.
+    //
+    // Producers take MarketEvent so that a participant's own confirmations cannot reach a public
+    // feed - the guarantee is the signature. InstrumentFeed does this filtering at its boundary;
+    // this is the same step for a test driving a producer straight off a book, so what the
+    // producer sees is what a real feed would have given it.
+    //
+    // An extension rather than an overload on the interface: the point is that only MarketEvent
+    // gets in, and an overload taking everything would hand that back.
+    public static IList<T> Process<T>(this IIncrementalProducer<T> producer,
+        IReadOnlyList<OrderBookEvent> events)
+        where T : MarketDataEvent =>
+        producer.Process(events.OfType<MarketEvent>().ToList());
+}

--- a/tests/Circus.Tests/MarketData/BookLevelViewTests.cs
+++ b/tests/Circus.Tests/MarketData/BookLevelViewTests.cs
@@ -1,5 +1,6 @@
 using Circus.Events;
 using Circus.MarketData;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
+++ b/tests/Circus.Tests/MarketData/ChannelFromDispatchTests.cs
@@ -3,6 +3,7 @@ using Circus.Agents;
 using Circus.MarketData;
 using Circus.Sequencing;
 using Circus.Sessions;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/IndicativePriceDataProducerTests.cs
@@ -2,6 +2,7 @@ using Circus.Actions;
 using Circus.Events;
 using Circus.MarketData;
 using Circus.Time;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/InstrumentFeedTests.cs
+++ b/tests/Circus.Tests/MarketData/InstrumentFeedTests.cs
@@ -1,6 +1,7 @@
 using Circus.Events;
 using Circus.MarketData;
 using Circus.Time;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/InstrumentStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/InstrumentStatusDataProducerTests.cs
@@ -2,6 +2,7 @@ using Circus.Actions;
 using Circus.Events;
 using Circus.MarketData;
 using Circus.Time;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/LevelBookTests.cs
+++ b/tests/Circus.Tests/MarketData/LevelBookTests.cs
@@ -1,4 +1,5 @@
 using Circus.MarketData;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/MarketByOrderIncrementalProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/MarketByOrderIncrementalProducerTests.cs
@@ -2,6 +2,7 @@ using Circus.Actions;
 using Circus.Events;
 using Circus.MarketData;
 using Circus.Time;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/MarketByPriceIncrementalProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/MarketByPriceIncrementalProducerTests.cs
@@ -1,5 +1,6 @@
 using Circus.Events;
 using Circus.MarketData;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/MarketDataChannelTests.cs
+++ b/tests/Circus.Tests/MarketData/MarketDataChannelTests.cs
@@ -1,6 +1,7 @@
 using Circus.Events;
 using Circus.MarketData;
 using Circus.Time;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/PublicPrivateSplitTests.cs
+++ b/tests/Circus.Tests/MarketData/PublicPrivateSplitTests.cs
@@ -1,0 +1,169 @@
+using Circus.Events;
+using Circus.MarketData;
+using Circus.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Circus.Tests.MarketData;
+
+// A book emits two kinds of thing and they go to different places. What happened to one
+// participant's order is addressed to that participant and carries the CompanyId saying whose it
+// was; what happened to the book is broadcast and carries no such thing. Real venues keep the two
+// apart at the protocol level - CME answers order entry on iLink and publishes market data on MDP -
+// and here the line is drawn in the type system instead.
+//
+// These assert the line holds, and that the public half is genuinely its own view rather than the
+// private half with fields removed: the two do not correspond one to one.
+public class PublicPrivateSplitTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+
+    private OrderBook _book = null!;
+
+    [SetUp]
+    public void SetUp() => _book = new OrderBook(Gold);
+
+    private static IReadOnlyList<OrderChange> ChangesIn(IReadOnlyList<OrderBookEvent> events) =>
+        events.OfType<OrdersChanged>().SelectMany(o => o.Changes).ToList();
+
+    // The guarantee, stated over every published type rather than the one that happened to have a
+    // test. A producer cannot leak client identity because it never sees any; this closes the other
+    // half, that no broadcast type declares a place to put it.
+    [Test]
+    public void NoBroadcastEvent_DeclaresClientIdentity()
+    {
+        var offenders = typeof(MarketEvent).Assembly.GetTypes()
+            .Where(t => typeof(MarketEvent).IsAssignableFrom(t))
+            .SelectMany(t => t.GetProperties().Select(p => new {Type = t.Name, Property = p.Name}))
+            .Where(x => x.Property is "CompanyId" or "ClientOrderId")
+            .Select(x => $"{x.Type}.{x.Property}")
+            .ToList();
+
+        Assert.IsEmpty(offenders,
+            "a broadcast event must never carry the originating client's identity");
+    }
+
+    [Test]
+    public void ARestingOrder_IsConfirmedPrivatelyAndReportedPublicly()
+    {
+        _book.UpdateStatus(OrderBookStatus.Open, time: Now1);
+
+        var events = _book.CreateLimitOrder("C1", "O1", new OrderValidity.Day(), Side.Buy, 3, 100,
+            time: Now2);
+
+        var confirmed = events.OfType<CreateOrderConfirmed>().Single();
+        Assert.AreEqual("C1", confirmed.CompanyId, "the participant is told, and told whose it was");
+
+        var change = ChangesIn(events).Single();
+        Assert.AreEqual(OrderChangeAction.Added, change.Action);
+        Assert.AreEqual(confirmed.Order.ExchangeOrderId, change.ExchangeOrderId,
+            "the market is told, by the id it is allowed to know");
+    }
+
+    // One to zero. A stop that has not triggered is not on the displayed book, so there is a
+    // confirmation for its owner and nothing for anyone else - which is why the public view cannot
+    // be the private one with fields dropped.
+    [Test]
+    public void AHiddenStop_IsConfirmedButNotReported()
+    {
+        _book.UpdateStatus(OrderBookStatus.Open, time: Now1);
+        _book.CreateLimitOrder("C1", "O1", new OrderValidity.Day(), Side.Buy, 3, 500, time: Now2);
+        _book.CreateLimitOrder("C2", "O2", new OrderValidity.Day(), Side.Sell, 3, 500, time: Now2);
+
+        var events = _book.CreateStopLimitOrder("C3", "O3", new OrderValidity.Day(), Side.Buy, 5, 530,
+            510, time: Now3);
+
+        Assert.IsNotEmpty(events.OfType<CreateOrderConfirmed>(), "its owner is told it was accepted");
+        Assert.IsEmpty(ChangesIn(events), "and nobody else, because it is not on the displayed book");
+    }
+
+    // One to two. An update that loses time priority is a single confirmation to its owner and, to
+    // the market, the old id leaving and a new one arriving at the back of the queue.
+    [Test]
+    public void ARepricedOrder_IsOneConfirmationAndTwoReportedChanges()
+    {
+        _book.UpdateStatus(OrderBookStatus.Open, time: Now1);
+        _book.CreateLimitOrder("C1", "O1", new OrderValidity.Day(), Side.Buy, 6, 100, time: Now2);
+
+        var events = _book.UpdateOrder("C1", "O1b", "O1", 6, 90, time: Now3);
+
+        var updated = events.OfType<UpdateOrderConfirmed>().Single();
+        var changes = ChangesIn(events);
+
+        Assert.AreEqual(2, changes.Count);
+        Assert.AreEqual(OrderChangeAction.Removed, changes[0].Action);
+        Assert.AreEqual(updated.PreviousExchangeOrderId, changes[0].ExchangeOrderId);
+        Assert.AreEqual(100, changes[0].Price, "the level it left");
+        Assert.AreEqual(OrderChangeAction.Added, changes[1].Action);
+        Assert.AreEqual(updated.Order.ExchangeOrderId, changes[1].ExchangeOrderId);
+        Assert.AreEqual(90, changes[1].Price, "and the back of the queue it arrived at");
+    }
+
+    // Two to one. A trade is a fill for each participant and a single print for everyone.
+    [Test]
+    public void ATrade_IsTwoFillsAndOnePrint()
+    {
+        _book.UpdateStatus(OrderBookStatus.Open, time: Now1);
+        _book.CreateLimitOrder("C1", "O1", new OrderValidity.Day(), Side.Buy, 3, 100, time: Now2);
+
+        var events = _book.CreateLimitOrder("C2", "O2", new OrderValidity.Day(), Side.Sell, 3, 100,
+            time: Now3);
+
+        var fills = events.OfType<FillOrderConfirmed>().ToList();
+        var print = events.OfType<TradePrinted>().Single();
+
+        Assert.AreEqual(2, fills.Count, "one for each participant, each carrying their own CompanyId");
+        Assert.AreEqual(new[] {"C1", "C2"}, fills.Select(f => f.CompanyId).ToArray());
+        Assert.AreEqual(fills[0].TradeId, print.TradeId, "and one print, carrying the id that pairs them");
+        Assert.AreEqual(100, print.Price);
+        Assert.AreEqual(3, print.Quantity);
+    }
+
+    [Test]
+    public void AnAggressorMatchingTwoOrders_PrintsOncePerTrade()
+    {
+        _book.UpdateStatus(OrderBookStatus.Open, time: Now1);
+        _book.CreateLimitOrder("C1", "O1", new OrderValidity.Day(), Side.Sell, 2, 100, time: Now2);
+        _book.CreateLimitOrder("C2", "O2", new OrderValidity.Day(), Side.Sell, 3, 110, time: Now2);
+
+        var events = _book.CreateLimitOrder("C3", "O3", new OrderValidity.Day(), Side.Buy, 5, 110,
+            time: Now3);
+
+        var prints = events.OfType<TradePrinted>().ToList();
+        Assert.AreEqual(2, prints.Count, "two trades, two prints - not four fills");
+        Assert.AreEqual(new[] {100m, 110m}, prints.Select(p => p.Price).ToArray());
+        Assert.AreEqual(2, prints.Select(p => p.TradeId).Distinct().Count());
+    }
+
+    [Test]
+    public void AnActionTouchingNoOrder_ReportsNothingPublicly()
+    {
+        var events = _book.UpdateStatus(OrderBookStatus.Open, time: Now1);
+
+        Assert.IsEmpty(events.OfType<OrdersChanged>(), "a status change moved no order");
+        Assert.IsEmpty(events.OfType<TradePrinted>());
+        Assert.IsNotEmpty(events.OfType<StatusChanged>(), "but the status change itself is published");
+    }
+
+    // The reason both halves stay in one stream: their order relative to each other is meaningful,
+    // and a venue simulator is exactly where someone would ask about it.
+    [Test]
+    public void BothHalves_ArriveInOneStreamInOrder()
+    {
+        _book.UpdateStatus(OrderBookStatus.Open, time: Now1);
+        _book.CreateLimitOrder("C1", "O1", new OrderValidity.Day(), Side.Buy, 3, 100, time: Now2);
+
+        var events = _book.CreateLimitOrder("C2", "O2", new OrderValidity.Day(), Side.Sell, 3, 100,
+            time: Now3);
+
+        var lastFill = events.ToList().FindLastIndex(e => e is FillOrderConfirmed);
+        var print = events.ToList().FindIndex(e => e is TradePrinted);
+
+        Assert.Greater(print, lastFill,
+            "the participants learn of their own fills before the market learns of the print");
+    }
+}

--- a/tests/Circus.Tests/MarketData/SnapshotRecoveryTests.cs
+++ b/tests/Circus.Tests/MarketData/SnapshotRecoveryTests.cs
@@ -3,6 +3,7 @@ using Circus.Agents;
 using Circus.MarketData;
 using Circus.Sequencing;
 using Circus.Sessions;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
@@ -1,6 +1,7 @@
 using Circus.Actions;
 using Circus.MarketData;
 using Circus.Time;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;

--- a/tests/Circus.Tests/Matching/FillEventShapeTests.cs
+++ b/tests/Circus.Tests/Matching/FillEventShapeTests.cs
@@ -1,5 +1,6 @@
 using Circus.Events;
 using Circus.MarketData;
+using Circus.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circus.Tests.Matching;


### PR DESCRIPTION
Step 1 of the channel-configuration work. **Draft until CI confirms it builds** — no local compiler here.

## The split

A book emits two kinds of thing. What happened to one participant's order carries the `CompanyId` saying whose it was and is addressed to them. What happened to the book is broadcast and carries no such thing.

`MarketEvent` is the broadcast half, and producers take it and nothing else. **A `CompanyId` reaching a public feed is now a compile error** rather than a rule five producers each had to keep and one reflection test had to check.

The hierarchy was already shaped this way — everything private already descended from `OrderEvent` — so this names a split that existed rather than inventing one.

Real venues draw the same line at the protocol level: CME answers order entry on iLink and publishes market data on MDP; Eurex uses ETI and EMDI/EOBI.

## Two producers were reading the private half

**`OrdersChanged`** — the displayed book's own view of what the confirmations did. Not a redaction of them, which is why it's its own event rather than a filter:

| Action | Private | Public |
|---|---|---|
| Stop created, still hidden | one confirmation | **nothing** |
| Limit order rests | one confirmation | one Added |
| Update losing time priority | one confirmation | **two** — Removed(old id), Added(new id) |

One-to-zero, one-to-one, one-to-two. Field-dropping can't produce that; it needs to know what the book did to its own queue. So the derivation moves out of `MarketByOrderIncrementalProducer`, which becomes a translation — the same move the depth derivation made in #89.

**`TradePrinted`** — the public print. It used to be derived by pairing the two fills of a trade, which meant a producer reading a message belonging to the participant whose order filled. The pairing now lives where the trade happened, and the id that did it is still on the event.

## One stream, deliberately

Both halves stay in one list out of `Process`. Their interleaving is meaningful — when a participant learns of its own fill relative to when the market learns of the print is exactly what a venue simulator gets used for — so there's a test asserting the order rather than leaving it to how a host drains two lists.

## A plan change worth flagging

I said the reflection test would be deleted. **It survives.** The compiler stops a producer *seeing* client identity; it doesn't stop a published type *declaring* somewhere to put it. It's now generalised over every `MarketEvent` in the assembly rather than the one type that happened to have a test — stronger than before, not redundant.

## Cost

Every order action carries one or two more events in `Dispatched.Events`. Durability is unaffected (the journal of record is the action stream), but determinism comparisons get bigger.

## Next

Steps 2–6: book depth as a parameter, `InstrumentFeed` taking a product set, multiple channels per group, per-channel depth and cadence, then CME-like and Eurex-like shapes as executable evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj)_