### PR TITLE
Let a group publish several channels

### DIFF
--- a/src/Circus/MarketData/MarketDataChannel.cs
+++ b/src/Circus/MarketData/MarketDataChannel.cs
@@ -30,6 +30,18 @@ public sealed class MarketDataChannel
     private long _sequence;
     private long _snapshotSequence;
 
+    public MarketDataChannel(string name = DefaultName)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+    }
+
+    // What a venue with more than one of these calls it. CME names its channels by product group,
+    // Eurex by interface; either way a subscriber picks one by name, so having one is what lets a
+    // venue's shape be written down rather than assembled by position.
+    public const string DefaultName = "default";
+
+    public string Name { get; }
+
     // What a subscriber has seen so far, so a caller resuming one can say where it got to.
     public long Sequence => _sequence;
 
@@ -39,6 +51,12 @@ public sealed class MarketDataChannel
     // thing numbering is for.
     public long SnapshotSequence => _snapshotSequence;
 
+    // What this channel carries, in the order it was given them. A channel is a subset of the
+    // venue, so knowing which subset is part of describing it.
+    public IReadOnlyList<string> Symbols => _symbols;
+
+    private readonly List<string> _symbols = new();
+
     public void Add(InstrumentFeed feed)
     {
         ArgumentNullException.ThrowIfNull(feed);
@@ -46,6 +64,8 @@ public sealed class MarketDataChannel
         if (!_feeds.TryAdd(feed.Symbol, feed))
             throw new ArgumentException(
                 $"a feed is already registered for {feed.Symbol}", nameof(feed));
+
+        _symbols.Add(feed.Symbol);
     }
 
     // Turns one dispatch's events into the messages this channel publishes for them.

--- a/src/Circus/Sequencing/InstrumentGroup.cs
+++ b/src/Circus/Sequencing/InstrumentGroup.cs
@@ -4,18 +4,33 @@ using Circus.Sessions;
 
 namespace Circus.Sequencing;
 
-// A group of instruments that share a single sequencer and a single market data channel.
-// Registering an instrument here adds it to both, so the wiring between them cannot be wrong.
+// A group of instruments that share one sequencer and the channels that publish them. Registering
+// an instrument here adds it to both, so the wiring between them cannot be wrong.
 //
 // A product complex -- a spread and its legs -- needs a common dispatch order the moment implied
-// pricing exists, and it needs a single channel so the per-instrument messages carry contiguous
-// sequence numbers a subscriber can count. This is the unit that provides both, bundled together.
+// pricing exists, and it needs its messages numbered on a stream a subscriber can count. This is
+// the unit that provides both.
 //
-// Single-threaded, like the sequencer and the channel inside it.
+// One sequencer, several channels. That is the shape both venues have: the dispatch order is the
+// venue's and there is one of it, while what gets published about it is a product decision with
+// several answers. CME runs a channel per product group carrying by-price and by-order together;
+// Eurex publishes the same instrument on EOBI and on EMDI with different products on each. A
+// channel here differs from its siblings in what it carries, not in the order it sees things.
+//
+// Declare the channels, then add instruments; an instrument goes on every channel unless it names
+// some, because in both venues the channels of a group carry the same instruments and differ in
+// products. A group that never declares one gets a single default channel carrying everything,
+// which is what a caller who has not thought about channels wants.
+//
+// Single-threaded, like the sequencer and the channels inside it.
 public sealed class InstrumentGroup
 {
     private readonly Sequencer _sequencer;
-    private readonly MarketDataChannel _channel;
+
+    // Insertion-ordered, so a caller iterating them gets the order it declared them in rather than
+    // a dictionary's.
+    private readonly Dictionary<string, (MarketDataChannel Channel, FeedProducts Products)> _channels = new();
+    private readonly List<string> _channelOrder = new();
     private readonly List<string> _symbols = new();
 
     // snapshotInterval is how often each book restates itself on the channel's snapshot stream.
@@ -24,12 +39,49 @@ public sealed class InstrumentGroup
     public InstrumentGroup(DateTime start, TimeSpan? snapshotInterval = null)
     {
         _sequencer = new Sequencer(start, snapshotInterval);
-        _channel = new MarketDataChannel();
     }
 
     public Sequencer Sequencer => _sequencer;
-    public MarketDataChannel Channel => _channel;
+
     public IReadOnlyList<string> Symbols => _symbols;
+
+    public IReadOnlyList<string> ChannelNames => _channelOrder;
+
+    // The one channel, for a venue that has one. Refused rather than guessed at once there are
+    // several: which of them a caller meant is not something to pick for them, and the messages
+    // are numbered per channel so merging two would produce a stream nobody publishes.
+    public MarketDataChannel Channel => _channelOrder.Count switch
+    {
+        1 => _channels[_channelOrder[0]].Channel,
+        0 => throw new InvalidOperationException(
+            "this group has no channels yet - declare one, or add an instrument and take the " +
+            "default that comes with it"),
+        _ => throw new InvalidOperationException(
+            $"this group publishes {_channelOrder.Count} channels ({string.Join(", ", _channelOrder)}), " +
+            "so there is no single one to take - name the one you mean")
+    };
+
+    public MarketDataChannel ChannelNamed(string name) =>
+        _channels.TryGetValue(name, out var entry)
+            ? entry.Channel
+            : throw new ArgumentException($"no channel named {name} in this group", nameof(name));
+
+    // Declares a channel and what it publishes. Every instrument already registered joins it, so
+    // the order channels and instruments are declared in does not change what comes out.
+    public void AddChannel(string name, FeedProducts products = FeedProducts.All)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        if (_channels.ContainsKey(name))
+            throw new ArgumentException($"a channel named {name} is already in this group", nameof(name));
+
+        var channel = new MarketDataChannel(name);
+        _channels[name] = (channel, products);
+        _channelOrder.Add(name);
+
+        foreach (var symbol in _symbols)
+            channel.Add(new InstrumentFeed(symbol, products));
+    }
 
     // Registers an instrument: creates a bare OrderBook and an InstrumentFeed, adds the book and
     // schedule to the sequencer and the feed to the channel.
@@ -42,28 +94,66 @@ public sealed class InstrumentGroup
     // a real feed carries and the useful answer until a caller has a venue shape in mind.
     public void Add(Instrument instrument, MarketSchedule schedule,
         int publishedDepth = OrderBook.DefaultPublishedDepth,
-        FeedProducts products = FeedProducts.All)
+        IReadOnlyList<string>? channels = null)
     {
         ArgumentNullException.ThrowIfNull(instrument);
         ArgumentNullException.ThrowIfNull(schedule);
 
+        RequireChannelsExist(channels);
+
         var book = new OrderBook(instrument, publishedDepth);
         _sequencer.Add(book, schedule);
-        _channel.Add(new InstrumentFeed(instrument.Symbol, products));
-        _symbols.Add(instrument.Symbol);
+        Publish(instrument.Symbol, channels);
     }
 
     // Registers a pre-built book (e.g. with custom price restrictions) alongside its schedule and
     // an instrument feed for it.
-    public void Add(IOrderBook book, MarketSchedule schedule,
-        FeedProducts products = FeedProducts.All)
+    public void Add(IOrderBook book, MarketSchedule schedule, IReadOnlyList<string>? channels = null)
     {
         ArgumentNullException.ThrowIfNull(book);
         ArgumentNullException.ThrowIfNull(schedule);
 
+        RequireChannelsExist(channels);
+
         _sequencer.Add(book, schedule);
-        _channel.Add(new InstrumentFeed(book.Symbol, products));
-        _symbols.Add(book.Symbol);
+        Publish(book.Symbol, channels);
+    }
+
+    // Before the book reaches the sequencer, so naming a channel that does not exist leaves the
+    // group exactly as it was rather than holding a book nothing publishes.
+    private void RequireChannelsExist(IReadOnlyList<string>? channels)
+    {
+        if (channels == null) return;
+
+        foreach (var name in channels)
+        {
+            if (!_channels.ContainsKey(name))
+                throw new ArgumentException($"no channel named {name} in this group", nameof(channels));
+        }
+    }
+
+    // Puts a symbol on the channels that carry it, and records it so a channel declared later
+    // picks it up too.
+    //
+    // Naming none means all of them, which is what both venues do - the channels of a group carry
+    // the same instruments and differ in products. Naming some is for a venue that does not, and
+    // naming one that does not exist is refused rather than silently publishing nowhere.
+    private void Publish(string symbol, IReadOnlyList<string>? channels)
+    {
+        // Only when the caller named none. Someone asking for a channel by name has a venue shape
+        // in mind, and inventing a default underneath them would publish where they did not ask.
+        if (channels == null && _channels.Count == 0)
+            AddChannel(MarketDataChannel.DefaultName);
+
+        var carrying = channels ?? _channelOrder;
+
+        foreach (var name in carrying)
+        {
+            var (channel, products) = _channels[name];
+            channel.Add(new InstrumentFeed(symbol, products));
+        }
+
+        _symbols.Add(symbol);
     }
 
     // Submits an action to the group's sequencer.

--- a/tests/Circus.Tests/Sequencing/InstrumentGroupTests.cs
+++ b/tests/Circus.Tests/Sequencing/InstrumentGroupTests.cs
@@ -103,10 +103,14 @@ public class InstrumentGroupTests
             group.Submit(new OpenTrading {Symbol = "UNKNOWN", Time = At(9, 0)}));
     }
 
+    // The channel arrives with the first instrument rather than with the group: a group that has
+    // registered nothing publishes nothing, and there is no channel to hand back until something
+    // asks to be carried. MultipleChannelTests pins the refusal on an empty group.
     [Test]
     public void ExposesSequencerAndChannel()
     {
         var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
 
         Assert.IsNotNull(group.Sequencer);
         Assert.IsNotNull(group.Channel);

--- a/tests/Circus.Tests/Sequencing/MultipleChannelTests.cs
+++ b/tests/Circus.Tests/Sequencing/MultipleChannelTests.cs
@@ -1,0 +1,179 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sequencing;
+
+// One sequencer, several channels. The dispatch order is the venue's and there is one of it; what
+// gets published about it is a product decision with several answers.
+//
+// CME runs a channel per product group carrying by-price and by-order together. Eurex publishes
+// the same instrument on EOBI and on EMDI, with by-order on one and by-price on the other and
+// state on both. Both are this class with different channels declared, which is what step 4 is
+// for - so the Eurex shape gets a test rather than a comment claiming it would work.
+public class MultipleChannelTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly Instrument Silver = new("SIZ6", 10, 10);
+    private static readonly DateTime Day = new(2000, 1, 3, 8, 0, 0);
+
+    private static MarketSchedule OpenThroughout() =>
+        new(new TimeSpan(8, 30, 0), new TimeSpan(9, 0, 0), new TimeSpan(23, 0, 0));
+
+    // Drives a trade and returns what each channel published for it. A trade moves every product
+    // at once, so what a channel carries is decided by its products rather than by the action.
+    private static Dictionary<string, List<ChannelMessage>> Trade(InstrumentGroup group)
+    {
+        var published = group.ChannelNames.ToDictionary(n => n, _ => new List<ChannelMessage>());
+
+        group.Submit(new OpenTrading {Symbol = Gold.Symbol, Time = Day.AddHours(1)});
+        group.Submit(Order("C1", Side.Buy, 3, 100, Day.AddHours(1).AddSeconds(1)));
+        group.Submit(Order("C2", Side.Sell, 3, 100, Day.AddHours(1).AddSeconds(2)));
+
+        foreach (var dispatched in group.Sequencer.AdvanceTo(Day.AddHours(2)))
+        {
+            foreach (var name in group.ChannelNames)
+                published[name].AddRange(group.ChannelNamed(name).Publish(dispatched.Events));
+        }
+
+        return published;
+    }
+
+    private static CreateLimitOrder Order(string companyId, Side side, int quantity, decimal price,
+        DateTime time) =>
+        new()
+        {
+            Symbol = Gold.Symbol, Time = time, CompanyId = companyId, ClientOrderId = $"O-{companyId}",
+            OrderValidity = new OrderValidity.Day(), Side = side, Quantity = quantity, Price = price
+        };
+
+    // Sorted, because which products a channel carries is what these are about - the order a feed
+    // emits them in is InstrumentFeedTests' subject, and asserting it here would couple these to
+    // something they do not care about.
+    private static string[] Kinds(IEnumerable<ChannelMessage> messages) =>
+        messages.Select(m => m.Data.GetType().Name).Distinct().OrderBy(n => n).ToArray();
+
+    [Test]
+    public void AGroupThatDeclaresNoChannel_GetsOneCarryingEverything()
+    {
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+
+        Assert.AreEqual(new[] {MarketDataChannel.DefaultName}, group.ChannelNames.ToArray());
+        Assert.AreEqual(new[]
+            {
+                nameof(InstrumentStatusDataEvent), nameof(MarketByOrderDeltaEvent),
+                nameof(MarketByPriceDeltaEvent), nameof(TradeDataEvent)
+            },
+            Kinds(Trade(group)[MarketDataChannel.DefaultName]));
+    }
+
+    // The Eurex shape: one instrument, two channels, different products on each and state on both.
+    [Test]
+    public void OneInstrument_CanBePublishedOnTwoChannelsCarryingDifferentProducts()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("EOBI", FeedProducts.ByOrder | FeedProducts.Status);
+        group.AddChannel("EMDI", FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status);
+        group.Add(Gold, OpenThroughout());
+
+        var published = Trade(group);
+
+        Assert.AreEqual(new[] {nameof(InstrumentStatusDataEvent), nameof(MarketByOrderDeltaEvent)},
+            Kinds(published["EOBI"]));
+        Assert.AreEqual(new[]
+            {
+                nameof(InstrumentStatusDataEvent), nameof(MarketByPriceDeltaEvent), nameof(TradeDataEvent)
+            },
+            Kinds(published["EMDI"]));
+    }
+
+    // Each channel counts its own messages. A subscriber to one must see a contiguous run, which
+    // it would not if the two shared a numbering and each dropped what the other carried.
+    [Test]
+    public void EachChannel_NumbersItsOwnMessages()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("EOBI", FeedProducts.ByOrder);
+        group.AddChannel("EMDI", FeedProducts.ByPrice | FeedProducts.Trades);
+        group.Add(Gold, OpenThroughout());
+
+        var published = Trade(group);
+
+        foreach (var (name, messages) in published)
+        {
+            Assert.IsNotEmpty(messages, $"{name} published nothing");
+            Assert.AreEqual(Enumerable.Range(1, messages.Count).Select(i => (long) i).ToArray(),
+                messages.Select(m => m.Sequence).ToArray(),
+                $"{name} must number its own messages from one, with no gap");
+        }
+    }
+
+    [Test]
+    public void AChannelDeclaredAfterAnInstrument_StillCarriesIt()
+    {
+        var group = new InstrumentGroup(Day);
+        group.Add(Gold, OpenThroughout());
+        group.AddChannel("late", FeedProducts.ByPrice);
+
+        var published = Trade(group);
+
+        Assert.IsNotEmpty(published["late"],
+            "declaring channels and adding instruments should commute");
+    }
+
+    [Test]
+    public void AnInstrument_CanBeHeldBackFromAChannel()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("majors");
+        group.AddChannel("minors");
+        group.Add(Gold, OpenThroughout(), channels: new[] {"majors"});
+        group.Add(Silver, OpenThroughout(), channels: new[] {"minors"});
+
+        Assert.AreEqual(new[] {Gold.Symbol}, group.ChannelNamed("majors").Symbols.ToArray());
+        Assert.AreEqual(new[] {Silver.Symbol}, group.ChannelNamed("minors").Symbols.ToArray());
+    }
+
+    [Test]
+    public void NamingAChannelThatDoesNotExist_IsRefused()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("real");
+
+        Assert.Throws<ArgumentException>(
+            () => group.Add(Gold, OpenThroughout(), channels: new[] {"imaginary"}));
+    }
+
+    [Test]
+    public void DeclaringTheSameChannelTwice_IsRefused()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("one");
+
+        Assert.Throws<ArgumentException>(() => group.AddChannel("one"));
+    }
+
+    // There is no single channel to take once there are several, and picking one would hand back
+    // a stream the caller did not ask for.
+    [Test]
+    public void TheSingleChannelShortcut_IsRefusedWhenThereAreSeveral()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("a");
+        group.AddChannel("b");
+        group.Add(Gold, OpenThroughout());
+
+        Assert.Throws<InvalidOperationException>(() => _ = group.Channel);
+        Assert.IsNotNull(group.ChannelNamed("a"));
+    }
+
+    [Test]
+    public void TheSingleChannelShortcut_IsRefusedWhenThereAreNone()
+    {
+        Assert.Throws<InvalidOperationException>(() => _ = new InstrumentGroup(Day).Channel);
+    }
+}


### PR DESCRIPTION
Step 4, option A. **Draft until CI confirms it builds.**

## The shape

One sequencer, several channels. The dispatch order is the venue's and there is one of it; what gets published about it is a product decision with several answers.

```csharp
group.AddChannel("EOBI", FeedProducts.ByOrder | FeedProducts.Status);
group.AddChannel("EMDI", FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status);
group.Add(Gold, schedule);
```

Channels are declared, then instruments added — a venue's shape written down in one place, the way CME publishes a channel config rather than having one assembled by position.

## An instrument goes on every channel by default

Because that's what both venues do. CME runs a channel per product group carrying by-price and by-order together; Eurex publishes the same instrument on EOBI *and* EMDI with different products on each and state on both. The channels of a group carry the same instruments and differ in **what they say about them**, not in membership.

Naming specific channels is supported for a venue that doesn't work that way, and naming one that doesn't exist is refused **before the book reaches the sequencer** — so the group is left as it was rather than holding a book nothing publishes.

## Declaring order doesn't matter

A channel declared *after* an instrument picks it up. Configuration should commute, and there's a test for it.

## Backward compatibility

A group that declares no channel gets one carrying everything, so every existing caller behaves exactly as before and `Channel` still means what it meant. It's refused once there are several — which one was meant isn't something to guess, and since messages are numbered per channel, merging two would produce a stream nobody publishes.

## `products` moved from `Add` to `AddChannel`

Which is the point: what a channel carries belongs to the channel, not to the registration of an instrument on it. No caller was passing it, so nothing had to change.

## Tests

The Eurex shape gets a real test rather than a comment claiming it would work — one instrument, two channels, different products on each, state on both. Plus per-channel sequence contiguity, declaration order commuting, holding an instrument back, and the refusals.

Kind comparisons are **sorted**: which products a channel carries is what these are about, and the order a feed emits them in is `InstrumentFeedTests`' subject.

## Next

Step 5: per-channel depth and cadence. Step 6: CME-like and Eurex-like shapes as executable evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj)_