### PR TITLE
Run one session through CME's shape and Eurex's

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ book. Market data producers turn events into what a subscriber sees - depth, ord
 trades, indicative quotes, instrument status - so the same code that publishes a live feed
 rebuilds one from a recorded trace.
 
+A book's events split in two. The public half is what a venue broadcasts and carries no client
+identity; the private half is what a participant is told about its own orders. A channel sees
+only the first.
+
+What a channel publishes is configuration rather than code. Each one declares which instruments
+it carries, which products about them, how deep its by-price products run, and how often it
+restates itself, so a group can wear CME's shape - one channel per product group carrying
+everything - or Eurex's, with the same book on an order-by-order interface and a netted depth one.
+Each channel numbers its own messages, and each publishes an incremental stream alongside a
+snapshot stream a subscriber uses to join mid-session or recover from a gap.
+
 Where time comes from is the only thing that differs between running and replaying.
 `LiveDriver` stamps arriving actions from a clock; `Replay` takes the instants already on a
 recorded trace. Both feed a `Sequencer`, one queue in front of every book, whose dispatch order
@@ -70,10 +81,15 @@ Sessions
 
 Market data
 - [x] Trades
-- [x] Price/qty/count for x levels
-- [x] All order updates
+- [x] Market by price (price/qty/count per level, price-keyed so each change applies on its own)
+- [x] Market by order (every resting order, with fills paired by trade id)
 - [x] Indicative open
 - [x] Instrument status (trading state, why, when it resumes, limit up/down)
+- [x] Public/private split (a feed never sees a client's own confirms)
+- [x] Snapshot stream per channel, for joining mid-session and recovering from a gap
+- [x] Channels configured per group: products, depth and snapshot cadence each
+- [ ] End-of-event markers
+- [ ] Instrument definition messages
 
 Safety features
 - [x] Banding

--- a/samples/Circus.Examples/Program.cs
+++ b/samples/Circus.Examples/Program.cs
@@ -12,6 +12,7 @@ internal static class Program
     {
         ("order-book", OrderBookExample.Run),
         ("market-data", MarketDataExample.Run),
+        ("venue-shapes", VenueShapesExample.Run),
         ("replay", ReplayExample.Run),
         ("live-venue", LiveVenueExample.Run),
         ("agent-swarm", AgentSwarmExample.Run)

--- a/samples/Circus.Examples/VenueShapesExample.cs
+++ b/samples/Circus.Examples/VenueShapesExample.cs
@@ -1,0 +1,121 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+
+namespace Circus.Examples;
+
+// One session, published twice: once the way CME shapes a feed and once the way Eurex does.
+//
+// CME runs a channel per product group carrying every product about every instrument on it, so a
+// subscriber takes one channel and has the whole complex. Eurex publishes the same book on two
+// interfaces - EOBI order by order, EMDI netted depth with the prints - so a participant that
+// wants both subscribes twice, and each interface restates itself at its own rate.
+//
+// Neither is built into the library. Both are the same three calls with different arguments,
+// which is the point: the shape of a venue is configuration here rather than code.
+public static class VenueShapesExample
+{
+    private static readonly Instrument Gold = new("GCZ6", TickSize: 10);
+    private static readonly Instrument Silver = new("SIZ6", TickSize: 10);
+
+    private static readonly DateTime Day = new(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+    private static readonly MarketSchedule Schedule =
+        new(new TimeSpan(8, 30, 0), new TimeSpan(9, 0, 0), new TimeSpan(17, 0, 0));
+
+    private static readonly TimeSpan SnapshotInterval = TimeSpan.FromMinutes(10);
+
+    public static void Run()
+    {
+        Describe("CME-shaped: one channel per product group", CmeShaped());
+        Console.WriteLine();
+        Describe("Eurex-shaped: one book, two interfaces", EurexShaped());
+    }
+
+    private static InstrumentGroup CmeShaped()
+    {
+        var group = new InstrumentGroup(Day, SnapshotInterval);
+
+        group.AddChannel("310", FeedProducts.All, depth: 10);
+        group.Add(Gold, Schedule);
+        group.Add(Silver, Schedule);
+
+        return group;
+    }
+
+    private static InstrumentGroup EurexShaped()
+    {
+        var group = new InstrumentGroup(Day, SnapshotInterval);
+
+        // The order-by-order interface carries the whole book, so its image is the heaviest thing
+        // published here and cycles once every six ticks rather than on all of them.
+        group.AddChannel("EOBI", FeedProducts.ByOrder | FeedProducts.Status, snapshotEvery: 6);
+        group.AddChannel("EMDI",
+            FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status | FeedProducts.Indicative,
+            depth: 10);
+
+        group.Add(Gold, Schedule);
+        group.Add(Silver, Schedule);
+
+        return group;
+    }
+
+    // Counts rather than a dump: what differs between the two shapes is which messages reach
+    // which subscriber, and a few hundred lines of them would bury that rather than show it.
+    private static void Describe(string title, InstrumentGroup group)
+    {
+        Console.WriteLine($"  {title}");
+
+        var published = Replay.RunAll(group, Trace(), Day.AddHours(2));
+
+        foreach (var name in group.ChannelNames)
+        {
+            var messages = published[name];
+            var channel = group.ChannelNamed(name);
+
+            Console.WriteLine($"    {name} [{string.Join(", ", channel.Symbols)}]");
+
+            foreach (var stream in new[] {ChannelStream.Incremental, ChannelStream.Snapshot})
+            {
+                var counts = messages.Where(m => m.Stream == stream)
+                    .GroupBy(m => m.Data.GetType().Name)
+                    .OrderBy(g => g.Key)
+                    .Select(g => $"{g.Key} x{g.Count()}")
+                    .ToList();
+
+                Console.WriteLine(counts.Count == 0
+                    ? $"      {stream,-11} -"
+                    : $"      {stream,-11} {string.Join(", ", counts)}");
+            }
+        }
+    }
+
+    // Enough flow to move every product: an opening auction, depth on both sides, an aggressor
+    // through three levels, and a second instrument so a channel carrying a group has two.
+    private static IReadOnlyList<OrderBookAction> Trace() =>
+        new List<OrderBookAction>
+        {
+            Order(Gold, "Buyer", "B-open", Side.Buy, 5, 1000, At(8, 45)),
+            Order(Gold, "Seller", "S-open", Side.Sell, 3, 1000, At(8, 46)),
+            Order(Gold, "Maker", "B1", Side.Buy, 4, 990, At(9, 5)),
+            Order(Gold, "Maker", "B2", Side.Buy, 3, 980, At(9, 6)),
+            Order(Gold, "Maker", "S1", Side.Sell, 4, 1010, At(9, 7)),
+            Order(Gold, "Maker", "S2", Side.Sell, 3, 1020, At(9, 8)),
+            Order(Gold, "Maker", "S3", Side.Sell, 5, 1030, At(9, 9)),
+            Order(Gold, "Taker", "T1", Side.Buy, 11, 1030, At(9, 15)),
+            Order(Silver, "Maker", "SB1", Side.Buy, 3, 490, At(9, 20)),
+            Order(Silver, "Taker", "ST1", Side.Sell, 3, 490, At(9, 21))
+        };
+
+    private static DateTime At(int hour, int minute) =>
+        new(Day.Year, Day.Month, Day.Day, hour, minute, 0, DateTimeKind.Utc);
+
+    private static CreateLimitOrder Order(Instrument instrument, string companyId, string clientOrderId,
+        Side side, int quantity, decimal price, DateTime time) =>
+        new()
+        {
+            Symbol = instrument.Symbol, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = new OrderValidity.Day(), Side = side, Quantity = quantity, Price = price
+        };
+}

--- a/src/Circus/Sequencing/Replay.cs
+++ b/src/Circus/Sequencing/Replay.cs
@@ -58,6 +58,32 @@ public static class Replay
         return messages;
     }
 
+    // The same, for a group publishing more than one channel: every channel is published from
+    // every dispatch, and what each carried comes back keyed by name. The overload above takes the
+    // group's single channel and has nothing to take once there are several, which is the whole
+    // reason this exists - a venue with two channels is the ordinary case now, not an exotic one.
+    //
+    // One dispatch order, several numberings. Each channel counts its own messages, so a
+    // subscriber to one sees a contiguous run whatever the others carried.
+    public static IReadOnlyDictionary<string, IReadOnlyList<ChannelMessage>> RunAll(
+        InstrumentGroup group, IEnumerable<OrderBookAction> trace, DateTime? until = null)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(trace);
+
+        var names = group.ChannelNames;
+        var collected = names.ToDictionary(name => name, _ => new List<ChannelMessage>());
+
+        Run(group.Sequencer, trace, dispatched =>
+        {
+            foreach (var name in names)
+                collected[name].AddRange(group.ChannelNamed(name).Publish(dispatched.Events));
+        }, until);
+
+        return collected.ToDictionary(
+            entry => entry.Key, entry => (IReadOnlyList<ChannelMessage>) entry.Value);
+    }
+
     private static void Report(IReadOnlyList<Dispatched> dispatched, Action<Dispatched>? onDispatched)
     {
         if (onDispatched == null) return;

--- a/tests/Circus.Tests/Helpers/OrderBookMirror.cs
+++ b/tests/Circus.Tests/Helpers/OrderBookMirror.cs
@@ -1,0 +1,133 @@
+using Circus.MarketData;
+
+namespace Circus.Tests.Helpers;
+
+// The book a by-order subscriber keeps, rebuilt from the messages it was sent. LevelBook's
+// counterpart on the other product: where that holds the ladder a by-price feed publishes, this
+// holds the orders a by-order feed publishes and aggregates the ladder itself.
+//
+// It lives in the tests rather than in the library because of one case it cannot get right. A
+// Filled delta says what traded, not what the order displays afterwards, and those differ when a
+// print goes through an iceberg's peak and into its reserve - which an auction can do, since it
+// fills an order's whole remaining quantity rather than its displayed peak. In continuous trading
+// an exhausted peak requeues and the feed says so, as an old id leaving and a new one arriving, so
+// a mirror stays exact; through an auction it can silently drift. The answer to that is the
+// answer to every other gap in an incremental stream - take the snapshot and start again - which
+// Reset is here to do.
+//
+// Orders are held in arrival order, which is queue order: the feed publishes an arrival at the
+// back of its price, and an order that loses priority arrives as a removal and a fresh id rather
+// than as a change of place.
+internal sealed class OrderBookMirror
+{
+    private readonly List<RestingOrder> _orders = new();
+
+    public IReadOnlyList<RestingOrder> Orders => _orders;
+
+    // Starts again from the by-order image, discarding whatever was here - the same contract
+    // LevelBook.Reset has, and for the same reason.
+    public void Reset(OrdersDataEvent snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        _orders.Clear();
+        _orders.AddRange(snapshot.Orders);
+    }
+
+    // The whole message or none of it, for the reason LevelBook applies one atomically: a message
+    // carrying a swept order's departure and the aggressor's remainder is one step between two
+    // consistent books, and reading between them is reading a book that never existed.
+    public void Apply(MarketByOrderDeltaEvent message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        foreach (var change in message.Changes)
+        {
+            switch (change.Action)
+            {
+                case MarketByOrderDeltaAction.Added:
+                    _orders.Add(new RestingOrder(change.Side, change.ExchangeOrderId, change.Price,
+                        change.Quantity));
+                    break;
+
+                case MarketByOrderDeltaAction.Modified:
+                    Replace(change.ExchangeOrderId,
+                        order => order with {Price = change.Price, Quantity = change.Quantity});
+                    break;
+
+                case MarketByOrderDeltaAction.Removed:
+                    Remove(change.ExchangeOrderId);
+                    break;
+
+                // Quantity is what traded, so what is left is what it displayed less that. An
+                // order with nothing left has gone: the feed says nothing further about a fully
+                // filled order, since leaving is what being filled means.
+                case MarketByOrderDeltaAction.Filled:
+                    var index = IndexOf(change.ExchangeOrderId);
+                    if (index < 0)
+                        break;
+
+                    var remaining = _orders[index].Quantity - change.Quantity;
+                    if (remaining > 0)
+                        _orders[index] = _orders[index] with {Quantity = remaining};
+                    else
+                        _orders.RemoveAt(index);
+
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(message), change.Action, null);
+            }
+        }
+    }
+
+    // The ladder a by-price feed would have published, aggregated here instead. This is the whole
+    // relationship between the two products: EMDI is EOBI added up, and a subscriber to the
+    // order-by-order feed can arrive at the depth feed's answer without being sent it.
+    public IReadOnlyList<Level> Levels(Side side, int depth)
+    {
+        var byPrice = new SortedDictionary<decimal, (int Quantity, int Count)>(
+            side == Side.Buy ? Comparer<decimal>.Create((a, b) => b.CompareTo(a)) : Comparer<decimal>.Default);
+
+        foreach (var order in _orders)
+        {
+            if (order.Side != side)
+                continue;
+
+            byPrice.TryGetValue(order.Price, out var running);
+            byPrice[order.Price] = (running.Quantity + order.Quantity, running.Count + 1);
+        }
+
+        return byPrice.Take(depth)
+            .Select(entry => new Level(entry.Key, entry.Value.Quantity, entry.Value.Count))
+            .ToList();
+    }
+
+    // Tolerant of an id that is not here, which is not laxity but the shape of the feed: an
+    // iceberg whose peak is exhausted reports the fill that emptied it and then the requeue, so
+    // the removal names an order the fill has already taken out.
+    private void Remove(string exchangeOrderId)
+    {
+        var index = IndexOf(exchangeOrderId);
+        if (index >= 0)
+            _orders.RemoveAt(index);
+    }
+
+    private void Replace(string exchangeOrderId, Func<RestingOrder, RestingOrder> update)
+    {
+        var index = IndexOf(exchangeOrderId);
+        if (index >= 0)
+            _orders[index] = update(_orders[index]);
+    }
+
+    private int IndexOf(string exchangeOrderId)
+    {
+        for (var i = 0; i < _orders.Count; i++)
+        {
+            if (_orders[i].ExchangeOrderId == exchangeOrderId)
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/tests/Circus.Tests/Venues/CmeShapedVenueTests.cs
+++ b/tests/Circus.Tests/Venues/CmeShapedVenueTests.cs
@@ -1,0 +1,136 @@
+using Circus.MarketData;
+using Circus.Sequencing;
+using NUnit.Framework;
+
+namespace Circus.Tests.Venues;
+
+// A venue shaped like CME's MDP 3.0: one channel per product group, carrying every product about
+// every instrument in the group.
+//
+// A subscriber takes one channel and has the whole complex - depth, order by order, prints and
+// instrument status arriving under one numbering. That is what makes a product group the unit of
+// a channel there: a spread and its legs need a common order the moment implied pricing exists,
+// and two channels do not give them one.
+//
+// Everything here is the group's configuration and nothing else. The claim being made is that the
+// shape is expressible, so any test that reached past AddChannel to get its answer would not be
+// making it.
+public class CmeShapedVenueTests
+{
+    // Named as CME names them, by product group. One channel, every product on it.
+    private const string Channel = "310";
+
+    private static InstrumentGroup Venue(TimeSpan? snapshotInterval = null)
+    {
+        var group = new InstrumentGroup(VenueSession.Day, snapshotInterval);
+
+        group.AddChannel(Channel, FeedProducts.All, depth: VenueSession.Depth);
+        group.Add(VenueSession.Gold, VenueSession.Schedule);
+        group.Add(VenueSession.Silver, VenueSession.Schedule);
+
+        return group;
+    }
+
+    private static IReadOnlyList<ChannelMessage> Run(TimeSpan? snapshotInterval = null) =>
+        VenueSession.Run(Venue(snapshotInterval))[Channel];
+
+    private static string[] Kinds(IEnumerable<ChannelMessage> messages, ChannelStream stream) =>
+        messages.Where(m => m.Stream == stream)
+            .Select(m => m.Data.GetType().Name)
+            .Distinct()
+            .OrderBy(name => name)
+            .ToArray();
+
+    [Test]
+    public void OneSubscription_CarriesEveryProduct()
+    {
+        var messages = Run();
+
+        Assert.AreEqual(new[]
+            {
+                nameof(IndicativePriceDataEvent), nameof(InstrumentStatusDataEvent),
+                nameof(MarketByOrderDeltaEvent), nameof(MarketByPriceDeltaEvent), nameof(TradeDataEvent)
+            },
+            Kinds(messages, ChannelStream.Incremental),
+            "depth, order by order, prints and state all arrive on the one channel");
+    }
+
+    [Test]
+    public void OneSubscription_CarriesEveryInstrumentInTheGroup()
+    {
+        var messages = Run();
+
+        Assert.AreEqual(new[] {VenueSession.Gold.Symbol, VenueSession.Silver.Symbol},
+            messages.Select(m => m.Data.Symbol).Distinct().OrderBy(s => s).ToArray());
+    }
+
+    // The property a channel's numbering exists for, across instruments rather than within one:
+    // a gap is loss and nothing else, so a subscriber counting the run can tell it has missed a
+    // message without knowing what the venue chose not to send it.
+    [Test]
+    public void TheChannel_NumbersItsMessagesContiguouslyAcrossInstruments()
+    {
+        var messages = Run().Where(m => m.Stream == ChannelStream.Incremental).ToList();
+
+        Assert.IsNotEmpty(messages);
+        Assert.AreEqual(Enumerable.Range(1, messages.Count).Select(i => (long) i).ToArray(),
+            messages.Select(m => m.Sequence).ToArray());
+    }
+
+    [Test]
+    public void TheDepthProduct_RunsTenDeep()
+    {
+        var deltas = Run().Select(m => m.Data).OfType<MarketByPriceDeltaEvent>().ToList();
+
+        Assert.IsNotEmpty(deltas);
+        Assert.IsTrue(deltas.All(d => d.Depth == VenueSession.Depth));
+    }
+
+    // One matching-engine event is one message per product, however many levels or orders it
+    // moved. The aggressor in the session sweeps three offer levels; a shape that reported them
+    // one at a time would leave every subscriber to recover the grouping before it could act.
+    [Test]
+    public void AnAggressorSweepingThreeLevels_IsOneMessageOnEachProduct()
+    {
+        var messages = Run();
+
+        var sweep = messages.Select(m => m.Data).OfType<MarketByPriceDeltaEvent>()
+            .Single(d => d.Changes.Count(c => c.Side == Side.Sell) == 3);
+
+        Assert.AreEqual(3, sweep.Changes.Count(c => c.Side == Side.Sell));
+
+        var atSameInstant = messages.Select(m => m.Data)
+            .OfType<MarketByOrderDeltaEvent>()
+            .Count(d => d.Time == sweep.Time);
+
+        Assert.AreEqual(1, atSameInstant,
+            "the by-order product reports the same event as one message too");
+    }
+
+    // The recovery half, on the same channel and numbered apart from the updates - CME publishes
+    // it on a separate connection, which is the same separation as a separate stream here.
+    [Test]
+    public void TheSnapshotStream_RestatesEveryProductThatHasAnImage()
+    {
+        var messages = Run(TimeSpan.FromMinutes(10));
+
+        Assert.AreEqual(new[]
+            {
+                nameof(IndicativePriceDataEvent), nameof(InstrumentStatusDataEvent),
+                nameof(LevelsDataEvent), nameof(OrdersDataEvent)
+            },
+            Kinds(messages, ChannelStream.Snapshot),
+            "a stream of prints has no image, so trades are not restated");
+    }
+
+    [Test]
+    public void TheSnapshotStream_IsNumberedApartFromTheUpdates()
+    {
+        var messages = Run(TimeSpan.FromMinutes(10));
+        var snapshots = messages.Where(m => m.Stream == ChannelStream.Snapshot).ToList();
+
+        Assert.IsNotEmpty(snapshots);
+        Assert.AreEqual(Enumerable.Range(1, snapshots.Count).Select(i => (long) i).ToArray(),
+            snapshots.Select(m => m.Sequence).ToArray());
+    }
+}

--- a/tests/Circus.Tests/Venues/EurexShapedVenueTests.cs
+++ b/tests/Circus.Tests/Venues/EurexShapedVenueTests.cs
@@ -1,0 +1,171 @@
+using Circus.MarketData;
+using Circus.Sequencing;
+using NUnit.Framework;
+
+namespace Circus.Tests.Venues;
+
+// A venue shaped like Eurex: the same instrument published on two interfaces carrying different
+// products, and a service per product rather than per group.
+//
+// EOBI is order by order and full depth. EMDI is netted depth with the prints, ten deep. Both
+// carry instrument state, because a subscriber to either needs to know the instrument is open -
+// which is the detail that makes state a product rather than a channel's private business.
+//
+// Two interfaces on one book is the shape the whole restructure was aimed at, and it is a
+// different shape from CME's rather than a rename of it: there, one subscription is the whole
+// venue; here, a participant that wants depth and order identity subscribes twice.
+public class EurexShapedVenueTests
+{
+    private const string GoldByOrder = "EOBI-GC";
+    private const string GoldByPrice = "EMDI-GC";
+    private const string SilverByOrder = "EOBI-SI";
+    private const string SilverByPrice = "EMDI-SI";
+
+    // EOBI's image is every resting order, which is the heaviest message a venue sends, so it
+    // cycles slower than the depth image beside it.
+    private const int ByOrderSnapshotEvery = 6;
+
+    private static InstrumentGroup Venue(TimeSpan? snapshotInterval = null)
+    {
+        var group = new InstrumentGroup(VenueSession.Day, snapshotInterval);
+
+        foreach (var (byOrder, byPrice) in new[]
+                     {(GoldByOrder, GoldByPrice), (SilverByOrder, SilverByPrice)})
+        {
+            group.AddChannel(byOrder, FeedProducts.ByOrder | FeedProducts.Status,
+                snapshotEvery: ByOrderSnapshotEvery);
+            group.AddChannel(byPrice,
+                FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status | FeedProducts.Indicative,
+                depth: VenueSession.Depth);
+        }
+
+        // A service per product, so each channel carries one instrument and leaves the other out.
+        group.Add(VenueSession.Gold, VenueSession.Schedule, new[] {GoldByOrder, GoldByPrice});
+        group.Add(VenueSession.Silver, VenueSession.Schedule, new[] {SilverByOrder, SilverByPrice});
+
+        return group;
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<ChannelMessage>> Run(
+        TimeSpan? snapshotInterval = null) =>
+        VenueSession.Run(Venue(snapshotInterval));
+
+    private static string[] Kinds(IEnumerable<ChannelMessage> messages, ChannelStream stream) =>
+        messages.Where(m => m.Stream == stream)
+            .Select(m => m.Data.GetType().Name)
+            .Distinct()
+            .OrderBy(name => name)
+            .ToArray();
+
+    [Test]
+    public void TheOrderByOrderInterface_CarriesOrdersAndStateAndNoLadder()
+    {
+        var published = Run();
+
+        Assert.AreEqual(new[] {nameof(InstrumentStatusDataEvent), nameof(MarketByOrderDeltaEvent)},
+            Kinds(published[GoldByOrder], ChannelStream.Incremental),
+            "no aggregated depth and no prints - a subscriber that wants either subscribes to EMDI");
+    }
+
+    [Test]
+    public void TheDepthInterface_CarriesTheLadderAndPrintsAndNoOrderIdentity()
+    {
+        var published = Run();
+
+        Assert.AreEqual(new[]
+            {
+                nameof(IndicativePriceDataEvent), nameof(InstrumentStatusDataEvent),
+                nameof(MarketByPriceDeltaEvent), nameof(TradeDataEvent)
+            },
+            Kinds(published[GoldByPrice], ChannelStream.Incremental));
+    }
+
+    // On EOBI an execution is an order event rather than a print: the same trade that EMDI
+    // publishes as one TradeDataEvent arrives here as the two sides of it, paired by a shared id.
+    // Without that id a consumer sees two fills at one price and cannot tell one trade between two
+    // orders from two separate trades.
+    [Test]
+    public void AnExecution_ReachesTheOrderByOrderInterfaceAsPairedOrderEvents()
+    {
+        var published = Run();
+
+        // The opening auction, which is the first thing either interface has a trade to report.
+        var print = published[GoldByPrice].Select(m => m.Data).OfType<TradeDataEvent>().First();
+
+        var fills = published[GoldByOrder].Select(m => m.Data).OfType<MarketByOrderDeltaEvent>()
+            .Where(d => d.Time == print.Time)
+            .SelectMany(d => d.Changes)
+            .Where(c => c.Action == MarketByOrderDeltaAction.Filled)
+            .ToList();
+
+        Assert.AreEqual(2, fills.Count, "one per side of the trade");
+        Assert.AreEqual(new[] {Side.Buy, Side.Sell}, fills.Select(f => f.Side).OrderBy(s => s).ToArray());
+        Assert.AreEqual(1, fills.Select(f => f.TradeId).Distinct().Count(),
+            "paired by a shared id - without it two fills at one price could be two trades");
+        Assert.AreEqual(print.Price, fills[0].Price);
+        Assert.AreEqual(print.Quantity, fills[0].Quantity);
+
+        Assert.IsEmpty(published[GoldByOrder].Select(m => m.Data).OfType<TradeDataEvent>(),
+            "EOBI carries the executions, not the trade summary");
+    }
+
+    // State on both, which is the reason it is a product rather than a channel's private business.
+    [Test]
+    public void InstrumentState_IsPublishedOnBothInterfaces()
+    {
+        var published = Run();
+
+        foreach (var channel in new[] {GoldByOrder, GoldByPrice})
+        {
+            Assert.IsNotEmpty(published[channel].Select(m => m.Data).OfType<InstrumentStatusDataEvent>(),
+                $"{channel} must say when the instrument opens");
+        }
+    }
+
+    [Test]
+    public void AServicePerProduct_CarriesThatProductAndNoOther()
+    {
+        var published = Run();
+
+        Assert.AreEqual(new[] {VenueSession.Gold.Symbol},
+            published[GoldByPrice].Select(m => m.Data.Symbol).Distinct().ToArray());
+        Assert.AreEqual(new[] {VenueSession.Silver.Symbol},
+            published[SilverByPrice].Select(m => m.Data.Symbol).Distinct().ToArray());
+    }
+
+    [Test]
+    public void EachInterface_NumbersItsOwnMessages()
+    {
+        var published = Run();
+
+        foreach (var (name, messages) in published)
+        {
+            var incremental = messages.Where(m => m.Stream == ChannelStream.Incremental).ToList();
+
+            Assert.IsNotEmpty(incremental, $"{name} published nothing");
+            Assert.AreEqual(Enumerable.Range(1, incremental.Count).Select(i => (long) i).ToArray(),
+                incremental.Select(m => m.Sequence).ToArray(),
+                $"{name} must number its own messages, with no gap where a sibling carried something");
+        }
+    }
+
+    [Test]
+    public void TheOrderByOrderImage_CyclesSlowerThanTheDepthImage()
+    {
+        var published = Run(TimeSpan.FromMinutes(10));
+
+        var byOrder = SnapshotInstants(published[GoldByOrder]);
+        var byPrice = SnapshotInstants(published[GoldByPrice]);
+
+        Assert.IsNotEmpty(byOrder);
+        Assert.AreEqual(byPrice.Length / ByOrderSnapshotEvery, byOrder.Length);
+        Assert.IsTrue(byOrder.All(byPrice.Contains),
+            "the slow interface restates on the venue's ticks, not on a schedule of its own");
+    }
+
+    private static DateTime[] SnapshotInstants(IEnumerable<ChannelMessage> messages) =>
+        messages.Where(m => m.Stream == ChannelStream.Snapshot)
+            .Select(m => m.Data.Time)
+            .Distinct()
+            .ToArray();
+}

--- a/tests/Circus.Tests/Venues/VenueSession.cs
+++ b/tests/Circus.Tests/Venues/VenueSession.cs
@@ -1,0 +1,107 @@
+using Circus.Actions;
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Sessions;
+
+namespace Circus.Tests.Venues;
+
+// One session, driven through whatever shape a venue is configured in. Every test in this folder
+// runs this same trace, so what differs between two venues is the configuration and nothing else -
+// which is the point being made, and would not be made by two traces that happened to agree.
+//
+// The trace is deliberately not quiet. It opens on an auction, builds depth on both sides, sweeps
+// three levels with one aggressor, empties a level with a cancel, and rests an iceberg that is
+// partly filled - so a shape that only works for a resting limit order fails here rather than in
+// whatever uses it next.
+internal static class VenueSession
+{
+    // Ten a tick, so every price below is a round number of them and a rejected order cannot
+    // quietly turn an assertion about depth into an assertion about nothing.
+    public static readonly Instrument Gold = new("GCZ6", TickSize: 10);
+    public static readonly Instrument Silver = new("SIZ6", TickSize: 10);
+
+    public static readonly DateTime Day = new(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+    public static readonly MarketSchedule Schedule =
+        new(new TimeSpan(8, 30, 0), new TimeSpan(9, 0, 0), new TimeSpan(17, 0, 0));
+
+    // Past the last action, so a snapshot cycle comes round a few more times after the flow stops
+    // and a shape whose channels restate at different rates has something to differ over.
+    public static readonly DateTime Until = Day.AddHours(2);
+
+    // How deep the by-price products here run. Ten is what CME's futures books carry and what
+    // Eurex's netted depth feed publishes, so both shapes want the same number and the difference
+    // between them is elsewhere.
+    public const int Depth = 10;
+
+    public static IReadOnlyList<OrderBookAction> Trace()
+    {
+        var trace = new List<OrderBookAction>();
+
+        // Pre-open. Orders accumulate rather than trading, and the indicative quote follows them.
+        trace.Add(Limit(Gold, "Buyer", "B-open", Side.Buy, 5, 1000, At(8, 45)));
+        trace.Add(Limit(Gold, "Seller", "S-open", Side.Sell, 3, 1000, At(8, 46)));
+        trace.Add(Limit(Silver, "Buyer", "B-ag", Side.Buy, 2, 500, At(8, 47)));
+        trace.Add(Limit(Silver, "Seller", "S-ag", Side.Sell, 2, 500, At(8, 48)));
+
+        // 09:00 opens on the schedule, printing the crossed pre-open book as one auction.
+
+        // Continuous. Four levels a side on Gold, so a sweep has something to sweep and a
+        // ten-deep window has something inside it.
+        trace.Add(Limit(Gold, "Maker", "B1", Side.Buy, 4, 990, At(9, 5)));
+        trace.Add(Limit(Gold, "Maker", "B2", Side.Buy, 3, 980, At(9, 6)));
+        trace.Add(Limit(Gold, "Maker", "B3", Side.Buy, 2, 970, At(9, 7)));
+        trace.Add(Limit(Gold, "Maker", "B4", Side.Buy, 6, 960, At(9, 8)));
+        trace.Add(Limit(Gold, "Maker", "S1", Side.Sell, 4, 1010, At(9, 9)));
+        trace.Add(Limit(Gold, "Maker", "S2", Side.Sell, 3, 1020, At(9, 10)));
+        trace.Add(Limit(Gold, "Maker", "S3", Side.Sell, 5, 1030, At(9, 11)));
+
+        // A second order at a price that already has one, so a level carries a queue and its
+        // aggregate count is something other than one.
+        trace.Add(Limit(Gold, "Other", "B1b", Side.Buy, 2, 990, At(9, 12)));
+
+        // An aggressor through three offer levels in one action. Every product has to report this
+        // as one thing: three levels moved, several orders filled, prints at three prices.
+        trace.Add(Limit(Gold, "Taker", "T1", Side.Buy, 11, 1030, At(9, 15)));
+
+        // A cancel that empties a level rather than thinning it.
+        trace.Add(new CancelOrder
+        {
+            Symbol = Gold.Symbol, Time = At(9, 20), CompanyId = "Maker", ClientOrderId = "B4-cancel",
+            PreviousClientOrderId = "B4"
+        });
+
+        // An iceberg, and an aggressor taking exactly its peak. In continuous trading an exhausted
+        // peak requeues with a fresh id, which a by-order feed reports and a by-price feed does
+        // not - the level is the same size either way. That divergence is a real one and both
+        // shapes here have to survive it.
+        trace.Add(new CreateLimitOrder
+        {
+            Symbol = Gold.Symbol, Time = At(9, 25), CompanyId = "Maker", ClientOrderId = "ICE",
+            OrderValidity = new OrderValidity.Day(), Side = Side.Sell, Quantity = 12, Price = 1040,
+            MaxVisibleQuantity = 3
+        });
+        trace.Add(Limit(Gold, "Taker", "T2", Side.Buy, 3, 1040, At(9, 26)));
+
+        // Silver, so a channel carrying a group rather than a product has two instruments to
+        // interleave and a channel carrying one product has something to leave out.
+        trace.Add(Limit(Silver, "Maker", "SB1", Side.Buy, 3, 490, At(9, 30)));
+        trace.Add(Limit(Silver, "Taker", "ST1", Side.Sell, 3, 490, At(9, 31)));
+
+        return trace;
+    }
+
+    public static IReadOnlyDictionary<string, IReadOnlyList<ChannelMessage>> Run(InstrumentGroup group) =>
+        Replay.RunAll(group, Trace(), Until);
+
+    private static DateTime At(int hour, int minute) =>
+        new(Day.Year, Day.Month, Day.Day, hour, minute, 0, DateTimeKind.Utc);
+
+    private static CreateLimitOrder Limit(Instrument instrument, string companyId, string clientOrderId,
+        Side side, int quantity, decimal price, DateTime time) =>
+        new()
+        {
+            Symbol = instrument.Symbol, Time = time, CompanyId = companyId, ClientOrderId = clientOrderId,
+            OrderValidity = new OrderValidity.Day(), Side = side, Quantity = quantity, Price = price
+        };
+}

--- a/tests/Circus.Tests/Venues/VenueShapeComparisonTests.cs
+++ b/tests/Circus.Tests/Venues/VenueShapeComparisonTests.cs
@@ -1,0 +1,171 @@
+using Circus.MarketData;
+using Circus.Sequencing;
+using Circus.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Circus.Tests.Venues;
+
+// The claim the other two classes are only half of: a venue shape decides how a market is
+// packaged, not what the market is. Two shapes over one session must agree about the book, the
+// prints and the state, or one of them is publishing something that did not happen.
+//
+// This is also where the two by-price and by-order products are held against each other. They are
+// not two feeds of two books - EMDI is EOBI added up - and a subscriber to the order-by-order
+// interface can arrive at the depth interface's ladder without being sent it. That relationship
+// is what makes a venue able to sell them separately, and nothing else here asserts it.
+//
+// What no shape here models, so it is findable rather than discovered: packet framing and A/B
+// line arbitration, instrument definition messages, end-of-event markers, implied and spread
+// books, statistics and banding messages, and EMDI's netted throttling. Each of those is a real
+// part of the venues being imitated and none of them is a channel's configuration, which is why
+// the shapes stop where they do.
+public class VenueShapeComparisonTests
+{
+    private const string CmeChannel = "310";
+    private const string EurexByOrder = "EOBI-GC";
+    private const string EurexByPrice = "EMDI-GC";
+
+    // One channel carrying every product about every instrument.
+    private static InstrumentGroup CmeShaped(TimeSpan? snapshotInterval = null)
+    {
+        var group = new InstrumentGroup(VenueSession.Day, snapshotInterval);
+
+        group.AddChannel(CmeChannel, FeedProducts.All, depth: VenueSession.Depth);
+        group.Add(VenueSession.Gold, VenueSession.Schedule);
+        group.Add(VenueSession.Silver, VenueSession.Schedule);
+
+        return group;
+    }
+
+    // The same book split across two interfaces carrying different products.
+    private static InstrumentGroup EurexShaped(TimeSpan? snapshotInterval = null)
+    {
+        var group = new InstrumentGroup(VenueSession.Day, snapshotInterval);
+
+        group.AddChannel(EurexByOrder, FeedProducts.ByOrder | FeedProducts.Status);
+        group.AddChannel(EurexByPrice,
+            FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status | FeedProducts.Indicative,
+            depth: VenueSession.Depth);
+        group.Add(VenueSession.Gold, VenueSession.Schedule, new[] {EurexByOrder, EurexByPrice});
+        group.Add(VenueSession.Silver, VenueSession.Schedule, new[] {EurexByOrder, EurexByPrice});
+
+        return group;
+    }
+
+    private static LevelBook LadderFrom(IEnumerable<ChannelMessage> messages, string symbol)
+    {
+        var book = new LevelBook();
+
+        foreach (var message in messages)
+        {
+            if (message.Data.Symbol == symbol && message.Data is MarketByPriceDeltaEvent delta)
+                book.Apply(delta);
+        }
+
+        return book;
+    }
+
+    private static OrderBookMirror MirrorFrom(IEnumerable<ChannelMessage> messages, string symbol)
+    {
+        var mirror = new OrderBookMirror();
+
+        foreach (var message in messages)
+        {
+            if (message.Data.Symbol == symbol && message.Data is MarketByOrderDeltaEvent delta)
+                mirror.Apply(delta);
+        }
+
+        return mirror;
+    }
+
+    private static (decimal Price, int Quantity)[] Prints(IEnumerable<ChannelMessage> messages,
+        string symbol) =>
+        messages.Select(m => m.Data).OfType<TradeDataEvent>()
+            .Where(t => t.Symbol == symbol)
+            .Select(t => (t.Price, t.Quantity))
+            .ToArray();
+
+    // The headline. One session, two packagings, one market.
+    [Test]
+    public void TwoShapes_AgreeAboutTheLadder()
+    {
+        var cme = VenueSession.Run(CmeShaped())[CmeChannel];
+        var eurex = VenueSession.Run(EurexShaped())[EurexByPrice];
+
+        var fromCme = LadderFrom(cme, VenueSession.Gold.Symbol);
+        var fromEurex = LadderFrom(eurex, VenueSession.Gold.Symbol);
+
+        Assert.IsNotEmpty(fromCme.Bids, "the session should have left a book behind");
+        Assert.AreEqual(fromCme.Bids, fromEurex.Bids);
+        Assert.AreEqual(fromCme.Offers, fromEurex.Offers);
+    }
+
+    [Test]
+    public void TwoShapes_AgreeAboutThePrints()
+    {
+        var cme = VenueSession.Run(CmeShaped())[CmeChannel];
+        var eurex = VenueSession.Run(EurexShaped())[EurexByPrice];
+
+        var fromCme = Prints(cme, VenueSession.Gold.Symbol);
+
+        Assert.IsNotEmpty(fromCme);
+        Assert.AreEqual(fromCme, Prints(eurex, VenueSession.Gold.Symbol));
+    }
+
+    // The relationship between the two products, which is the reason a venue can sell them
+    // separately: the depth interface is the order-by-order interface added up. A subscriber to
+    // EOBI alone arrives at EMDI's ladder by aggregating what it was already sent.
+    [Test]
+    public void TheDepthLadder_IsTheOrderByOrderBookAddedUp()
+    {
+        var published = VenueSession.Run(EurexShaped());
+
+        var ladder = LadderFrom(published[EurexByPrice], VenueSession.Gold.Symbol);
+        var mirror = MirrorFrom(published[EurexByOrder], VenueSession.Gold.Symbol);
+
+        Assert.IsNotEmpty(ladder.Bids);
+        Assert.AreEqual(ladder.Bids, mirror.Levels(Side.Buy, VenueSession.Depth));
+        Assert.AreEqual(ladder.Offers, mirror.Levels(Side.Sell, VenueSession.Depth));
+    }
+
+    // And the same thing against the images rather than the updates, which is the path a
+    // subscriber joining mid-session takes. A shape whose two interfaces agree on the deltas but
+    // not on what they restate would strand every joiner on one of them.
+    [Test]
+    public void TheTwoImages_DescribeTheSameBook()
+    {
+        var published = VenueSession.Run(EurexShaped(TimeSpan.FromMinutes(10)));
+
+        var ladder = new LevelBook();
+        ladder.Reset(LastImage<LevelsDataEvent>(published[EurexByPrice]));
+
+        var mirror = new OrderBookMirror();
+        mirror.Reset(LastImage<OrdersDataEvent>(published[EurexByOrder]));
+
+        Assert.IsNotEmpty(ladder.Bids);
+        Assert.AreEqual(ladder.Bids, mirror.Levels(Side.Buy, VenueSession.Depth));
+        Assert.AreEqual(ladder.Offers, mirror.Levels(Side.Sell, VenueSession.Depth));
+    }
+
+    // A subscriber that joins late and takes the image lands where one that heard everything is.
+    // That is what the snapshot stream is for, and it has to hold whatever shape the venue wears.
+    [Test]
+    public void AJoinerTakingTheImage_LandsWhereTheStreamLeftIt()
+    {
+        var published = VenueSession.Run(EurexShaped(TimeSpan.FromMinutes(10)));
+
+        var fromStream = LadderFrom(published[EurexByPrice], VenueSession.Gold.Symbol);
+
+        var joiner = new LevelBook();
+        joiner.Reset(LastImage<LevelsDataEvent>(published[EurexByPrice]));
+
+        Assert.AreEqual(fromStream.Bids, joiner.Bids);
+        Assert.AreEqual(fromStream.Offers, joiner.Offers);
+    }
+
+    private static T LastImage<T>(IEnumerable<ChannelMessage> messages) where T : MarketDataEvent =>
+        messages.Where(m => m.Stream == ChannelStream.Snapshot && m.Data.Symbol == VenueSession.Gold.Symbol)
+            .Select(m => m.Data)
+            .OfType<T>()
+            .Last();
+}


### PR DESCRIPTION
Step 6, the last of the channel restructure. The venue claims scattered through the comments now run.

One trace — an opening auction, depth on both sides, an aggressor through three levels, a cancel emptying a level, an iceberg partly filled — driven through two configurations, with nothing else different between them. Same trace both ways, so what differs is the configuration and not two sessions that happened to agree.

## The two shapes

**CME-shaped** — one channel per product group, carrying every product about every instrument on it:

```csharp
group.AddChannel("310", FeedProducts.All, depth: 10);
group.Add(gold, schedule);
group.Add(silver, schedule);
```

One subscription, one numbering, the whole complex. That is why a product group is the unit of a channel there: a spread and its legs need a common order the moment implied pricing exists, and two channels do not give them one.

**Eurex-shaped** — a service per product, the same book on two interfaces:

```csharp
group.AddChannel("EOBI-GC", FeedProducts.ByOrder | FeedProducts.Status, snapshotEvery: 6);
group.AddChannel("EMDI-GC", FeedProducts.ByPrice | FeedProducts.Trades | FeedProducts.Status
                          | FeedProducts.Indicative, depth: 10);
group.Add(gold, schedule, new[] {"EOBI-GC", "EMDI-GC"});
```

A participant wanting depth and order identity subscribes twice. State is on both, since a subscriber to either needs to know the instrument is open — which is what makes state a product rather than a channel's private business. EOBI's image is every resting order, the heaviest message the venue sends, so it cycles once every six ticks against EMDI's every one.

The EOBI-specific detail that gets its own test: an execution arrives there as the two sides of it paired by a trade id, not as a print.

## Holding them against each other

A shape decides how a market is packaged, not what the market is. `VenueShapeComparisonTests` runs both over the session and checks they agree on the ladder and on the prints.

It also holds the two *products* against each other, which is the sharper claim: **EMDI is EOBI added up.** Aggregating the order-by-order stream arrives at the depth stream's ladder without being sent it — asserted against the deltas and again against the images, since a shape whose interfaces agree on updates but not on what they restate would strand every joiner on one of them.

## Also in here

- **`Replay.RunAll`** — publishes every channel of a group. `Replay.Run` takes the group's *single* channel and throws once there are several, which step 4 made the ordinary case; that rough edge was the first thing this step tripped over.
- **`samples/Circus.Examples/VenueShapesExample.cs`** — prints both channel maps for one session, so the difference is visible without reading tests. CI smoke-runs it.
- **README** — the market-data section still described the layer as it was before any of this work. Now covers the public/private split, both products, per-channel configuration and the snapshot stream, with end-of-event markers and instrument definition messages listed as not done.

## What no shape here models

Named in the comparison tests rather than left to be discovered: packet framing and A/B line arbitration, instrument definition messages, end-of-event markers, implied and spread books, statistics and banding messages, and EMDI's netted throttling. Each is a real part of the venues being imitated and none is a channel's configuration, which is why the shapes stop where they do.

## Two things found on the way

Neither is fixed here — both are small and belong in their own change.

**`TradeDataEvent` carries no trade id**, while `MarketByOrderDelta` does. A consumer holding both products cannot join a print to the fills that made it. The Eurex test pairs them by time and price instead.

**A by-order mirror can drift through an auction.** A `Filled` delta says what traded, not what the order displays afterwards, and those differ when a print goes through an iceberg's peak into its reserve — which an auction can do, since it fills an order's whole remaining quantity rather than its displayed peak. In continuous trading an exhausted peak requeues and the feed says so, so a mirror stays exact. That is why `OrderBookMirror` is a test helper rather than the shipped counterpart to `LevelBook`, and why the session exercises its iceberg in continuous trading. The fix would be for the by-order feed to carry the resulting displayed quantity alongside what traded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj)_