### PR TITLE
Let a book be told how deep to report

### DIFF
--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -63,19 +63,26 @@ public class OrderBook : IOrderBook
     // enough. Cleared at the top of every call rather than left to grow unbounded across them.
     private readonly List<InternalOrder> _pendingImmediateOrCancelStops = new();
 
-    // How deep the published book runs. A property of the feed rather than of matching, but a
-    // fixed one - every by-price product here is ten deep, as CME's futures books are - which is
-    // what lets the book say which levels changed rather than leaving a consumer to work out
-    // whether a change fell inside the window it happens to be publishing.
-    private const int PublishedDepth = 10;
+    // Ten, because that is what CME's futures books publish and what a by-price product here has
+    // always carried. A default rather than a rule - see below.
+    public const int DefaultPublishedDepth = 10;
+
+    // How deep this book reports its levels. A capability, not a subscription: the book says how
+    // far it is willing to look, and a channel publishing less takes the top of what it is given.
+    // A venue whose deepest product is twenty sets this to twenty and lets its five-deep channel
+    // truncate; setting it to five would leave that channel with nothing to truncate from.
+    //
+    // Deliberately not "which channels want what". The book knows how deep to look and nothing
+    // about who is reading, which is what keeps it a function of its actions and one number.
+    private readonly int _publishedDepth;
 
     // The published window as it stood before the action and as it stands after, diffed to
     // produce LevelsChanged. Reused per book for the reason the buffer above is: one action at a
     // time, so four lists outlive every call rather than being allocated within it.
-    private readonly List<(long Tick, int Quantity, int Count)> _bidsBefore = new(PublishedDepth);
-    private readonly List<(long Tick, int Quantity, int Count)> _offersBefore = new(PublishedDepth);
-    private readonly List<(long Tick, int Quantity, int Count)> _bidsAfter = new(PublishedDepth);
-    private readonly List<(long Tick, int Quantity, int Count)> _offersAfter = new(PublishedDepth);
+    private readonly List<(long Tick, int Quantity, int Count)> _bidsBefore;
+    private readonly List<(long Tick, int Quantity, int Count)> _offersBefore;
+    private readonly List<(long Tick, int Quantity, int Count)> _bidsAfter;
+    private readonly List<(long Tick, int Quantity, int Count)> _offersAfter;
 
     // Nothing outside this table names a status - the rest of the book reads the current phase
     // and acts on what it says. Pre-open's auction instance is also what prints on the way out
@@ -150,8 +157,8 @@ public class OrderBook : IOrderBook
 
     private const int MaxClientOrderIdLength = 20;
 
-    public OrderBook(Instrument instrument)
-        : this(instrument, Adapt(instrument.PriceRestrictions))
+    public OrderBook(Instrument instrument, int publishedDepth = DefaultPublishedDepth)
+        : this(instrument, Adapt(instrument.PriceRestrictions), publishedDepth)
     {
     }
 
@@ -180,11 +187,22 @@ public class OrderBook : IOrderBook
     // Restrictions supplied outright rather than derived from the instrument. Internal because it
     // is a seam, not an API: it exists so combinations an Instrument cannot yet describe - two
     // trade-scoped restrictions disagreeing about severity, say - can still be exercised.
-    internal OrderBook(Instrument instrument, IReadOnlyList<IPriceRestriction> priceRestrictions)
+    internal OrderBook(Instrument instrument, IReadOnlyList<IPriceRestriction> priceRestrictions,
+        int publishedDepth = DefaultPublishedDepth)
     {
+        if (publishedDepth <= 0)
+            throw new ArgumentOutOfRangeException(nameof(publishedDepth), publishedDepth,
+                "a book that reports no levels publishes no depth at all");
+
         _instrument = instrument;
         _priceRestrictions = priceRestrictions;
         _phases = BuildPhases(instrument.MatchingAlgorithm);
+        _publishedDepth = publishedDepth;
+
+        _bidsBefore = new List<(long, int, int)>(publishedDepth);
+        _offersBefore = new List<(long, int, int)>(publishedDepth);
+        _bidsAfter = new List<(long, int, int)>(publishedDepth);
+        _offersAfter = new List<(long, int, int)>(publishedDepth);
     }
 
     public string Symbol => _instrument.Symbol;
@@ -450,7 +468,7 @@ public class OrderBook : IOrderBook
     // The same goes for order-by-order, which gets a snapshot of its own once it has one to give.
     private BookSnapshot Snapshot(DateTime time) =>
         new(_instrument.Symbol, time,
-            GetLevels(Side.Buy, PublishedDepth), GetLevels(Side.Sell, PublishedDepth),
+            GetLevels(Side.Buy, _publishedDepth), GetLevels(Side.Sell, _publishedDepth),
             GetRestingOrders(),
             _status, _statusReason, _resumeAt, _limitState,
             _indicativeQuote is { } quote ? ToDecimal(quote.PriceTicks) : null,
@@ -582,7 +600,7 @@ public class OrderBook : IOrderBook
     }
 
     private void CaptureWindow(List<(long Tick, int Quantity, int Count)> into, Side side) =>
-        _matcher.Working[side].CopyLevelsFromBest(PublishedDepth, into);
+        _matcher.Working[side].CopyLevelsFromBest(_publishedDepth, into);
 
     // One event carrying every level the action moved, or none at all if it moved none - an
     // action that touches no level, a status change or a rejected order, says nothing here.

--- a/src/Circus/Sequencing/InstrumentGroup.cs
+++ b/src/Circus/Sequencing/InstrumentGroup.cs
@@ -32,14 +32,19 @@ public sealed class InstrumentGroup
     public IReadOnlyList<string> Symbols => _symbols;
 
     // Registers an instrument: creates a bare OrderBook and an InstrumentFeed, adds the book and
-    // schedule to the sequencer and the feed to the channel. Depth is not a parameter - every
-    // by-price product is ten deep, fixed in the book that reports the levels.
-    public void Add(Instrument instrument, MarketSchedule schedule)
+    // schedule to the sequencer and the feed to the channel.
+    //
+    // publishedDepth is how deep that book reports its levels - the deepest any product taken off
+    // it will want, since a channel publishing less truncates what it is given and one publishing
+    // more has nothing to truncate from. Ten by default, which is what CME's futures books carry.
+    // A caller wanting a book configured further builds one and uses the overload below.
+    public void Add(Instrument instrument, MarketSchedule schedule,
+        int publishedDepth = OrderBook.DefaultPublishedDepth)
     {
         ArgumentNullException.ThrowIfNull(instrument);
         ArgumentNullException.ThrowIfNull(schedule);
 
-        var book = new OrderBook(instrument);
+        var book = new OrderBook(instrument, publishedDepth);
         _sequencer.Add(book, schedule);
         _channel.Add(new InstrumentFeed(instrument.Symbol));
         _symbols.Add(instrument.Symbol);

--- a/tests/Circus.Tests/MarketData/PublishedDepthTests.cs
+++ b/tests/Circus.Tests/MarketData/PublishedDepthTests.cs
@@ -1,0 +1,119 @@
+using Circus.Events;
+using Circus.MarketData;
+using Circus.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Circus.Tests.MarketData;
+
+// How deep a book reports its levels is a capability rather than a rule: it says how far it is
+// willing to look, and a channel publishing less takes the top of what it is given. Ten by
+// default, which is what CME's futures books carry, and the only value anything here uses today.
+//
+// It matters because a venue whose deepest product is twenty has to have a book looking twenty
+// deep - a channel cannot truncate from a window that was never built. These pin that the number
+// is honoured rather than approximated, at both ends and in the middle.
+public class PublishedDepthTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly DateTime Start = new(2000, 1, 1, 12, 0, 0);
+
+    // Twelve resting bids at descending prices, so any depth up to twelve is exercised by a real
+    // ladder rather than by a book that happened to be shallower than the window.
+    private static OrderBook BookWithTwelveBids(int? publishedDepth = null)
+    {
+        var book = publishedDepth is { } depth ? new OrderBook(Gold, depth) : new OrderBook(Gold);
+        book.UpdateStatus(OrderBookStatus.Open, time: Start);
+
+        for (var i = 0; i < 12; i++)
+        {
+            book.CreateLimitOrder($"C{i}", $"O{i}", new OrderValidity.Day(), Side.Buy, 1, 200 - i * 10,
+                time: Start.AddSeconds(i + 1));
+        }
+
+        return book;
+    }
+
+    private static IReadOnlyList<LevelChange> LastReport(OrderBook book) =>
+        book.CreateLimitOrder("CX", "OX", new OrderValidity.Day(), Side.Buy, 1, 205,
+                time: Start.AddMinutes(1))
+            .OfType<LevelsChanged>().Single().Changes;
+
+    [Test]
+    public void ByDefault_ABookReportsTenDeep()
+    {
+        var book = BookWithTwelveBids();
+
+        // A new best bid pushes the tenth level out of the window, so the report names it: an
+        // Added at the top and a Removed for whatever fell off the bottom.
+        var changes = LastReport(book);
+
+        Assert.AreEqual(2, changes.Count);
+        Assert.AreEqual(LevelChangeAction.Added, changes[0].Action);
+        Assert.AreEqual(205, changes[0].Price);
+        Assert.AreEqual(LevelChangeAction.Removed, changes[1].Action);
+        Assert.AreEqual(110, changes[1].Price, "the tenth level, pushed past a ten-deep window");
+    }
+
+    [TestCase(1)]
+    [TestCase(5)]
+    [TestCase(10)]
+    public void AShallowerBook_ReportsThatManyLevels(int depth)
+    {
+        var book = BookWithTwelveBids(depth);
+        var changes = LastReport(book);
+
+        Assert.AreEqual(LevelChangeAction.Added, changes[0].Action);
+        Assert.AreEqual(205, changes[0].Price);
+        Assert.AreEqual(LevelChangeAction.Removed, changes[1].Action);
+        Assert.AreEqual(200 - (depth - 1) * 10, changes[1].Price,
+            "whatever sat at the bottom of the window is what falls out of it");
+    }
+
+    // The case the parameter exists for. A twenty-deep book has all twelve levels inside its
+    // window, so nothing falls out and a channel publishing five has twelve to truncate from.
+    [Test]
+    public void ADeeperBook_ReportsEverythingItHolds()
+    {
+        var book = BookWithTwelveBids(20);
+        var changes = LastReport(book);
+
+        Assert.AreEqual(1, changes.Count,
+            "nothing left a window deeper than the book, so only the arrival is news");
+        Assert.AreEqual(LevelChangeAction.Added, changes[0].Action);
+        Assert.AreEqual(205, changes[0].Price);
+    }
+
+    [Test]
+    public void ASnapshot_CarriesTheSameDepthTheReportsDo()
+    {
+        var book = BookWithTwelveBids(4);
+
+        var snapshot = book.Process(new Actions.PublishSnapshot {Symbol = Gold.Symbol, Time = Start.AddMinutes(1)})
+            .OfType<BookSnapshot>().Single();
+
+        Assert.AreEqual(4, snapshot.Bids.Count,
+            "a snapshot restates the window, so it is the same window the deltas move");
+        Assert.AreEqual(new[] {200m, 190m, 180m, 170m}, snapshot.Bids.Select(b => b.Price).ToArray());
+    }
+
+    // Order-by-order is a different product and deliberately not windowed: a depth feed publishes
+    // a window because that is what fits on a wire, where an order-by-order feed carries the book.
+    [Test]
+    public void TheByOrderSnapshot_IsNotCappedByPublishedDepth()
+    {
+        var book = BookWithTwelveBids(3);
+
+        var snapshot = book.Process(new Actions.PublishSnapshot {Symbol = Gold.Symbol, Time = Start.AddMinutes(1)})
+            .OfType<BookSnapshot>().Single();
+
+        Assert.AreEqual(3, snapshot.Bids.Count);
+        Assert.AreEqual(12, snapshot.Orders.Count, "every resting order, however deep it sits");
+    }
+
+    [Test]
+    public void ABookReportingNoLevels_IsRefused()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OrderBook(Gold, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OrderBook(Gold, -1));
+    }
+}

--- a/tests/Circus.Tests/MarketData/PublishedDepthTests.cs
+++ b/tests/Circus.Tests/MarketData/PublishedDepthTests.cs
@@ -34,7 +34,7 @@ public class PublishedDepthTests
     }
 
     private static IReadOnlyList<LevelChange> LastReport(OrderBook book) =>
-        book.CreateLimitOrder("CX", "OX", new OrderValidity.Day(), Side.Buy, 1, 205,
+        book.CreateLimitOrder("CX", "OX", new OrderValidity.Day(), Side.Buy, 1, 210,
                 time: Start.AddMinutes(1))
             .OfType<LevelsChanged>().Single().Changes;
 
@@ -49,7 +49,7 @@ public class PublishedDepthTests
 
         Assert.AreEqual(2, changes.Count);
         Assert.AreEqual(LevelChangeAction.Added, changes[0].Action);
-        Assert.AreEqual(205, changes[0].Price);
+        Assert.AreEqual(210, changes[0].Price);
         Assert.AreEqual(LevelChangeAction.Removed, changes[1].Action);
         Assert.AreEqual(110, changes[1].Price, "the tenth level, pushed past a ten-deep window");
     }
@@ -63,7 +63,7 @@ public class PublishedDepthTests
         var changes = LastReport(book);
 
         Assert.AreEqual(LevelChangeAction.Added, changes[0].Action);
-        Assert.AreEqual(205, changes[0].Price);
+        Assert.AreEqual(210, changes[0].Price);
         Assert.AreEqual(LevelChangeAction.Removed, changes[1].Action);
         Assert.AreEqual(200 - (depth - 1) * 10, changes[1].Price,
             "whatever sat at the bottom of the window is what falls out of it");
@@ -80,7 +80,7 @@ public class PublishedDepthTests
         Assert.AreEqual(1, changes.Count,
             "nothing left a window deeper than the book, so only the arrival is news");
         Assert.AreEqual(LevelChangeAction.Added, changes[0].Action);
-        Assert.AreEqual(205, changes[0].Price);
+        Assert.AreEqual(210, changes[0].Price);
     }
 
     [Test]


### PR DESCRIPTION
Step 2 of the channel-configuration work. **Draft until CI confirms it builds.**

## Why

`PublishedDepth` was a `const`, so ten wasn't a default — it was a rule. A venue whose deepest product runs twenty couldn't have one: a channel truncates what it's given, and there's nothing to truncate from a window that was never built.

## The line this holds

Depth is a **capability**, not a subscription. The book says how far it's willing to look; it still knows nothing about who's reading or how much of it they publish.

That's the distinction worth keeping when channels become configurable in step 4. The alternative — telling the book which channels exist — would have it doing fan-out that belongs to the channel, and would stop it being a function of its actions plus one number.

## Scope

Ten stays the default, so every existing caller behaves exactly as before. `InstrumentGroup.Add` passes it through, so the parameter is reachable without hand-building a book. A depth of zero or less is refused.

## Tests

Driven off a twelve-level ladder, so a window is always exercised against a book *deeper* than it rather than one that happened to be shallower:

- **default** — a new best bid pushes the tenth level out, and the report names it
- **1, 5, 10** — same, with the level that falls out matching the configured depth
- **20** — nothing falls out; only the arrival is news, which is the case the parameter exists for
- **snapshot** — carries the same window the deltas move
- **by-order snapshot** — deliberately *not* capped: a depth feed publishes a window because that's what fits on a wire; an order-by-order feed carries the book

## Next

Step 3: `InstrumentFeed` takes a product set rather than hardcoding five producers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj)_