### PR TITLE
Let a feed be told which products it carries

### DIFF
--- a/src/Circus/MarketData/FeedProducts.cs
+++ b/src/Circus/MarketData/FeedProducts.cs
@@ -1,0 +1,37 @@
+namespace Circus.MarketData;
+
+// Which products a feed carries, and so what a channel built on it publishes.
+//
+// One flag per product rather than per message, because a product's incremental and snapshot
+// halves are the same thing seen twice - a channel carrying market by price carries both the
+// deltas and the images. Whether snapshots are published at all is a separate question, answered
+// by whether the venue runs a snapshot cycle.
+//
+// This is what lets one engine wear different venues. CME channels carry by-price and by-order
+// together with trades and status; Eurex splits by-order onto EOBI and by-price onto EMDI, with
+// state on both; an ITCH-shaped venue publishes by-order alone and leaves aggregation to its
+// subscribers. Those are three sets of these flags rather than three implementations.
+[Flags]
+public enum FeedProducts
+{
+    None = 0,
+
+    // Aggregated depth - CME's Market by Price, Eurex's EMDI.
+    ByPrice = 1,
+
+    // Order by order - CME's Market by Order, Eurex's EOBI.
+    ByOrder = 2,
+
+    // The public print, one per trade.
+    Trades = 4,
+
+    // What state the instrument is in, as one composite.
+    Status = 8,
+
+    // The auction quote a book is running.
+    Indicative = 16,
+
+    // Everything, which is more than a real depth feed carries and the useful default for a
+    // simulator: a caller who has not thought about channels should still see the whole venue.
+    All = ByPrice | ByOrder | Trades | Status | Indicative
+}

--- a/src/Circus/MarketData/InstrumentFeed.cs
+++ b/src/Circus/MarketData/InstrumentFeed.cs
@@ -9,14 +9,16 @@ namespace Circus.MarketData;
 // pure functions of the events they are handed, since the book now reports which price levels
 // moved rather than leaving a producer to work it out by shadowing the book.
 //
-// No depth to configure. Every by-price product here is ten deep, fixed in the book that reports
-// the levels, as CME's futures books are. Two depth streams merged into one channel would be
-// indistinguishable anyway, so a venue publishing a five-deep and a ten-deep product does it as
-// two feeds rather than one carrying both.
+// Which products it carries is configured, because a venue is not one shape. CME channels carry
+// by-price and by-order together with trades and status; Eurex splits by-order onto EOBI and
+// by-price onto EMDI, publishing state on both; an ITCH-shaped venue carries by-order alone. All
+// of them are this class with different flags, which is the point of the flags existing.
 //
-// A venue separating market-by-price from market-by-order would compose its own bundle rather
-// than use this: both are here, which is the useful default for a simulator and more than a real
-// depth feed carries.
+// Everything by default: a caller who has not thought about channels sees the whole venue, which
+// is more than any real depth feed carries and the useful answer for a simulator.
+//
+// How deep the by-price products run is not here. That is the book's, since the book is what
+// reports the levels, and a feed publishes as much of what it is given as it wants.
 public sealed class InstrumentFeed
 {
     private readonly MarketByPriceIncrementalProducer _levels = new();
@@ -33,12 +35,26 @@ public sealed class InstrumentFeed
     private readonly IndicativePriceSnapshotProducer _indicativeSnapshot = new();
     private readonly MarketByOrderSnapshotProducer _orderByOrderSnapshot = new();
 
-    public InstrumentFeed(string symbol)
+    private readonly FeedProducts _products;
+
+    public InstrumentFeed(string symbol, FeedProducts products = FeedProducts.All)
     {
+        if (products == FeedProducts.None)
+            throw new ArgumentException(
+                "a feed carrying no products publishes nothing, which is a channel that should " +
+                "not have been created rather than one that is quiet", nameof(products));
+
         Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
+        _products = products;
     }
 
     public string Symbol { get; }
+
+    // What this feed carries. A channel is a subset of the venue in two directions - which
+    // instruments, and which products about them - and this is the second.
+    public FeedProducts Products => _products;
+
+    private bool Carries(FeedProducts product) => (_products & product) != 0;
 
     // Ordering within one call is by producer, in the fixed order below, rather than interleaved
     // by time: every event in a single dispatch shares an instant, so there is no time order
@@ -52,11 +68,11 @@ public sealed class InstrumentFeed
 
         List<MarketDataEvent>? output = null;
 
-        Collect(ref output, _status.Process(events));
-        Collect(ref output, _trades.Process(events));
-        Collect(ref output, _levels.Process(events));
-        Collect(ref output, _orderByOrder.Process(events));
-        Collect(ref output, _indicative.Process(events));
+        if (Carries(FeedProducts.Status)) Collect(ref output, _status.Process(events));
+        if (Carries(FeedProducts.Trades)) Collect(ref output, _trades.Process(events));
+        if (Carries(FeedProducts.ByPrice)) Collect(ref output, _levels.Process(events));
+        if (Carries(FeedProducts.ByOrder)) Collect(ref output, _orderByOrder.Process(events));
+        if (Carries(FeedProducts.Indicative)) Collect(ref output, _indicative.Process(events));
 
         return output ?? (IReadOnlyList<MarketDataEvent>) Array.Empty<MarketDataEvent>();
     }
@@ -75,10 +91,10 @@ public sealed class InstrumentFeed
 
         List<MarketDataEvent>? output = null;
 
-        Collect(ref output, _statusSnapshot.Process(events));
-        Collect(ref output, _levelsSnapshot.Process(events));
-        Collect(ref output, _orderByOrderSnapshot.Process(events));
-        Collect(ref output, _indicativeSnapshot.Process(events));
+        if (Carries(FeedProducts.Status)) Collect(ref output, _statusSnapshot.Process(events));
+        if (Carries(FeedProducts.ByPrice)) Collect(ref output, _levelsSnapshot.Process(events));
+        if (Carries(FeedProducts.ByOrder)) Collect(ref output, _orderByOrderSnapshot.Process(events));
+        if (Carries(FeedProducts.Indicative)) Collect(ref output, _indicativeSnapshot.Process(events));
 
         return output ?? (IReadOnlyList<MarketDataEvent>) Array.Empty<MarketDataEvent>();
     }

--- a/src/Circus/Sequencing/InstrumentGroup.cs
+++ b/src/Circus/Sequencing/InstrumentGroup.cs
@@ -38,27 +38,31 @@ public sealed class InstrumentGroup
     // it will want, since a channel publishing less truncates what it is given and one publishing
     // more has nothing to truncate from. Ten by default, which is what CME's futures books carry.
     // A caller wanting a book configured further builds one and uses the overload below.
+    // products is what the channel publishes about it. Everything by default, which is more than
+    // a real feed carries and the useful answer until a caller has a venue shape in mind.
     public void Add(Instrument instrument, MarketSchedule schedule,
-        int publishedDepth = OrderBook.DefaultPublishedDepth)
+        int publishedDepth = OrderBook.DefaultPublishedDepth,
+        FeedProducts products = FeedProducts.All)
     {
         ArgumentNullException.ThrowIfNull(instrument);
         ArgumentNullException.ThrowIfNull(schedule);
 
         var book = new OrderBook(instrument, publishedDepth);
         _sequencer.Add(book, schedule);
-        _channel.Add(new InstrumentFeed(instrument.Symbol));
+        _channel.Add(new InstrumentFeed(instrument.Symbol, products));
         _symbols.Add(instrument.Symbol);
     }
 
     // Registers a pre-built book (e.g. with custom price restrictions) alongside its schedule and
     // an instrument feed for it.
-    public void Add(IOrderBook book, MarketSchedule schedule)
+    public void Add(IOrderBook book, MarketSchedule schedule,
+        FeedProducts products = FeedProducts.All)
     {
         ArgumentNullException.ThrowIfNull(book);
         ArgumentNullException.ThrowIfNull(schedule);
 
         _sequencer.Add(book, schedule);
-        _channel.Add(new InstrumentFeed(book.Symbol));
+        _channel.Add(new InstrumentFeed(book.Symbol, products));
         _symbols.Add(book.Symbol);
     }
 

--- a/tests/Circus.Tests/MarketData/FeedProductsTests.cs
+++ b/tests/Circus.Tests/MarketData/FeedProductsTests.cs
@@ -1,0 +1,124 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Circus.Tests.MarketData;
+
+// A channel is a subset of the venue in two directions: which instruments it carries, and which
+// products it carries about them. This is the second, and it is what lets one engine wear
+// different venues - CME carrying by-price and by-order together, Eurex splitting them across
+// EOBI and EMDI with state on both, an ITCH-shaped venue carrying by-order alone.
+//
+// One flag per product, not per message: a product's incremental and snapshot halves are the same
+// thing seen twice, so a feed carrying market by price carries both its deltas and its images.
+public class FeedProductsTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+
+    private static readonly DateTime Now1 = new(2000, 1, 1, 12, 0, 0);
+    private static readonly DateTime Now2 = new(2000, 1, 1, 12, 1, 0);
+    private static readonly DateTime Now3 = new(2000, 1, 1, 12, 2, 0);
+    private static readonly DateTime Now4 = new(2000, 1, 1, 12, 3, 0);
+
+    // A trade, which is the action that moves every product at once - depth, orders, and a print -
+    // so what comes out is decided by the flags rather than by the action being too quiet to say.
+    private static (IReadOnlyList<MarketDataEvent> Incremental, IReadOnlyList<MarketDataEvent> Snapshot)
+        Publish(FeedProducts products)
+    {
+        var feed = new InstrumentFeed(Gold.Symbol, products);
+        var book = new OrderBook(Gold);
+
+        feed.Process(book.UpdateStatus(OrderBookStatus.Open, time: Now1));
+        feed.Process(book.CreateLimitOrder("C1", "O1", new OrderValidity.Day(), Side.Buy, 3, 100,
+            time: Now2));
+
+        var incremental = feed.Process(
+            book.CreateLimitOrder("C2", "O2", new OrderValidity.Day(), Side.Sell, 3, 100, time: Now3));
+
+        var snapshot = feed.Snapshot(
+            book.Process(new PublishSnapshot {Symbol = Gold.Symbol, Time = Now4}));
+
+        return (incremental, snapshot);
+    }
+
+    private static IEnumerable<string> Kinds(IEnumerable<MarketDataEvent> data) =>
+        data.Select(d => d.GetType().Name).Distinct();
+
+    [Test]
+    public void ByDefault_AFeedCarriesEverything()
+    {
+        var (incremental, snapshot) = Publish(FeedProducts.All);
+
+        Assert.AreEqual(new[]
+            {
+                nameof(TradeDataEvent), nameof(MarketByPriceDeltaEvent), nameof(MarketByOrderDeltaEvent)
+            },
+            Kinds(incremental).ToArray());
+        Assert.AreEqual(new[]
+            {
+                nameof(InstrumentStatusDataEvent), nameof(LevelsDataEvent), nameof(OrdersDataEvent),
+                nameof(IndicativePriceDataEvent)
+            },
+            Kinds(snapshot).ToArray());
+    }
+
+    [Test]
+    public void ADepthOnlyFeed_CarriesDepthAndNothingElse()
+    {
+        var (incremental, snapshot) = Publish(FeedProducts.ByPrice);
+
+        Assert.AreEqual(new[] {nameof(MarketByPriceDeltaEvent)}, Kinds(incremental).ToArray());
+        Assert.AreEqual(new[] {nameof(LevelsDataEvent)}, Kinds(snapshot).ToArray(),
+            "one flag covers both halves of a product");
+    }
+
+    [Test]
+    public void AnOrderByOrderOnlyFeed_CarriesOrdersAndNothingElse()
+    {
+        var (incremental, snapshot) = Publish(FeedProducts.ByOrder);
+
+        Assert.AreEqual(new[] {nameof(MarketByOrderDeltaEvent)}, Kinds(incremental).ToArray());
+        Assert.AreEqual(new[] {nameof(OrdersDataEvent)}, Kinds(snapshot).ToArray());
+    }
+
+    [Test]
+    public void ATradesOnlyFeed_PublishesPrintsAndNoBook()
+    {
+        var (incremental, snapshot) = Publish(FeedProducts.Trades);
+
+        Assert.AreEqual(new[] {nameof(TradeDataEvent)}, Kinds(incremental).ToArray());
+        Assert.IsEmpty(snapshot, "there is no snapshot of a stream of prints");
+    }
+
+    // Eurex's split, as far as this models it: order by order with state on one channel, depth
+    // with trades and state on another, and the same instrument on both.
+    [Test]
+    public void TwoFeedsOnOneInstrument_CanCarryDifferentProducts()
+    {
+        var eobi = Publish(FeedProducts.ByOrder | FeedProducts.Status);
+        var emdi = Publish(FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status);
+
+        Assert.AreEqual(new[] {nameof(MarketByOrderDeltaEvent)}, Kinds(eobi.Incremental).ToArray());
+        Assert.AreEqual(new[] {nameof(TradeDataEvent), nameof(MarketByPriceDeltaEvent)},
+            Kinds(emdi.Incremental).ToArray());
+
+        Assert.Contains(nameof(InstrumentStatusDataEvent), Kinds(eobi.Snapshot).ToArray());
+        Assert.Contains(nameof(InstrumentStatusDataEvent), Kinds(emdi.Snapshot).ToArray(),
+            "state is on both, because a subscriber to either needs to know the instrument is open");
+    }
+
+    [Test]
+    public void AFeedCarryingNothing_IsRefused()
+    {
+        Assert.Throws<ArgumentException>(() => new InstrumentFeed(Gold.Symbol, FeedProducts.None));
+    }
+
+    [Test]
+    public void AFeed_SaysWhatItCarries()
+    {
+        var feed = new InstrumentFeed(Gold.Symbol, FeedProducts.ByPrice | FeedProducts.Trades);
+
+        Assert.AreEqual(FeedProducts.ByPrice | FeedProducts.Trades, feed.Products);
+    }
+}


### PR DESCRIPTION
Step 3 of the channel-configuration work. **Draft until CI confirms it builds.**

## Why

`InstrumentFeed` built all five producers and published all five products, so every channel was the same channel. A venue isn't one shape:

| Venue | Channels | Products |
|---|---|---|
| **CME** | one per product group | by-price + by-order + trades + status, together |
| **Eurex** | EOBI, EMDI | EOBI: by-order + state. EMDI: by-price + trades + state |
| **ITCH-like** | one | by-order alone; subscribers aggregate |

Those are three sets of flags, not three implementations.

## One flag per product, not per message

A product's incremental and snapshot halves are the same thing seen twice, so a feed carrying market by price carries both its deltas and its images. Whether snapshots get published *at all* is a separate question, already answered by whether the venue runs a snapshot cycle.

## Scope

`FeedProducts.All` is the default, so every existing caller behaves exactly as before — and it's the useful answer for a simulator, being more than any real depth feed carries. `InstrumentGroup.Add` passes it through on both overloads.

`FeedProducts.None` is refused rather than published as silence: it's a channel that shouldn't have been created.

**Depth deliberately stays on the book.** The book reports the levels; a feed publishes as much of what it's given as it wants. Same division that keeps the book ignorant of who's reading.

## Tests

Driven off a *trade*, since that's the action that moves every product at once — depth, orders and a print — so what comes out is decided by the flags rather than by the action being too quiet to say anything.

Covers the default, each product in isolation, `Trades` having no snapshot half, and a Eurex-shaped pair: two feeds on one instrument carrying different products, with state on both because a subscriber to either needs to know the instrument is open.

## Next

Step 4: multiple channels per group, with an instrument able to sit on more than one. That's where the real design lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj)_