### PR TITLE
Carry a trade's id onto the print

### DIFF
--- a/src/Circus/MarketData/TradeDataEvent.cs
+++ b/src/Circus/MarketData/TradeDataEvent.cs
@@ -1,4 +1,15 @@
 namespace Circus.MarketData;
 
-public record TradeDataEvent(string Symbol, DateTime Time, decimal Price, int Quantity)
+// One trade, as a venue broadcasts it - CME's TradeSummary, Eurex's EMDI print. One message per
+// trade rather than per fill, so an aggressor sweeping two resting orders prints twice and not
+// four times.
+//
+// TradeId is the same id the two fills of the trade carry on the by-order feed, which is what
+// makes the two products joinable. A subscriber holding both otherwise has a print at a price and
+// a quantity, and some order events at the same instant, and no way to say which fills made which
+// print - a sweep at one price across two resting orders looks identical to two unrelated trades.
+// It is not the id a participant knows its own fill by either: that arrives privately on
+// FillOrderConfirmed, which carries this same id, so a participant can find its own execution
+// inside the public print.
+public record TradeDataEvent(string Symbol, DateTime Time, string TradeId, decimal Price, int Quantity)
     : MarketDataEvent(Symbol, Time);

--- a/src/Circus/MarketData/TradeDataProducer.cs
+++ b/src/Circus/MarketData/TradeDataProducer.cs
@@ -9,6 +9,11 @@ namespace Circus.MarketData;
 // participant whose order filled and carries their CompanyId - so deriving a broadcast message
 // from it meant a producer reading something no subscriber is entitled to. The book publishes
 // TradePrinted for the same pair now, and the pairing lives where the trade happened.
+//
+// The trade's id comes across with it. It is the only field of a fill that is not about who filled
+// - the two sides of a trade share it, and so do the order events the by-order feed publishes for
+// them - so carrying it broadcasts nothing private and is what lets a subscriber holding both
+// products join a print to the fills that made it.
 public class TradeDataProducer : IIncrementalProducer<TradeDataEvent>
 {
     public IList<TradeDataEvent> Process(IReadOnlyList<MarketEvent> events)
@@ -21,7 +26,8 @@ public class TradeDataProducer : IIncrementalProducer<TradeDataEvent>
                 continue;
 
             output ??= new List<TradeDataEvent>();
-            output.Add(new TradeDataEvent(trade.Symbol, trade.Time, trade.Price, trade.Quantity));
+            output.Add(new TradeDataEvent(trade.Symbol, trade.Time, trade.TradeId, trade.Price,
+                trade.Quantity));
         }
 
         return output ?? (IList<TradeDataEvent>) Array.Empty<TradeDataEvent>();

--- a/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/TradeDataProducerTests.cs
@@ -1,4 +1,5 @@
 using Circus.Actions;
+using Circus.Events;
 using Circus.MarketData;
 using Circus.Time;
 using Circus.Tests.Helpers;
@@ -55,6 +56,59 @@ public class TradeDataProducerTests
         Assert.AreEqual(2, events.Count, "two trades, two prints - not four fills");
         Assert.AreEqual(new[] {100m, 110m}, events.Select(e => e.Price).ToArray());
         Assert.AreEqual(new[] {2, 3}, events.Select(e => e.Quantity).ToArray());
+        Assert.AreEqual(2, events.Select(e => e.TradeId).Distinct().Count(),
+            "an id apiece - two prints sharing one would say they were the same trade");
+    }
+
+    // The id is the book's, not the producer's. It is what the two fills of the trade carry, so a
+    // subscriber holding the by-order feed as well can join a print to the order events that made
+    // it - and a participant can find its own fill inside a print it was part of.
+    [Test]
+    public void APrint_CarriesTheIdTheFillsOfItsTradeCarry()
+    {
+        var gold = new Instrument("GCZ6", 10, 10);
+        var clock = new ManualClock(new DateTime(2000, 1, 1, 12, 0, 0));
+
+        var book = new TimestampingOrderBook(gold, clock);
+        book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        var bookEvents =
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        var print = new TradeDataProducer().Process(bookEvents).Single();
+        var fills = bookEvents.OfType<FillOrderConfirmed>().ToList();
+
+        Assert.AreEqual(2, fills.Count, "one per side");
+        Assert.IsNotEmpty(print.TradeId);
+        Assert.IsTrue(fills.All(f => f.TradeId == print.TradeId));
+    }
+
+    // And the same join against the public by-order product, which is where a subscriber actually
+    // meets it - a fill event is private and never reaches a feed.
+    [Test]
+    public void APrint_JoinsToTheByOrderMessageForTheSameTrade()
+    {
+        var gold = new Instrument("GCZ6", 10, 10);
+        var clock = new ManualClock(new DateTime(2000, 1, 1, 12, 0, 0));
+
+        var book = new TimestampingOrderBook(gold, clock);
+        book.UpdateStatus(OrderBookStatus.Open);
+        book.CreateLimitOrder("Company1", "Order1", new OrderValidity.Day(), Side.Buy, 3, 100);
+
+        var bookEvents =
+            book.CreateLimitOrder("Company2", "Order2", new OrderValidity.Day(), Side.Sell, 3, 100);
+
+        var print = new TradeDataProducer().Process(bookEvents).Single();
+
+        var filled = new MarketByOrderIncrementalProducer().Process(bookEvents)
+            .SelectMany(message => message.Changes)
+            .Where(change => change.TradeId == print.TradeId)
+            .ToList();
+
+        Assert.AreEqual(2, filled.Count, "the two sides of the print, found by its id alone");
+        Assert.IsTrue(filled.All(change => change.Action == MarketByOrderDeltaAction.Filled));
+        Assert.AreEqual(new[] {Side.Buy, Side.Sell}, filled.Select(c => c.Side).OrderBy(s => s).ToArray());
     }
 
     // The property that lets this hold nothing: what a batch produces does not depend on the

--- a/tests/Circus.Tests/Venues/EurexShapedVenueTests.cs
+++ b/tests/Circus.Tests/Venues/EurexShapedVenueTests.cs
@@ -92,16 +92,17 @@ public class EurexShapedVenueTests
         // The opening auction, which is the first thing either interface has a trade to report.
         var print = published[GoldByPrice].Select(m => m.Data).OfType<TradeDataEvent>().First();
 
+        // By the print's own id, across interfaces, with nothing else to go on. Matching on time
+        // and price would find the same two here and the wrong ones the moment a sweep prints
+        // twice at one price in one action.
         var fills = published[GoldByOrder].Select(m => m.Data).OfType<MarketByOrderDeltaEvent>()
-            .Where(d => d.Time == print.Time)
             .SelectMany(d => d.Changes)
-            .Where(c => c.Action == MarketByOrderDeltaAction.Filled)
+            .Where(c => c.TradeId == print.TradeId)
             .ToList();
 
         Assert.AreEqual(2, fills.Count, "one per side of the trade");
         Assert.AreEqual(new[] {Side.Buy, Side.Sell}, fills.Select(f => f.Side).OrderBy(s => s).ToArray());
-        Assert.AreEqual(1, fills.Select(f => f.TradeId).Distinct().Count(),
-            "paired by a shared id - without it two fills at one price could be two trades");
+        Assert.IsTrue(fills.All(f => f.Action == MarketByOrderDeltaAction.Filled));
         Assert.AreEqual(print.Price, fills[0].Price);
         Assert.AreEqual(print.Quantity, fills[0].Quantity);
 

--- a/tests/Circus.Tests/Venues/VenueShapeComparisonTests.cs
+++ b/tests/Circus.Tests/Venues/VenueShapeComparisonTests.cs
@@ -78,11 +78,13 @@ public class VenueShapeComparisonTests
         return mirror;
     }
 
-    private static (decimal Price, int Quantity)[] Prints(IEnumerable<ChannelMessage> messages,
-        string symbol) =>
+    // The id included, so two shapes agreeing about the prints agree about which trades they were
+    // and not merely about the tape's shape.
+    private static (string TradeId, decimal Price, int Quantity)[] Prints(
+        IEnumerable<ChannelMessage> messages, string symbol) =>
         messages.Select(m => m.Data).OfType<TradeDataEvent>()
             .Where(t => t.Symbol == symbol)
-            .Select(t => (t.Price, t.Quantity))
+            .Select(t => (t.TradeId, t.Price, t.Quantity))
             .ToArray();
 
     // The headline. One session, two packagings, one market.
@@ -126,6 +128,51 @@ public class VenueShapeComparisonTests
         Assert.IsNotEmpty(ladder.Bids);
         Assert.AreEqual(ladder.Bids, mirror.Levels(Side.Buy, VenueSession.Depth));
         Assert.AreEqual(ladder.Offers, mirror.Levels(Side.Sell, VenueSession.Depth));
+    }
+
+    // The other join between the two products, and the one a shape can most easily break: every
+    // print on the depth interface names a trade the order-by-order interface reported the two
+    // sides of. A participant reading both is exactly the case this is for - it sees the market's
+    // print and its own two order events and can say they are the same trade.
+    //
+    // Over the whole session rather than one trade, because the sweep is where matching on time
+    // and price stops working: one action prints at three prices, and an aggressor taking two
+    // resting orders at one price would print twice with nothing but the id to tell them apart.
+    //
+    // Keyed on the instrument as well as the id, because a trade id counts within a book rather
+    // than across the venue - Gold's first trade and Silver's are both "1". That is how CME and
+    // Eurex scope theirs too, and a channel carrying a whole product group has to join on both.
+    [Test]
+    public void EveryPrint_NamesATradeTheOrderByOrderInterfaceReportedBothSidesOf()
+    {
+        var published = VenueSession.Run(EurexShaped());
+
+        var sidesOfTrade = published[EurexByOrder].Select(m => m.Data).OfType<MarketByOrderDeltaEvent>()
+            .SelectMany(message => message.Changes
+                .Where(change => change.TradeId != null)
+                .Select(change => (Trade: (message.Symbol, change.TradeId!), Change: change)))
+            .GroupBy(entry => entry.Trade)
+            .ToDictionary(group => group.Key, group => group.Select(entry => entry.Change).ToList());
+
+        var prints = published[EurexByPrice].Select(m => m.Data).OfType<TradeDataEvent>().ToList();
+
+        Assert.IsNotEmpty(prints);
+        Assert.AreEqual(prints.Count, prints.Select(p => (p.Symbol, p.TradeId)).Distinct().Count(),
+            "one print per trade, so one id per print");
+
+        foreach (var print in prints)
+        {
+            Assert.IsTrue(sidesOfTrade.TryGetValue((print.Symbol, print.TradeId), out var sides),
+                $"{print.Symbol} trade {print.TradeId} printed with no order events naming it");
+            Assert.AreEqual(new[] {Side.Buy, Side.Sell}, sides!.Select(s => s.Side).OrderBy(s => s).ToArray());
+            Assert.IsTrue(sides.All(s => s.Action == MarketByOrderDeltaAction.Filled));
+            Assert.IsTrue(sides.All(s => s.Price == print.Price && s.Quantity == print.Quantity),
+                "the two sides of a trade are the trade, at its price and its size");
+        }
+
+        Assert.AreEqual(prints.Select(p => (p.Symbol, p.TradeId)).OrderBy(t => t).ToArray(),
+            sidesOfTrade.Keys.OrderBy(t => t).ToArray(),
+            "and nothing filled that no print named");
     }
 
     // And the same thing against the images rather than the updates, which is the path a


### PR DESCRIPTION
One of the two things #98 turned up. A subscriber holding both the depth and the order-by-order product had a print at a price and a quantity, some order events at the same instant, and no way to say which fills made which print.

Matching on time and price looks like it works until it doesn't: an aggressor taking two resting orders at one price prints twice in one action, and nothing distinguishes those two trades from each other.

## The change

`TradeDataEvent` gains `TradeId`, and `TradeDataProducer` passes through the one already on `TradePrinted`.

That is the whole of it. The book mints an id per trade, both `FillOrderConfirmed` events carry it, `TradePrinted` carries it, and the by-order feed publishes it on each side of the trade. Only the print dropped it on the way out.

It broadcasts nothing private. A trade id is the one part of a fill that isn't about *who* filled — the two sides share it — which is why it can go on a public message where the rest of a fill cannot. It also means a participant can find its own execution inside the print it was part of, since the private confirm carries the same id.

Ids come from a per-book counter, so replays still reproduce exactly.

## Tests

- `TradeDataProducerTests` — a print carries the id its fills carry, two prints in one dispatch have an id apiece, and a print joins to the public by-order message for the same trade.
- `EurexShapedVenueTests` — the cross-interface pairing now goes by the print's own id rather than by time and price, which is what the test was always claiming to demonstrate.
- `VenueShapeComparisonTests` — over the whole session, every print names a trade the order-by-order interface reported both sides of, at its price and its size, and nothing filled that no print named. The shape comparison also now includes ids, so two shapes agreeing about the prints agree about which *trades* they were.

One thing that surfaced writing that last test and is worth stating: **trade ids count within a book, not across the venue** — Gold's first trade and Silver's are both `"1"`. That is how CME and Eurex scope theirs, so it's correct rather than a defect, but a channel carrying a whole product group has to join on the instrument as well as the id. The test does, and says so.

## Still open

The other finding from #98 is untouched: a `Filled` delta says what traded, not what the order displays afterwards, so a by-order mirror can drift when an auction prints through an iceberg's peak into its reserve. Fixing that would also let `OrderBookMirror` graduate from a test helper to the shipped counterpart of `LevelBook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeTCTU7eDSvtha6Edvafrj)_