### PR TITLE
Let each channel set its own depth and snapshot cadence

### DIFF
--- a/src/Circus/Events/OrderBookEvent.cs
+++ b/src/Circus/Events/OrderBookEvent.cs
@@ -141,9 +141,9 @@ public record LimitStateChanged(string Symbol, DateTime Time, Side? Side, decima
 // Removed the rank it last held, and is carried for a consumer that wants it rather than for
 // identifying the level.
 //
-// Removed covers a level leaving the published window as well as leaving the book - the window is
-// fixed at ten deep, and a level pushed past that is no longer published whether or not orders
-// still rest there. It returns as Added if it comes back.
+// Removed covers a level leaving the published window as well as leaving the book - a level
+// pushed past the window's depth is no longer published whether or not orders still rest there.
+// It returns as Added if it comes back.
 public record LevelChange(Side Side, int LevelIndex, decimal Price, int Quantity, int Count,
     LevelChangeAction Action);
 
@@ -163,7 +163,20 @@ public record LevelChange(Side Side, int LevelIndex, decimal Price, int Quantity
 // an action that touches no level - a status change, a rejected order - reports nothing.
 //
 // Changes are ordered best price outward within a side, arrivals and changes before departures.
-public record LevelsChanged(string Symbol, DateTime Time, IReadOnlyList<LevelChange> Changes)
+//
+// Depth is how many levels a side of the window holds, and it is part of what the event says
+// rather than a note about it: the same action produces a different set of changes at five deep
+// than at ten, so a report is only meaningful paired with the window it describes. A book asked
+// for several depths answers with one of these per depth, and a feed takes the one it publishes.
+//
+// It has to work that way, because a shallower report is not a filtered deeper one. Bids at
+// 200/190/180/170/160/150 with a new bid arriving at 195: ten deep, only the arrival is news, and
+// price-keyed reporting deliberately says nothing about the levels that merely moved rank. Five
+// deep, 160 has been pushed out of the window and has to be Removed - a change that appears
+// nowhere in the ten-deep report, at any rank. Truncating by LevelIndex would silently leave a
+// five-deep subscriber holding a level that is no longer published.
+public record LevelsChanged(string Symbol, DateTime Time, int Depth,
+        IReadOnlyList<LevelChange> Changes)
     : MarketEvent(Symbol, Time)
 {
     // Spelled out because a record's generated equality compares a list member by reference, and
@@ -176,12 +189,13 @@ public record LevelsChanged(string Symbol, DateTime Time, IReadOnlyList<LevelCha
         && EqualityContract == other.EqualityContract
         && Symbol == other.Symbol
         && Time == other.Time
+        && Depth == other.Depth
         && Changes.SequenceEqual(other.Changes);
 
-    public override int GetHashCode() => HashCode.Combine(Symbol, Time, Changes.Count);
+    public override int GetHashCode() => HashCode.Combine(Symbol, Time, Depth, Changes.Count);
 
     public override string ToString() =>
-        $"{nameof(LevelsChanged)} {{ Symbol = {Symbol}, Time = {Time:O}, " +
+        $"{nameof(LevelsChanged)} {{ Symbol = {Symbol}, Time = {Time:O}, Depth = {Depth}, " +
         $"Changes = [{string.Join(", ", Changes)}] }}";
 }
 
@@ -194,9 +208,12 @@ public record LevelsChanged(string Symbol, DateTime Time, IReadOnlyList<LevelCha
 // are carried here, so a snapshot feed can republish them and a subscriber can start from
 // something true. That is what CME's snapshot does, carrying instrument status alongside the book.
 //
-// Levels are the published window, ten deep, in displayed size - the same aggregate LevelsChanged
-// reports moves to. Orders are the whole working book, best price outward and in queue order
-// within a price, since an order-by-order product carries the book rather than a window.
+// Levels are the deepest window the book reports, in displayed size - the same aggregate
+// LevelsChanged reports moves to. A feed publishing less takes the top of it, which unlike a
+// delta is a plain truncation: an image says where the book is, so the first five entries of a
+// ten-deep image are exactly the five-deep image. Orders are the whole working book, best price
+// outward and in queue order within a price, since an order-by-order product carries the book
+// rather than a window.
 public record BookSnapshot(string Symbol, DateTime Time, IReadOnlyList<Level> Bids,
         IReadOnlyList<Level> Offers, IReadOnlyList<RestingOrder> Orders, OrderBookStatus Status,
         OrderBookStatusChangeReason StatusReason, DateTime? ResumesAt, Side? LimitState,

--- a/src/Circus/MarketData/InstrumentFeed.cs
+++ b/src/Circus/MarketData/InstrumentFeed.cs
@@ -17,11 +17,20 @@ namespace Circus.MarketData;
 // Everything by default: a caller who has not thought about channels sees the whole venue, which
 // is more than any real depth feed carries and the useful answer for a simulator.
 //
-// How deep the by-price products run is not here. That is the book's, since the book is what
-// reports the levels, and a feed publishes as much of what it is given as it wants.
+// Two numbers go with the products. Depth is how far the by-price products run, which has to be
+// agreed with the book rather than applied here - a shallower delta stream is not a filtered
+// deeper one, so the book is asked to report at this depth and this feed takes those reports. The
+// snapshot half does truncate, because an image cuts cleanly where a delta does not.
+//
+// snapshotEvery is how many snapshot ticks pass between images. The venue ticks at the finest
+// cadence any of its channels wants and each feed counts the ticks it cares about, so a group
+// whose depth feed restates itself every cycle and whose order-by-order feed restates itself every
+// fifth is one interval and two counters rather than two schedules to keep in step. Real venues
+// are shaped that way for the same reason: a full order-by-order image is the heaviest message a
+// venue sends, so it cycles slower than the depth image beside it.
 public sealed class InstrumentFeed
 {
-    private readonly MarketByPriceIncrementalProducer _levels = new();
+    private readonly MarketByPriceIncrementalProducer _levels;
     private readonly MarketByOrderIncrementalProducer _orderByOrder = new();
     private readonly TradeDataProducer _trades = new();
     private readonly IndicativePriceDataProducer _indicative = new();
@@ -30,22 +39,43 @@ public sealed class InstrumentFeed
     // The other half of what a venue publishes, on its own stream: where the book is, rather than
     // what changed about it. Each republishes the same message type its incremental counterpart
     // does, so a subscriber applies a snapshot the same way it applies an update.
-    private readonly MarketByPriceSnapshotProducer _levelsSnapshot = new();
+    private readonly MarketByPriceSnapshotProducer _levelsSnapshot;
     private readonly InstrumentStatusSnapshotProducer _statusSnapshot = new();
     private readonly IndicativePriceSnapshotProducer _indicativeSnapshot = new();
     private readonly MarketByOrderSnapshotProducer _orderByOrderSnapshot = new();
 
     private readonly FeedProducts _products;
+    private readonly int _depth;
+    private readonly int _snapshotEvery;
 
-    public InstrumentFeed(string symbol, FeedProducts products = FeedProducts.All)
+    // Snapshot ticks seen, not dispatches: a tick is a dispatch carrying a BookSnapshot for this
+    // instrument, and everything else passes without moving the count.
+    private long _snapshotTicks;
+
+    public InstrumentFeed(string symbol, FeedProducts products = FeedProducts.All,
+        int depth = OrderBook.DefaultPublishedDepth, int snapshotEvery = 1)
     {
         if (products == FeedProducts.None)
             throw new ArgumentException(
                 "a feed carrying no products publishes nothing, which is a channel that should " +
                 "not have been created rather than one that is quiet", nameof(products));
 
+        if (depth <= 0)
+            throw new ArgumentOutOfRangeException(nameof(depth), depth,
+                "a feed carrying no levels is not a by-price feed");
+
+        if (snapshotEvery <= 0)
+            throw new ArgumentOutOfRangeException(nameof(snapshotEvery), snapshotEvery,
+                "a feed that skips every tick has no snapshot stream - leave the group's " +
+                "snapshot interval unset instead, which says so");
+
         Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
         _products = products;
+        _depth = depth;
+        _snapshotEvery = snapshotEvery;
+
+        _levels = new MarketByPriceIncrementalProducer(depth);
+        _levelsSnapshot = new MarketByPriceSnapshotProducer(depth);
     }
 
     public string Symbol { get; }
@@ -53,6 +83,13 @@ public sealed class InstrumentFeed
     // What this feed carries. A channel is a subset of the venue in two directions - which
     // instruments, and which products about them - and this is the second.
     public FeedProducts Products => _products;
+
+    // How deep its by-price products run. The book has to be reporting at this depth for them to
+    // carry anything, which is why the two are configured together.
+    public int Depth => _depth;
+
+    // How many snapshot ticks pass between images on this feed. One restates on every tick.
+    public int SnapshotEvery => _snapshotEvery;
 
     private bool Carries(FeedProducts product) => (_products & product) != 0;
 
@@ -81,12 +118,23 @@ public sealed class InstrumentFeed
     // streams are numbered separately and published independently - a subscriber in sync reads
     // only the incremental one, and a channel is free to carry no snapshot feed at all.
     //
-    // A dispatch that is not a snapshot tick produces nothing here, so the common path costs three
-    // scans that find nothing rather than a branch the caller has to know to take.
+    // A dispatch that is not a snapshot tick produces nothing here, so the common path costs one
+    // scan that finds nothing rather than a branch the caller has to know to take.
+    //
+    // Ticks are counted before the cadence is applied, so a feed on every fifth tick publishes on
+    // the fifth and not the first. A joiner therefore waits at most a full cycle, which is what
+    // the cycle means; publishing immediately and then every fifth would make the first gap
+    // shorter than the promise.
     public IReadOnlyList<MarketDataEvent> Snapshot(IReadOnlyList<OrderBookEvent> bookEvents)
     {
         var events = PublicHalf(bookEvents);
         if (events.Count == 0)
+            return Array.Empty<MarketDataEvent>();
+
+        if (!IsSnapshotTick(events))
+            return Array.Empty<MarketDataEvent>();
+
+        if (++_snapshotTicks % _snapshotEvery != 0)
             return Array.Empty<MarketDataEvent>();
 
         List<MarketDataEvent>? output = null;
@@ -114,6 +162,20 @@ public sealed class InstrumentFeed
         }
 
         return publicEvents ?? (IReadOnlyList<MarketEvent>) Array.Empty<MarketEvent>();
+    }
+
+    // A tick is a dispatch the book answered with an image. Counting those rather than every
+    // dispatch is what makes the cadence "every fifth snapshot" instead of "every fifth action",
+    // which would tie how often a feed restates itself to how busy the instrument is.
+    private static bool IsSnapshotTick(IReadOnlyList<MarketEvent> events)
+    {
+        for (var i = 0; i < events.Count; i++)
+        {
+            if (events[i] is BookSnapshot)
+                return true;
+        }
+
+        return false;
     }
 
     private static void Collect<T>(ref List<MarketDataEvent>? output, IList<T> produced)

--- a/src/Circus/MarketData/LevelsDataEvent.cs
+++ b/src/Circus/MarketData/LevelsDataEvent.cs
@@ -1,5 +1,11 @@
 namespace Circus.MarketData;
 
-public record LevelsDataEvent(string Symbol, DateTime Time, IReadOnlyList<Level> Bids,
+// The by-price snapshot: where the book is, rather than what changed about it.
+//
+// Depth is the window this feed publishes, and the lists are that window or shorter when the book
+// holds less. Unlike a delta an image truncates cleanly - the first five entries of a ten-deep
+// image are the five-deep image - so a feed shallower than the book it reads takes the top of what
+// it is given rather than needing an image of its own.
+public record LevelsDataEvent(string Symbol, DateTime Time, int Depth, IReadOnlyList<Level> Bids,
         IReadOnlyList<Level> Offers)
     : MarketDataEvent(Symbol, Time);

--- a/src/Circus/MarketData/MarketByPriceDeltaEvent.cs
+++ b/src/Circus/MarketData/MarketByPriceDeltaEvent.cs
@@ -29,7 +29,14 @@ public record MarketByPriceDelta(Side Side, int LevelIndex, decimal Price, int Q
 // type - not because either needs reassembling on the way through.
 //
 // Changes are ordered best price outward within a side, arrivals and changes before departures.
-public record MarketByPriceDeltaEvent(string Symbol, DateTime Time, IReadOnlyList<MarketByPriceDelta> Changes)
+//
+// Depth is how many levels a side of this feed's window holds - CME's ten for futures, a
+// top-of-book product's one - and a subscriber needs it to know what a departure means: at ten
+// deep a Removed says the level emptied, at one deep it usually says a better price arrived.
+// A venue publishing the same book at two depths publishes two streams of these, because a
+// shallower one is not a filtered deeper one; see LevelsChanged for why.
+public record MarketByPriceDeltaEvent(string Symbol, DateTime Time, int Depth,
+        IReadOnlyList<MarketByPriceDelta> Changes)
     : MarketDataEvent(Symbol, Time)
 {
     // Both spelled out for the reason LevelsChanged spells them out: a record's generated equality
@@ -41,11 +48,12 @@ public record MarketByPriceDeltaEvent(string Symbol, DateTime Time, IReadOnlyLis
         && EqualityContract == other.EqualityContract
         && Symbol == other.Symbol
         && Time == other.Time
+        && Depth == other.Depth
         && Changes.SequenceEqual(other.Changes);
 
-    public override int GetHashCode() => HashCode.Combine(Symbol, Time, Changes.Count);
+    public override int GetHashCode() => HashCode.Combine(Symbol, Time, Depth, Changes.Count);
 
     public override string ToString() =>
         $"{nameof(MarketByPriceDeltaEvent)} {{ Symbol = {Symbol}, Time = {Time:O}, " +
-        $"Changes = [{string.Join(", ", Changes)}] }}";
+        $"Depth = {Depth}, Changes = [{string.Join(", ", Changes)}] }}";
 }

--- a/src/Circus/MarketData/MarketByPriceIncrementalProducer.cs
+++ b/src/Circus/MarketData/MarketByPriceIncrementalProducer.cs
@@ -10,18 +10,38 @@ namespace Circus.MarketData;
 // depth from order events has to hold the book the subscriber is missing, which is what the
 // previous LevelDataProducer did - and why it could never resync after a missed event.
 //
-// A dispatch is one action's events, and the book emits at most one LevelsChanged for it, so the
-// loop below normally runs once. It is a loop rather than a lookup because a dispatch spanning
-// instruments would carry one per book, and each has to become its own message.
+// A dispatch is one action's events, and the book emits one LevelsChanged per depth it reports,
+// so the loop below normally runs once and the filter normally matches everything. It is a loop
+// rather than a lookup because a dispatch spanning instruments would carry one per book, and each
+// has to become its own message.
+//
+// Depth is a subscription rather than a truncation. The book is asked to report at this depth and
+// this producer takes those reports; it does not take a deeper report and cut it down, because a
+// shallower window's departures are not present in a deeper window's report at all - see
+// LevelsChanged. A producer whose depth the book does not report publishes nothing, which is the
+// failure InstrumentGroup exists to prevent by building both from one number.
 public class MarketByPriceIncrementalProducer : IIncrementalProducer<MarketByPriceDeltaEvent>
 {
+    private readonly int _depth;
+
+    public MarketByPriceIncrementalProducer(int depth = OrderBook.DefaultPublishedDepth)
+    {
+        if (depth <= 0)
+            throw new ArgumentOutOfRangeException(nameof(depth), depth,
+                "a feed carrying no levels is not a by-price feed");
+
+        _depth = depth;
+    }
+
+    public int Depth => _depth;
+
     public IList<MarketByPriceDeltaEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<MarketByPriceDeltaEvent>? output = null;
 
         foreach (var ev in events)
         {
-            if (ev is not LevelsChanged levels)
+            if (ev is not LevelsChanged levels || levels.Depth != _depth)
                 continue;
 
             var changes = new List<MarketByPriceDelta>(levels.Changes.Count);
@@ -32,7 +52,7 @@ public class MarketByPriceIncrementalProducer : IIncrementalProducer<MarketByPri
             }
 
             output ??= new List<MarketByPriceDeltaEvent>();
-            output.Add(new MarketByPriceDeltaEvent(levels.Symbol, levels.Time, changes));
+            output.Add(new MarketByPriceDeltaEvent(levels.Symbol, levels.Time, levels.Depth, changes));
         }
 
         return output ?? (IList<MarketByPriceDeltaEvent>) Array.Empty<MarketByPriceDeltaEvent>();

--- a/src/Circus/MarketData/SnapshotProducers.cs
+++ b/src/Circus/MarketData/SnapshotProducers.cs
@@ -13,8 +13,26 @@ namespace Circus.MarketData;
 // One class per product rather than one producing all three, because a channel carrying only
 // depth should be able to leave the rest out - the same reason InstrumentFeed is a bundle of
 // producers rather than one that does everything.
+//
+// The one place a feed shallower than its book truncates rather than subscribing. An image says
+// where the book is, so the first five entries of a ten-deep image are the five-deep image and
+// nothing is lost by cutting. A delta is the opposite - see LevelsChanged - which is why the
+// incremental half takes reports made at its depth instead.
 public class MarketByPriceSnapshotProducer : IIncrementalProducer<LevelsDataEvent>
 {
+    private readonly int _depth;
+
+    public MarketByPriceSnapshotProducer(int depth = OrderBook.DefaultPublishedDepth)
+    {
+        if (depth <= 0)
+            throw new ArgumentOutOfRangeException(nameof(depth), depth,
+                "a feed carrying no levels is not a by-price feed");
+
+        _depth = depth;
+    }
+
+    public int Depth => _depth;
+
     public IList<LevelsDataEvent> Process(IReadOnlyList<MarketEvent> events)
     {
         List<LevelsDataEvent>? output = null;
@@ -25,10 +43,25 @@ public class MarketByPriceSnapshotProducer : IIncrementalProducer<LevelsDataEven
                 continue;
 
             output ??= new List<LevelsDataEvent>();
-            output.Add(new LevelsDataEvent(snapshot.Symbol, snapshot.Time, snapshot.Bids, snapshot.Offers));
+            output.Add(new LevelsDataEvent(snapshot.Symbol, snapshot.Time, _depth,
+                Truncate(snapshot.Bids), Truncate(snapshot.Offers)));
         }
 
         return output ?? (IList<LevelsDataEvent>) Array.Empty<LevelsDataEvent>();
+    }
+
+    // The book's list unchanged when it is already within the window, so the common case - a feed
+    // as deep as the book that feeds it - copies nothing.
+    private IReadOnlyList<Level> Truncate(IReadOnlyList<Level> levels)
+    {
+        if (levels.Count <= _depth)
+            return levels;
+
+        var window = new List<Level>(_depth);
+        for (var i = 0; i < _depth; i++)
+            window.Add(levels[i]);
+
+        return window;
     }
 }
 

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -67,14 +67,22 @@ public class OrderBook : IOrderBook
     // always carried. A default rather than a rule - see below.
     public const int DefaultPublishedDepth = 10;
 
-    // How deep this book reports its levels. A capability, not a subscription: the book says how
-    // far it is willing to look, and a channel publishing less takes the top of what it is given.
-    // A venue whose deepest product is twenty sets this to twenty and lets its five-deep channel
-    // truncate; setting it to five would leave that channel with nothing to truncate from.
+    // The depths this book reports its levels at, ascending and distinct. One number is the usual
+    // case; several are for a venue publishing the same instrument's depth in more than one shape,
+    // which is common enough to be named - CME runs a top-of-book channel alongside its ten-deep
+    // one, and Databento sells mbp-1 and mbp-10 off the same book.
     //
-    // Deliberately not "which channels want what". The book knows how deep to look and nothing
-    // about who is reading, which is what keeps it a function of its actions and one number.
-    private readonly int _publishedDepth;
+    // Several rather than one deep report the feeds truncate, because a delta does not truncate:
+    // see LevelsChanged. Each depth gets its own diff of the same before and after windows, which
+    // costs a scan of a bounded window and nothing else - the ladders are not walked again.
+    //
+    // Still not "which channels want what". The book is told how far to look and knows nothing
+    // about who is reading, which is what keeps it a function of its actions and its depths.
+    private int[] _publishedDepths;
+
+    // The deepest of them, which is the window actually captured: every shallower report is a
+    // prefix of it.
+    private int _maxPublishedDepth;
 
     // The published window as it stood before the action and as it stands after, diffed to
     // produce LevelsChanged. Reused per book for the reason the buffer above is: one action at a
@@ -158,7 +166,14 @@ public class OrderBook : IOrderBook
     private const int MaxClientOrderIdLength = 20;
 
     public OrderBook(Instrument instrument, int publishedDepth = DefaultPublishedDepth)
-        : this(instrument, Adapt(instrument.PriceRestrictions), publishedDepth)
+        : this(instrument, Adapt(instrument.PriceRestrictions), new[] {publishedDepth})
+    {
+    }
+
+    // For a venue publishing the same book at more than one depth. Order and duplicates do not
+    // matter; what comes back out is ascending and distinct.
+    public OrderBook(Instrument instrument, IReadOnlyList<int> publishedDepths)
+        : this(instrument, Adapt(instrument.PriceRestrictions), publishedDepths)
     {
     }
 
@@ -189,20 +204,57 @@ public class OrderBook : IOrderBook
     // trade-scoped restrictions disagreeing about severity, say - can still be exercised.
     internal OrderBook(Instrument instrument, IReadOnlyList<IPriceRestriction> priceRestrictions,
         int publishedDepth = DefaultPublishedDepth)
+        : this(instrument, priceRestrictions, new[] {publishedDepth})
     {
-        if (publishedDepth <= 0)
-            throw new ArgumentOutOfRangeException(nameof(publishedDepth), publishedDepth,
-                "a book that reports no levels publishes no depth at all");
+    }
+
+    internal OrderBook(Instrument instrument, IReadOnlyList<IPriceRestriction> priceRestrictions,
+        IReadOnlyList<int> publishedDepths)
+    {
+        ArgumentNullException.ThrowIfNull(publishedDepths);
+
+        if (publishedDepths.Count == 0)
+            throw new ArgumentException(
+                "a book reporting at no depth publishes no by-price data at all", nameof(publishedDepths));
+
+        foreach (var depth in publishedDepths)
+        {
+            if (depth <= 0)
+                throw new ArgumentOutOfRangeException(nameof(publishedDepths), depth,
+                    "a book that reports no levels publishes no depth at all");
+        }
 
         _instrument = instrument;
         _priceRestrictions = priceRestrictions;
         _phases = BuildPhases(instrument.MatchingAlgorithm);
-        _publishedDepth = publishedDepth;
+        _publishedDepths = publishedDepths.Distinct().OrderBy(d => d).ToArray();
+        _maxPublishedDepth = _publishedDepths[^1];
 
-        _bidsBefore = new List<(long, int, int)>(publishedDepth);
-        _offersBefore = new List<(long, int, int)>(publishedDepth);
-        _bidsAfter = new List<(long, int, int)>(publishedDepth);
-        _offersAfter = new List<(long, int, int)>(publishedDepth);
+        _bidsBefore = new List<(long, int, int)>(_maxPublishedDepth);
+        _offersBefore = new List<(long, int, int)>(_maxPublishedDepth);
+        _bidsAfter = new List<(long, int, int)>(_maxPublishedDepth);
+        _offersAfter = new List<(long, int, int)>(_maxPublishedDepth);
+    }
+
+    // What this book reports its levels at, ascending and distinct.
+    public IReadOnlyList<int> PublishedDepths => _publishedDepths;
+
+    // Adds a depth to report at. For a channel declared after the book was built: the alternative
+    // is a book that publishes nothing to it, which is the one failure mode worth spending an API
+    // on. Idempotent, and safe between actions - the windows are captured at the top of every
+    // Process, so a depth added here is diffed from the next action onwards and never from a
+    // window it was not part of.
+    internal void AlsoReport(int depth)
+    {
+        if (depth <= 0)
+            throw new ArgumentOutOfRangeException(nameof(depth), depth,
+                "a book that reports no levels publishes no depth at all");
+
+        if (Array.IndexOf(_publishedDepths, depth) >= 0)
+            return;
+
+        _publishedDepths = _publishedDepths.Append(depth).OrderBy(d => d).ToArray();
+        _maxPublishedDepth = _publishedDepths[^1];
     }
 
     public string Symbol => _instrument.Symbol;
@@ -468,7 +520,7 @@ public class OrderBook : IOrderBook
     // The same goes for order-by-order, which gets a snapshot of its own once it has one to give.
     private BookSnapshot Snapshot(DateTime time) =>
         new(_instrument.Symbol, time,
-            GetLevels(Side.Buy, _publishedDepth), GetLevels(Side.Sell, _publishedDepth),
+            GetLevels(Side.Buy, _maxPublishedDepth), GetLevels(Side.Sell, _maxPublishedDepth),
             GetRestingOrders(),
             _status, _statusReason, _resumeAt, _limitState,
             _indicativeQuote is { } quote ? ToDecimal(quote.PriceTicks) : null,
@@ -600,36 +652,55 @@ public class OrderBook : IOrderBook
     }
 
     private void CaptureWindow(List<(long Tick, int Quantity, int Count)> into, Side side) =>
-        _matcher.Working[side].CopyLevelsFromBest(_publishedDepth, into);
+        _matcher.Working[side].CopyLevelsFromBest(_maxPublishedDepth, into);
 
-    // One event carrying every level the action moved, or none at all if it moved none - an
-    // action that touches no level, a status change or a rejected order, says nothing here.
+    // One event per reported depth, each carrying every level the action moved within that window,
+    // and none at all for a depth it moved nothing in - an action that touches no level, a status
+    // change or a rejected order, says nothing here.
+    //
+    // The windows are captured once at the deepest and diffed once per depth, since a shallower
+    // window is a prefix of a deeper one. Diffing rather than truncating the deepest report is the
+    // whole point: see LevelsChanged for the case that makes truncation wrong.
     private void AppendLevelChanges(List<OrderBookEvent> events, DateTime time)
     {
         CaptureWindow(_bidsAfter, Side.Buy);
         CaptureWindow(_offersAfter, Side.Sell);
 
-        List<LevelChange>? changes = null;
-        CollectLevelChanges(ref changes, Side.Buy, _bidsBefore, _bidsAfter);
-        CollectLevelChanges(ref changes, Side.Sell, _offersBefore, _offersAfter);
+        // Shallowest first, so a book reporting several does so in a fixed order rather than the
+        // order it was configured in.
+        foreach (var depth in _publishedDepths)
+        {
+            List<LevelChange>? changes = null;
+            CollectLevelChanges(ref changes, Side.Buy, _bidsBefore, _bidsAfter, depth);
+            CollectLevelChanges(ref changes, Side.Sell, _offersBefore, _offersAfter, depth);
 
-        if (changes != null)
-            events.Add(new LevelsChanged(_instrument.Symbol, time, changes));
+            if (changes != null)
+                events.Add(new LevelsChanged(_instrument.Symbol, time, depth, changes));
+        }
     }
 
     // Diffed by price rather than by position - see LevelChange for why - which also means a
     // level that only moved rank contributes nothing, since its price, size and count are all
-    // unchanged. Ten a side at most, so the nested scans below are bounded at a hundred
-    // comparisons and need no index to beat that.
+    // unchanged. Ten a side at most in the usual case, so the nested scans below are bounded at a
+    // hundred comparisons and need no index to beat that.
+    //
+    // depth is where this window ends. The lists are the deepest window, so a shallower report
+    // reads a prefix of them at both ends - a level below the cut is outside the window and is
+    // neither reported nor available to match against, which is exactly what makes a level pushed
+    // past the cut a departure rather than nothing at all.
     private void CollectLevelChanges(ref List<LevelChange>? changes, Side side,
-        List<(long Tick, int Quantity, int Count)> before, List<(long Tick, int Quantity, int Count)> after)
+        List<(long Tick, int Quantity, int Count)> before, List<(long Tick, int Quantity, int Count)> after,
+        int depth)
     {
+        var beforeCount = Math.Min(before.Count, depth);
+        var afterCount = Math.Min(after.Count, depth);
+
         // Arrivals and changes first, best price outward, so a consumer applying them in order
         // builds the near side of the book before the far side.
-        for (var i = 0; i < after.Count; i++)
+        for (var i = 0; i < afterCount; i++)
         {
             var (tick, quantity, count) = after[i];
-            var previous = IndexOfTick(before, tick);
+            var previous = IndexOfTick(before, beforeCount, tick);
 
             if (previous < 0)
             {
@@ -644,18 +715,18 @@ public class OrderBook : IOrderBook
         }
 
         // Then departures, carrying the rank each last held and nothing left at it.
-        for (var i = 0; i < before.Count; i++)
+        for (var i = 0; i < beforeCount; i++)
         {
             var tick = before[i].Tick;
-            if (IndexOfTick(after, tick) < 0)
+            if (IndexOfTick(after, afterCount, tick) < 0)
                 (changes ??= new List<LevelChange>()).Add(new LevelChange(side, i + 1, ToDecimal(tick),
                     0, 0, LevelChangeAction.Removed));
         }
     }
 
-    private static int IndexOfTick(List<(long Tick, int Quantity, int Count)> levels, long tick)
+    private static int IndexOfTick(List<(long Tick, int Quantity, int Count)> levels, int count, long tick)
     {
-        for (var i = 0; i < levels.Count; i++)
+        for (var i = 0; i < count; i++)
         {
             if (levels[i].Tick == tick)
                 return i;

--- a/src/Circus/Sequencing/InstrumentGroup.cs
+++ b/src/Circus/Sequencing/InstrumentGroup.cs
@@ -15,7 +15,11 @@ namespace Circus.Sequencing;
 // venue's and there is one of it, while what gets published about it is a product decision with
 // several answers. CME runs a channel per product group carrying by-price and by-order together;
 // Eurex publishes the same instrument on EOBI and on EMDI with different products on each. A
-// channel here differs from its siblings in what it carries, not in the order it sees things.
+// channel here differs from its siblings in what it carries, not in the order it sees things:
+// which instruments, which products about them, how deep its by-price products run, and how often
+// it restates itself. All four are declared on the channel, and the books are built to match -
+// which they have to be for depth, since a shallow delta stream has to be diffed at its own
+// window rather than cut down from a deep one.
 //
 // Declare the channels, then add instruments; an instrument goes on every channel unless it names
 // some, because in both venues the channels of a group carry the same instruments and differ in
@@ -27,15 +31,29 @@ public sealed class InstrumentGroup
 {
     private readonly Sequencer _sequencer;
 
+    // What one channel publishes: the stream itself and the three things a feed on it is built
+    // from. Held rather than derived, because a channel declared before any instrument has to be
+    // able to describe itself, and one declared after has to build the same feed for a symbol that
+    // is already here.
+    private sealed record ChannelConfig(MarketDataChannel Channel, FeedProducts Products, int Depth,
+        int SnapshotEvery);
+
     // Insertion-ordered, so a caller iterating them gets the order it declared them in rather than
     // a dictionary's.
-    private readonly Dictionary<string, (MarketDataChannel Channel, FeedProducts Products)> _channels = new();
+    private readonly Dictionary<string, ChannelConfig> _channels = new();
     private readonly List<string> _channelOrder = new();
     private readonly List<string> _symbols = new();
 
-    // snapshotInterval is how often each book restates itself on the channel's snapshot stream.
-    // Null publishes no snapshot feed, which leaves a subscriber unable to join mid-session or
-    // recover from a gap - the position everything here was in before there was one.
+    // The books this group built, so a channel declared later can ask them to start reporting at
+    // its depth. Only the ones built here: a book handed in ready-made reports what its owner told
+    // it to, and this is not the place to change that.
+    private readonly Dictionary<string, OrderBook> _ownBooks = new();
+
+    // snapshotInterval is how often each book is asked to restate itself. Set it to the finest
+    // cadence any channel here wants; a channel wanting a slower one counts ticks and skips, which
+    // is what AddChannel's snapshotEvery is for. Null publishes no snapshot feed at all, which
+    // leaves a subscriber unable to join mid-session or recover from a gap - the position
+    // everything here was in before there was one.
     public InstrumentGroup(DateTime start, TimeSpan? snapshotInterval = null)
     {
         _sequencer = new Sequencer(start, snapshotInterval);
@@ -62,52 +80,89 @@ public sealed class InstrumentGroup
     };
 
     public MarketDataChannel ChannelNamed(string name) =>
-        _channels.TryGetValue(name, out var entry)
-            ? entry.Channel
+        _channels.TryGetValue(name, out var config)
+            ? config.Channel
             : throw new ArgumentException($"no channel named {name} in this group", nameof(name));
 
     // Declares a channel and what it publishes. Every instrument already registered joins it, so
     // the order channels and instruments are declared in does not change what comes out.
-    public void AddChannel(string name, FeedProducts products = FeedProducts.All)
+    //
+    // depth is how far its by-price products run. The channel's books are told to report at it -
+    // the ones this group built, at least - because a shallower delta stream is not a filtered
+    // deeper one and has to be diffed at its own window. Ten by default, which is what CME's
+    // futures books carry; one is a top-of-book product, and a channel carrying no by-price
+    // product ignores it.
+    //
+    // snapshotEvery is how many of the group's snapshot ticks pass between this channel's images.
+    // One restates on every tick. It is a count rather than an interval so that the channels of a
+    // group stay in step: the group ticks at the finest cadence any of them wants, and a channel
+    // wanting a slower one skips ticks rather than keeping a schedule of its own.
+    public void AddChannel(string name, FeedProducts products = FeedProducts.All,
+        int depth = OrderBook.DefaultPublishedDepth, int snapshotEvery = 1)
     {
         ArgumentNullException.ThrowIfNull(name);
 
         if (_channels.ContainsKey(name))
             throw new ArgumentException($"a channel named {name} is already in this group", nameof(name));
 
+        // Here rather than left to the first feed built from it, so a channel declared before any
+        // instrument is refused where it was written rather than when something is added to it.
+        if (depth <= 0)
+            throw new ArgumentOutOfRangeException(nameof(depth), depth,
+                "a channel carrying no levels is not a by-price channel");
+
+        if (snapshotEvery <= 0)
+            throw new ArgumentOutOfRangeException(nameof(snapshotEvery), snapshotEvery,
+                "a channel that skips every tick has no snapshot stream - leave the group's " +
+                "snapshot interval unset instead, which says so");
+
         var channel = new MarketDataChannel(name);
-        _channels[name] = (channel, products);
+        var config = new ChannelConfig(channel, products, depth, snapshotEvery);
+        _channels[name] = config;
         _channelOrder.Add(name);
 
         foreach (var symbol in _symbols)
-            channel.Add(new InstrumentFeed(symbol, products));
+        {
+            // Before the feed, so the feed it joins is one the book will actually report to.
+            if (Carries(config, FeedProducts.ByPrice) && _ownBooks.TryGetValue(symbol, out var book))
+                book.AlsoReport(depth);
+
+            channel.Add(FeedFor(symbol, config));
+        }
     }
 
     // Registers an instrument: creates a bare OrderBook and an InstrumentFeed, adds the book and
     // schedule to the sequencer and the feed to the channel.
     //
-    // publishedDepth is how deep that book reports its levels - the deepest any product taken off
-    // it will want, since a channel publishing less truncates what it is given and one publishing
-    // more has nothing to truncate from. Ten by default, which is what CME's futures books carry.
-    // A caller wanting a book configured further builds one and uses the overload below.
-    // products is what the channel publishes about it. Everything by default, which is more than
-    // a real feed carries and the useful answer until a caller has a venue shape in mind.
+    // How deep the book reports is not a parameter here any more, because it is not a property of
+    // the instrument: it is what its by-price channels publish, and the book is built to report at
+    // each of those depths. A group whose only channel is ten deep gets a ten-deep book; one
+    // running a top-of-book channel beside it gets a book reporting at one and at ten, since a
+    // one-deep delta stream has to be diffed at one deep rather than cut down from ten.
+    //
+    // A caller wanting a book configured further - custom price restrictions, its own depths -
+    // builds one and uses the overload below.
     public void Add(Instrument instrument, MarketSchedule schedule,
-        int publishedDepth = OrderBook.DefaultPublishedDepth,
         IReadOnlyList<string>? channels = null)
     {
         ArgumentNullException.ThrowIfNull(instrument);
         ArgumentNullException.ThrowIfNull(schedule);
 
         RequireChannelsExist(channels);
+        EnsureSomeChannel(channels);
 
-        var book = new OrderBook(instrument, publishedDepth);
+        var book = new OrderBook(instrument, DepthsFor(channels));
         _sequencer.Add(book, schedule);
+        _ownBooks[instrument.Symbol] = book;
         Publish(instrument.Symbol, channels);
     }
 
     // Registers a pre-built book (e.g. with custom price restrictions) alongside its schedule and
     // an instrument feed for it.
+    //
+    // Its depths are its owner's. A channel here publishes by-price data for it only where the two
+    // agree, so a book built at ten and a channel declared at five leave that channel's by-price
+    // products empty for this instrument - build the book with the depths its channels publish.
     public void Add(IOrderBook book, MarketSchedule schedule, IReadOnlyList<string>? channels = null)
     {
         ArgumentNullException.ThrowIfNull(book);
@@ -117,6 +172,45 @@ public sealed class InstrumentGroup
 
         _sequencer.Add(book, schedule);
         Publish(book.Symbol, channels);
+    }
+
+    // The depths the by-price channels carrying this instrument publish at. Channels carrying no
+    // by-price product contribute nothing, so an order-by-order channel does not make the book
+    // diff a window nobody reads; if none of them do, the book still reports at the default, which
+    // costs one bounded diff and keeps a book's behaviour independent of who happens to subscribe.
+    private int[] DepthsFor(IReadOnlyList<string>? channels)
+    {
+        var depths = (channels ?? _channelOrder)
+            .Select(name => _channels[name])
+            .Where(config => Carries(config, FeedProducts.ByPrice))
+            .Select(config => config.Depth)
+            .Distinct()
+            .ToArray();
+
+        return depths.Length > 0 ? depths : new[] {OrderBook.DefaultPublishedDepth};
+    }
+
+    // The depths the book this group built for a symbol reports at, or nothing for a book handed
+    // in ready-made. Internal because it is the one part of the wiring between a channel's
+    // declared depth and its book's reports that is otherwise invisible: get it wrong and the
+    // symptom is by-price data quietly not arriving, which is what this lets a test rule out.
+    internal IReadOnlyList<int> PublishedDepthsFor(string symbol) =>
+        _ownBooks.TryGetValue(symbol, out var book)
+            ? book.PublishedDepths
+            : Array.Empty<int>();
+
+    private static bool Carries(ChannelConfig config, FeedProducts product) =>
+        (config.Products & product) != 0;
+
+    private static InstrumentFeed FeedFor(string symbol, ChannelConfig config) =>
+        new(symbol, config.Products, config.Depth, config.SnapshotEvery);
+
+    // The default channel, created before the book is, so the book can be built to report at the
+    // depth that channel publishes. Only when the caller named none - see Publish.
+    private void EnsureSomeChannel(IReadOnlyList<string>? channels)
+    {
+        if (channels == null && _channels.Count == 0)
+            AddChannel(MarketDataChannel.DefaultName);
     }
 
     // Before the book reaches the sequencer, so naming a channel that does not exist leaves the
@@ -142,16 +236,14 @@ public sealed class InstrumentGroup
     {
         // Only when the caller named none. Someone asking for a channel by name has a venue shape
         // in mind, and inventing a default underneath them would publish where they did not ask.
-        if (channels == null && _channels.Count == 0)
-            AddChannel(MarketDataChannel.DefaultName);
+        // Already done for an instrument this group built the book for, since the book had to be
+        // told what to report before it existed; idempotent, so the other overload lands here.
+        EnsureSomeChannel(channels);
 
         var carrying = channels ?? _channelOrder;
 
         foreach (var name in carrying)
-        {
-            var (channel, products) = _channels[name];
-            channel.Add(new InstrumentFeed(symbol, products));
-        }
+            _channels[name].Channel.Add(FeedFor(symbol, _channels[name]));
 
         _symbols.Add(symbol);
     }

--- a/tests/Circus.Tests/MarketData/LevelBookTests.cs
+++ b/tests/Circus.Tests/MarketData/LevelBookTests.cs
@@ -18,7 +18,7 @@ public class LevelBookTests
         Message(new MarketByPriceDelta(side, levelIndex, price, quantity, count, action));
 
     private static MarketByPriceDeltaEvent Message(params MarketByPriceDelta[] changes) =>
-        new("GCZ6", Now, changes);
+        new("GCZ6", Now, OrderBook.DefaultPublishedDepth, changes);
 
     [Test]
     public void ANewBook_IsEmpty()

--- a/tests/Circus.Tests/MarketData/PublishedDepthTests.cs
+++ b/tests/Circus.Tests/MarketData/PublishedDepthTests.cs
@@ -5,13 +5,15 @@ using NUnit.Framework;
 
 namespace Circus.Tests.MarketData;
 
-// How deep a book reports its levels is a capability rather than a rule: it says how far it is
-// willing to look, and a channel publishing less takes the top of what it is given. Ten by
-// default, which is what CME's futures books carry, and the only value anything here uses today.
+// How deep a book reports its levels: the windows it diffs its ladders across, one report per
+// window. Ten by default, which is what CME's futures books carry.
 //
-// It matters because a venue whose deepest product is twenty has to have a book looking twenty
-// deep - a channel cannot truncate from a window that was never built. These pin that the number
-// is honoured rather than approximated, at both ends and in the middle.
+// A book can be asked for several windows at once, and then reports once per window. That is not
+// an optimisation of "report deep and let each channel cut" - it is the only thing that works,
+// because a shallow delta stream is not a filtered deep one. AShallowReport_CarriesDepartures-
+// TheDeepReportDoesNot below is the case that says why.
+//
+// These pin that each number is honoured rather than approximated, at both ends and in the middle.
 public class PublishedDepthTests
 {
     private static readonly Instrument Gold = new("GCZ6", 10, 10);
@@ -19,9 +21,14 @@ public class PublishedDepthTests
 
     // Twelve resting bids at descending prices, so any depth up to twelve is exercised by a real
     // ladder rather than by a book that happened to be shallower than the window.
-    private static OrderBook BookWithTwelveBids(int? publishedDepth = null)
+    private static OrderBook BookWithTwelveBids(int? publishedDepth = null) =>
+        Fill(publishedDepth is { } depth ? new OrderBook(Gold, depth) : new OrderBook(Gold));
+
+    private static OrderBook BookWithTwelveBids(IReadOnlyList<int> publishedDepths) =>
+        Fill(new OrderBook(Gold, publishedDepths));
+
+    private static OrderBook Fill(OrderBook book)
     {
-        var book = publishedDepth is { } depth ? new OrderBook(Gold, depth) : new OrderBook(Gold);
         book.UpdateStatus(OrderBookStatus.Open, time: Start);
 
         for (var i = 0; i < 12; i++)
@@ -34,9 +41,13 @@ public class PublishedDepthTests
     }
 
     private static IReadOnlyList<LevelChange> LastReport(OrderBook book) =>
+        Reports(book).Single().Changes;
+
+    // Every report a new best bid produces, in the order the book emitted them.
+    private static IReadOnlyList<LevelsChanged> Reports(OrderBook book) =>
         book.CreateLimitOrder("CX", "OX", new OrderValidity.Day(), Side.Buy, 1, 210,
                 time: Start.AddMinutes(1))
-            .OfType<LevelsChanged>().Single().Changes;
+            .OfType<LevelsChanged>().ToList();
 
     [Test]
     public void ByDefault_ABookReportsTenDeep()
@@ -115,5 +126,97 @@ public class PublishedDepthTests
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new OrderBook(Gold, 0));
         Assert.Throws<ArgumentOutOfRangeException>(() => new OrderBook(Gold, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OrderBook(Gold, new[] {10, 0}));
+        Assert.Throws<ArgumentException>(() => new OrderBook(Gold, Array.Empty<int>()));
+    }
+
+    // A book can be asked for more than one window, which is what a venue publishing the same
+    // instrument's depth in two shapes needs - CME's top-of-book channel beside its ten-deep one,
+    // Databento's mbp-1 beside mbp-10.
+    [Test]
+    public void ABookAskedForSeveralDepths_ReportsOnceForEach()
+    {
+        var book = BookWithTwelveBids(new[] {10, 1});
+
+        var reports = Reports(book);
+
+        Assert.AreEqual(new[] {1, 10}, reports.Select(r => r.Depth).ToArray(),
+            "shallowest first, so the order is the book's and not the order it was configured in");
+    }
+
+    [Test]
+    public void TheSameDepthAskedForTwice_IsReportedOnce()
+    {
+        var book = BookWithTwelveBids(new[] {10, 10, 10});
+
+        Assert.AreEqual(new[] {10}, Reports(book).Select(r => r.Depth).ToArray());
+    }
+
+    // The case that decides the whole design. A new best bid at ten deep is one Added and nothing
+    // else: the levels beneath it only moved rank, and price-keyed reporting deliberately says
+    // nothing about that. At one deep the same action pushed 200 out of the window, so the report
+    // has to say so - and that Removed appears nowhere in the ten-deep report, at any rank.
+    //
+    // So a shallow feed cannot be built by filtering a deep report by LevelIndex. It has to be
+    // diffed at its own depth, which is why the book reports once per depth rather than once.
+    [Test]
+    public void AShallowReport_CarriesDeparturesTheDeepReportDoesNot()
+    {
+        var book = BookWithTwelveBids(new[] {1, 20});
+
+        var reports = Reports(book).ToDictionary(r => r.Depth);
+
+        Assert.AreEqual(1, reports[20].Changes.Count, "deeper than the book, so only the arrival is news");
+        Assert.AreEqual(LevelChangeAction.Added, reports[20].Changes[0].Action);
+        Assert.AreEqual(210, reports[20].Changes[0].Price);
+
+        Assert.AreEqual(2, reports[1].Changes.Count);
+        Assert.AreEqual(LevelChangeAction.Added, reports[1].Changes[0].Action);
+        Assert.AreEqual(210, reports[1].Changes[0].Price);
+        Assert.AreEqual(LevelChangeAction.Removed, reports[1].Changes[1].Action);
+        Assert.AreEqual(200, reports[1].Changes[1].Price,
+            "the old best bid left a one-deep window, and no deeper report mentions it");
+    }
+
+    // The same thing away from the top of the book, so it is not an artefact of depth one.
+    [Test]
+    public void ALevelPushedPastAShallowWindow_IsReportedAsLeavingIt()
+    {
+        var book = BookWithTwelveBids(new[] {5, 20});
+
+        var reports = Reports(book).ToDictionary(r => r.Depth);
+
+        Assert.AreEqual(1, reports[20].Changes.Count,
+            "nothing left a window deeper than the book");
+        Assert.AreEqual(new[] {(LevelChangeAction.Added, 210m), (LevelChangeAction.Removed, 160m)},
+            reports[5].Changes.Select(c => (c.Action, c.Price)).ToArray(),
+            "five deep, the fifth-best bid is now sixth and out of the window");
+    }
+
+    // Depths added after the book was built, for a channel declared after its instruments. Which
+    // is what InstrumentGroup does, so declaring channels and adding instruments still commute.
+    [Test]
+    public void ADepthAddedLater_IsReportedFromThenOn()
+    {
+        var book = BookWithTwelveBids();
+        book.AlsoReport(1);
+        book.AlsoReport(1);
+
+        Assert.AreEqual(new[] {1, 10}, book.PublishedDepths.ToArray(),
+            "added once, however many times it is asked for");
+        Assert.AreEqual(new[] {1, 10}, Reports(book).Select(r => r.Depth).ToArray());
+    }
+
+    // The window a snapshot carries is the deepest, and a feed publishing less takes the top of
+    // it - which unlike a delta is a plain cut, since an image says where the book is.
+    [Test]
+    public void ASnapshotOfAMultiDepthBook_CarriesTheDeepestWindow()
+    {
+        var book = BookWithTwelveBids(new[] {1, 4});
+
+        var snapshot = book.Process(new Actions.PublishSnapshot {Symbol = Gold.Symbol, Time = Start.AddMinutes(1)})
+            .OfType<BookSnapshot>().Single();
+
+        Assert.AreEqual(new[] {200m, 190m, 180m, 170m}, snapshot.Bids.Select(b => b.Price).ToArray());
     }
 }

--- a/tests/Circus.Tests/Sequencing/ChannelDepthTests.cs
+++ b/tests/Circus.Tests/Sequencing/ChannelDepthTests.cs
@@ -1,0 +1,187 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using Circus.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sequencing;
+
+// How deep a channel's by-price products run, declared per channel rather than per book. A venue
+// publishing the same instrument at two depths is ordinary - CME runs a top-of-book channel
+// beside its ten-deep one, Databento sells mbp-1 and mbp-10 off the same book - and this is what
+// makes that expressible.
+//
+// The group is what makes it work, because the two halves cannot be configured apart: a shallow
+// delta stream has to be diffed at its own window (see PublishedDepthTests), so declaring a
+// five-deep channel has to reach back and tell the book to report at five. Doing that by hand is
+// the mistake this class exists to make impossible.
+public class ChannelDepthTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly DateTime Day = new(2000, 1, 3, 8, 0, 0);
+
+    // Out of the way of a run that starts at 08:00, so no session boundary lands inside it.
+    private static readonly MarketSchedule OutOfTheWay =
+        new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
+
+    // Rests three bids at descending prices, then a fourth that becomes the best - so a one-deep
+    // channel sees the old best leave its window while a ten-deep one sees only the arrival.
+    private static Dictionary<string, List<ChannelMessage>> BuildAndTopTheBook(InstrumentGroup group)
+    {
+        var published = group.ChannelNames.ToDictionary(n => n, _ => new List<ChannelMessage>());
+
+        group.Submit(new OpenTrading {Symbol = Gold.Symbol, Time = Day.AddMinutes(1)});
+
+        var prices = new[] {200m, 190m, 180m, 210m};
+        for (var i = 0; i < prices.Length; i++)
+        {
+            group.Submit(new CreateLimitOrder
+            {
+                Symbol = Gold.Symbol, Time = Day.AddMinutes(45).AddSeconds(i), CompanyId = "C1",
+                ClientOrderId = $"O{i}", OrderValidity = new OrderValidity.Day(), Side = Side.Buy,
+                Quantity = 1, Price = prices[i]
+            });
+        }
+
+        foreach (var dispatched in group.Sequencer.AdvanceTo(Day.AddHours(1)))
+        {
+            foreach (var name in group.ChannelNames)
+                published[name].AddRange(group.ChannelNamed(name).Publish(dispatched.Events));
+        }
+
+        return published;
+    }
+
+    private static MarketByPriceDeltaEvent LastDelta(IEnumerable<ChannelMessage> messages) =>
+        messages.Select(m => m.Data).OfType<MarketByPriceDeltaEvent>().Last();
+
+    [Test]
+    public void AChannel_PublishesAtTheDepthItWasDeclaredWith()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("tob", FeedProducts.ByPrice, depth: 1);
+        group.AddChannel("deep", FeedProducts.ByPrice, depth: 10);
+        group.Add(Gold, OutOfTheWay);
+
+        var published = BuildAndTopTheBook(group);
+
+        Assert.AreEqual(1, LastDelta(published["tob"]).Depth);
+        Assert.AreEqual(10, LastDelta(published["deep"]).Depth);
+    }
+
+    // The payoff, and the reason depth could not simply be a filter on the way out. The same
+    // action is one message on each channel, and they say different things: ten deep the old best
+    // bid is still published and unchanged, one deep it is gone.
+    [Test]
+    public void AShallowChannel_IsToldWhenALevelLeavesItsWindow()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("tob", FeedProducts.ByPrice, depth: 1);
+        group.AddChannel("deep", FeedProducts.ByPrice, depth: 10);
+        group.Add(Gold, OutOfTheWay);
+
+        var published = BuildAndTopTheBook(group);
+
+        Assert.AreEqual(new[] {(MarketByPriceDeltaAction.Added, 210m)},
+            LastDelta(published["deep"]).Changes.Select(c => (c.Action, c.Price)).ToArray(),
+            "ten deep, the levels beneath the new best only moved rank, which is not news");
+
+        Assert.AreEqual(
+            new[] {(MarketByPriceDeltaAction.Added, 210m), (MarketByPriceDeltaAction.Removed, 200m)},
+            LastDelta(published["tob"]).Changes.Select(c => (c.Action, c.Price)).ToArray(),
+            "one deep, 200 is no longer published and the channel has to say so");
+    }
+
+    // A subscriber applying one channel's messages ends up with that channel's window, which is
+    // the property the Removed above exists to give it.
+    [Test]
+    public void ASubscriberToAShallowChannel_HoldsTheShallowBook()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("tob", FeedProducts.ByPrice, depth: 1);
+        group.AddChannel("deep", FeedProducts.ByPrice, depth: 10);
+        group.Add(Gold, OutOfTheWay);
+
+        var published = BuildAndTopTheBook(group);
+
+        Assert.AreEqual(new[] {210m}, Replay(published["tob"]).Bids.Select(b => b.Price).ToArray());
+        Assert.AreEqual(new[] {210m, 200m, 190m, 180m},
+            Replay(published["deep"]).Bids.Select(b => b.Price).ToArray());
+    }
+
+    private static LevelBook Replay(IEnumerable<ChannelMessage> messages)
+    {
+        var book = new LevelBook();
+
+        foreach (var message in messages)
+        {
+            if (message.Data is MarketByPriceDeltaEvent delta)
+                book.Apply(delta);
+        }
+
+        return book;
+    }
+
+    // The book is built from its channels' depths, so a group declaring one shallow channel does
+    // not leave a ten-deep book diffing a window nobody reads - and, more to the point, cannot
+    // leave a channel reading a window the book never diffed.
+    [Test]
+    public void ABookIsBuilt_ToReportEveryDepthItsChannelsPublish()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("tob", FeedProducts.ByPrice, depth: 1);
+        group.AddChannel("deep", FeedProducts.ByPrice, depth: 5);
+        group.AddChannel("orders", FeedProducts.ByOrder, depth: 20);
+        group.Add(Gold, OutOfTheWay);
+
+        Assert.AreEqual(new[] {1, 5}, group.PublishedDepthsFor(Gold.Symbol).ToArray(),
+            "an order-by-order channel carries no by-price product, so its depth means nothing");
+    }
+
+    // Declaring channels and adding instruments still commute, which they only can if a late
+    // channel can reach the books that are already here.
+    [Test]
+    public void AChannelDeclaredAfterAnInstrument_StillGetsItsOwnDepth()
+    {
+        var group = new InstrumentGroup(Day);
+        group.AddChannel("deep", FeedProducts.ByPrice, depth: 10);
+        group.Add(Gold, OutOfTheWay);
+        group.AddChannel("tob", FeedProducts.ByPrice, depth: 1);
+
+        var published = BuildAndTopTheBook(group);
+
+        Assert.AreEqual(
+            new[] {(MarketByPriceDeltaAction.Added, 210m), (MarketByPriceDeltaAction.Removed, 200m)},
+            LastDelta(published["tob"]).Changes.Select(c => (c.Action, c.Price)).ToArray());
+    }
+
+    [Test]
+    public void ASnapshot_CarriesTheChannelsOwnDepth()
+    {
+        var group = new InstrumentGroup(Day, TimeSpan.FromMinutes(10));
+        group.AddChannel("tob", FeedProducts.ByPrice, depth: 1);
+        group.AddChannel("deep", FeedProducts.ByPrice, depth: 10);
+        group.Add(Gold, OutOfTheWay);
+
+        var published = BuildAndTopTheBook(group);
+
+        var top = published["tob"].Select(m => m.Data).OfType<LevelsDataEvent>().Last();
+        var deep = published["deep"].Select(m => m.Data).OfType<LevelsDataEvent>().Last();
+
+        Assert.AreEqual(1, top.Depth);
+        Assert.AreEqual(new[] {210m}, top.Bids.Select(b => b.Price).ToArray(),
+            "an image truncates cleanly, unlike a delta");
+        Assert.AreEqual(10, deep.Depth);
+        Assert.AreEqual(new[] {210m, 200m, 190m, 180m}, deep.Bids.Select(b => b.Price).ToArray());
+    }
+
+    [Test]
+    public void AChannelCarryingNoLevels_IsRefused()
+    {
+        var group = new InstrumentGroup(Day);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => group.AddChannel("nothing", FeedProducts.ByPrice, depth: 0));
+    }
+}

--- a/tests/Circus.Tests/Sequencing/SnapshotCadenceTests.cs
+++ b/tests/Circus.Tests/Sequencing/SnapshotCadenceTests.cs
@@ -1,0 +1,171 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sequencing;
+
+// How often a channel restates itself, declared per channel and counted in the group's ticks.
+//
+// The venue has one snapshot schedule and ticks at the finest cadence any of its channels wants;
+// a channel wanting a slower one skips ticks. That is one interval and a counter per channel
+// rather than several schedules to keep in step, and it is the shape real venues have for a
+// concrete reason: a full order-by-order image is the heaviest message a venue sends, so it
+// cycles slower than the depth image beside it.
+public class SnapshotCadenceTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+    private static readonly DateTime Day = new(2000, 1, 3, 8, 0, 0);
+
+    private static readonly TimeSpan Tick = TimeSpan.FromMinutes(10);
+
+    // Out of the way of a run that starts at 08:00, so no session boundary lands inside it - a
+    // transition falling on a snapshot instant is its own question and not this one.
+    private static readonly MarketSchedule OutOfTheWay =
+        new(new TimeSpan(22, 0, 0), new TimeSpan(22, 30, 0), new TimeSpan(23, 30, 0));
+
+    private static CreateLimitOrder Bid(int index, decimal price) =>
+        new()
+        {
+            Symbol = Gold.Symbol, Time = Day.AddMinutes(45).AddSeconds(index), CompanyId = "C1",
+            ClientOrderId = $"O{index}", OrderValidity = new OrderValidity.Day(), Side = Side.Buy,
+            Quantity = 1, Price = price
+        };
+
+    // Runs the group forward over six snapshot ticks, and returns what each channel published.
+    private static Dictionary<string, List<ChannelMessage>> RunSixTicks(InstrumentGroup group,
+        int orders = 1)
+    {
+        var published = group.ChannelNames.ToDictionary(n => n, _ => new List<ChannelMessage>());
+
+        group.Submit(new OpenTrading {Symbol = Gold.Symbol, Time = Day.AddMinutes(1)});
+
+        for (var i = 0; i < orders; i++)
+            group.Submit(Bid(i, 200 - i * 10));
+
+        foreach (var dispatched in group.Sequencer.AdvanceTo(Day + Tick * 6))
+        {
+            foreach (var name in group.ChannelNames)
+                published[name].AddRange(group.ChannelNamed(name).Publish(dispatched.Events));
+        }
+
+        return published;
+    }
+
+    // Distinct, because a channel carrying several products publishes several messages per tick
+    // and what is being counted here is the ticks.
+    private static DateTime[] SnapshotTimes(IEnumerable<ChannelMessage> messages) =>
+        messages.Where(m => m.Stream == ChannelStream.Snapshot)
+            .Select(m => m.Data.Time)
+            .Distinct()
+            .ToArray();
+
+    [Test]
+    public void ByDefault_AChannelRestatesItselfOnEveryTick()
+    {
+        var group = new InstrumentGroup(Day, Tick);
+        group.Add(Gold, OutOfTheWay);
+
+        var times = SnapshotTimes(RunSixTicks(group)[MarketDataChannel.DefaultName]);
+
+        Assert.AreEqual(6, times.Length);
+        Assert.AreEqual(Day + Tick, times[0]);
+        Assert.AreEqual(Day + Tick * 6, times[^1]);
+    }
+
+    // The point of the whole thing: two channels on one schedule, restating at different rates.
+    [Test]
+    public void TwoChannels_CanRestateAtDifferentRates()
+    {
+        var group = new InstrumentGroup(Day, Tick);
+        group.AddChannel("fast", FeedProducts.ByPrice);
+        group.AddChannel("slow", FeedProducts.ByOrder, snapshotEvery: 3);
+        group.Add(Gold, OutOfTheWay);
+
+        var published = RunSixTicks(group);
+
+        Assert.AreEqual(6, SnapshotTimes(published["fast"]).Length);
+        Assert.AreEqual(new[] {Day + Tick * 3, Day + Tick * 6}, SnapshotTimes(published["slow"]),
+            "every third tick, and on the third rather than the first - a joiner waits at most a " +
+            "full cycle, which is what a cycle means");
+    }
+
+    // A skipped tick is not a gap. The snapshot stream is numbered per channel, so a channel that
+    // publishes on one tick in three counts one, two, three - not one, four, seven.
+    [Test]
+    public void ASlowChannel_NumbersOnlyWhatItPublishes()
+    {
+        var group = new InstrumentGroup(Day, Tick);
+        group.AddChannel("slow", FeedProducts.ByPrice, snapshotEvery: 3);
+        group.Add(Gold, OutOfTheWay);
+
+        var snapshots = RunSixTicks(group)["slow"]
+            .Where(m => m.Stream == ChannelStream.Snapshot)
+            .ToList();
+
+        Assert.IsNotEmpty(snapshots);
+        Assert.AreEqual(Enumerable.Range(1, snapshots.Count).Select(i => (long) i).ToArray(),
+            snapshots.Select(m => m.Sequence).ToArray());
+    }
+
+    // Skipping a tick withholds the image, not the updates. A subscriber in sync reads only the
+    // incremental stream, so a slow snapshot cycle costs a joiner time and costs nobody else
+    // anything - which is why a venue can afford to cycle its heaviest product slowly.
+    [Test]
+    public void ASlowChannel_StillPublishesEveryIncremental()
+    {
+        var group = new InstrumentGroup(Day, Tick);
+        group.AddChannel("fast", FeedProducts.ByPrice);
+        group.AddChannel("slow", FeedProducts.ByPrice, snapshotEvery: 3);
+        group.Add(Gold, OutOfTheWay);
+
+        var published = RunSixTicks(group, orders: 4);
+
+        var fast = published["fast"].Count(m => m.Stream == ChannelStream.Incremental);
+        Assert.AreNotEqual(0, fast);
+        Assert.AreEqual(fast, published["slow"].Count(m => m.Stream == ChannelStream.Incremental));
+    }
+
+    // The snapshot a slow channel does publish is stamped with where its own incremental stream
+    // stands, which is what a joiner discards its buffer up to. Skipping ticks must not leave that
+    // pointing anywhere but the end of what the channel has actually published.
+    [Test]
+    public void TheSnapshotASlowChannelPublishes_IsAsOfWhereItsIncrementalStreamStands()
+    {
+        var group = new InstrumentGroup(Day, Tick);
+        group.AddChannel("slow", FeedProducts.ByPrice, snapshotEvery: 3);
+        group.Add(Gold, OutOfTheWay);
+
+        var messages = RunSixTicks(group, orders: 4);
+        var snapshot = messages["slow"].Last(m => m.Stream == ChannelStream.Snapshot);
+        var incrementals = messages["slow"].Where(m => m.Stream == ChannelStream.Incremental).ToList();
+
+        Assert.IsNotEmpty(incrementals);
+        Assert.AreEqual(incrementals[^1].Sequence, snapshot.AsOfSequence,
+            "as of everything the channel had published by then, skipped ticks included");
+    }
+
+    [Test]
+    public void AChannelThatSkipsEveryTick_IsRefused()
+    {
+        var group = new InstrumentGroup(Day, Tick);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => group.AddChannel("never", FeedProducts.ByPrice, snapshotEvery: 0));
+    }
+
+    // A cadence is counted in snapshot ticks rather than dispatches, so how often a channel
+    // restates itself does not depend on how busy the instrument is.
+    [Test]
+    public void OrderFlowBetweenTicks_DoesNotMoveTheCount()
+    {
+        var group = new InstrumentGroup(Day, Tick);
+        group.AddChannel("slow", FeedProducts.ByPrice, snapshotEvery: 3);
+        group.Add(Gold, OutOfTheWay);
+
+        var published = RunSixTicks(group, orders: 15);
+
+        Assert.AreEqual(new[] {Day + Tick * 3, Day + Tick * 6}, SnapshotTimes(published["slow"]));
+    }
+}


### PR DESCRIPTION
Step 5 of the channel restructure. Two channels of one group can now publish the same instrument at different depths and restate themselves at different rates — a top-of-book channel beside a ten-deep one, a slow order-by-order snapshot cycle beside a fast depth one.

```csharp
var group = new InstrumentGroup(start, snapshotInterval: TimeSpan.FromSeconds(10));
group.AddChannel("EOBI", FeedProducts.ByOrder | FeedProducts.Status, snapshotEvery: 6);
group.AddChannel("EMDI", FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status, depth: 10);
group.AddChannel("TOB",  FeedProducts.ByPrice, depth: 1);
group.Add(gold, schedule);
```

## Depth is not a filter

The plan for this step said the book reports at the deepest depth any channel needs and each channel truncates. That does not work, and the case is small enough to state outright.

Bids at 200/190/180/170/160/150. A new best bid arrives at 210.

- **Ten deep**, the report is one `Added 210`. The levels beneath it only moved rank, and price-keyed reporting deliberately says nothing about that — it is the whole reason a level whose rank changed costs nothing to publish.
- **One deep**, the same action is an `Added 210` **and** a `Removed 200`, because 200 is no longer inside the window this channel publishes.

That `Removed` appears nowhere in the ten-deep report, at any rank. Filtering by `LevelIndex` would leave a top-of-book subscriber holding a price the channel no longer publishes.

So the book is told the depths its channels publish and diffs its captured window once per depth, emitting one `LevelsChanged` per depth with a `Depth` on it. A feed takes the reports made at its own depth rather than cutting down someone else's. The windows are still captured once, at the deepest, since a shallow window is a prefix of a deep one — the extra cost is a bounded scan per depth and no second walk of the ladders.

The **snapshot** half does truncate, because an image cuts cleanly where a delta does not: the first five entries of a ten-deep image are the five-deep image. `BookSnapshot` carries the deepest window and `MarketByPriceSnapshotProducer` takes the top of it.

## Cadence

`snapshotEvery` is a count of the group's snapshot ticks rather than an interval of its own. The group ticks at the finest cadence any of its channels wants and a slower channel skips ticks, so the channels of a group stay in step without several schedules to keep aligned. Real venues are shaped that way because a full order-by-order image is the heaviest message a venue sends, so it cycles slower than the depth image beside it.

A skipped tick is not a gap: the snapshot stream is numbered per channel, so a channel publishing on one tick in three counts one, two, three. Ticks are counted before the cadence is applied, so a feed on every fifth tick publishes on the fifth and not the first — a joiner waits at most a full cycle, which is what a cycle means. And skipping withholds the image, not the updates; the incremental stream is untouched.

## Changes

- `LevelsChanged` and `MarketByPriceDeltaEvent` carry `Depth`; `LevelsDataEvent` carries the depth its image was cut to.
- `OrderBook` takes a set of depths (`new OrderBook(gold, new[] {1, 10})`), reports once per depth shallowest-first, and gains `AlsoReport` so a channel declared after an instrument still gets its own window — declaring channels and adding instruments still commute.
- `MarketByPriceIncrementalProducer` and `MarketByPriceSnapshotProducer` take a depth; `InstrumentFeed` takes depth and `snapshotEvery` and counts its own ticks.
- `InstrumentGroup.AddChannel` takes `depth` and `snapshotEvery`, and builds each book from the depths of the by-price channels carrying it. `InstrumentGroup.Add` no longer takes `publishedDepth` — how deep a book reports is not a property of the instrument, it is what its by-price channels publish. A book handed in ready-made keeps its owner's depths.

## Tests

- `ChannelDepthTests` — two channels at one and ten deep, the departure the shallow one is told about and the deep one is not, and a `LevelBook` replay of each channel ending at that channel's window.
- `SnapshotCadenceTests` — two channels restating at different rates off one schedule, contiguous numbering across skipped ticks, `AsOfSequence` still pointing at the channel's own last incremental, and cadence independent of how busy the instrument is.
- `PublishedDepthTests` — the multi-depth book, the worked example above at the book level, and a depth added after the fact.

Left for step 6: the CME-like and Eurex-like venue shapes as executable evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj)_