### PR TITLE
Let a session span midnight

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Sessions
 - [x] Time provider
 - [x] Sessions
 - [x] Multiple sessions per day
+- [x] Overnight sessions (spanning midnight, dated by trading day rather than by the clock)
 - [ ] Market statistics
 
 Market data

--- a/docs/overnight-sessions-plan.md
+++ b/docs/overnight-sessions-plan.md
@@ -1,0 +1,222 @@
+# Sessions that span midnight
+
+A plan, carried out. Steps 1 to 4 and 6 have landed; the `Circus.Tests.Venues` case noted at the end
+of step 5 is outstanding.
+
+What follows is the plan as written, not a description of what was built, and the two differ in one
+place. Step 3 argues for a gap between one session's close and the next's pre-open; what landed
+requires the same gap between a session's own three boundaries, since `PreOpen == Open` skips the
+open for exactly the reason a touching pair skips a pre-open, and permitting one while refusing the
+other would have been arbitrary. Once step 5's last case lands this document should be deleted -
+the reasoning that survives is all in comments on the code it explains.
+
+Overnight sessions were not supported, and the code said so where it decided: `TradingSession` held
+three times of day, all of which had to fall within the same day. A product that opens at 17:00 and
+closes at 16:00 the next afternoon - which is most of what CME lists, and the shape Globex has had
+since it was Globex - could not be described to this venue at all.
+
+## Where we are
+
+`TradingSession(TimeSpan PreOpen, TimeSpan Open, TimeSpan Close)` is a triple of times of day, and
+three things hold it to one calendar day:
+
+- `MarketSchedule`'s constructor requires `PreOpen <= Open <= Close` within each session, and each
+  session's `PreOpen` to be at or after the previous one's `Close`. An overnight session written as
+  `(17:00, 17:00, 16:00)` is rejected by the second of those - `Open > Close`.
+- `MarketSchedule.SessionAt` asks whether a `TimeOfDay` falls in `[PreOpen, Close)`, so a session in
+  progress can only ever be one that began earlier on the same date. At 02:00 nothing is running,
+  whatever opened last evening.
+- `MarketSchedule.NextAfter` anchors every boundary it returns on `time.Date`, so no transition it
+  produces can land on a different date to the instant it was asked about.
+
+Everything downstream is already indifferent to this and stays that way. The `Sequencer` holds one
+pending transition per book, gets it from `NextAfter`, and queues the next only once the current one
+has been dispatched - it never reasons about dates. `InstrumentGroup` passes a schedule through.
+`OrderBook` reads `EndsTradingDay` off the close it is handed and never asks what day it is except
+in the two places listed under step 4.
+
+So the change is contained: it is a change to what a schedule can describe and to how it answers,
+plus one decision about what "the trading day" names once a session outlives a date.
+
+## Where we are going
+
+A session's boundaries become offsets from the start of the day it is anchored on, rather than times
+within that day. `TimeSpan` already carries this: `new TradingSession(new TimeSpan(17, 0, 0), new
+TimeSpan(17, 0, 0), new TimeSpan(40, 0, 0))` is Globex's day - pre-open and open at 17:00, close at
+16:00 the following afternoon. No new type, no `DayOffset` field beside each time, and a schedule
+that does not span midnight is written exactly as it is written today.
+
+The schedule stays what it is: stateless, one day repeated, answering "what is due after this
+instant" rather than walking. That property is what the `Sequencer` needs and it survives the change
+intact - the only thing that grows is how far back the query has to look for a session that might
+still be running.
+
+The alternative shapes were considered and are not recommended. An explicit `DayOffset` per boundary
+says the same thing in three more fields and invites the two of them to disagree. A calendar of
+concretely dated sessions - which is what holidays and half-days will eventually want - is a much
+larger change that this one does not block: a dated calendar is a different implementation of the
+same `NextAfter` question, and building it later is easier against a `TradingSession` that already
+knows a session can outlive a date.
+
+## Steps
+
+### 1. Let a session's offsets exceed a day
+
+`TradingSession`'s comment is the specification and it is what changes first. The three times become
+offsets from the anchor day's midnight, `Close` may exceed 24 hours, and the record itself is
+otherwise untouched.
+
+`MarketSchedule`'s per-session check (`PreOpen <= Open <= Close`) already reads correctly against
+offsets and needs nothing. The ordering check between neighbours does too.
+
+What is new is a bound on the whole schedule. A day repeated indefinitely only makes sense if one
+day's sessions cannot reach into the day after next:
+
+```csharp
+if (sessions[^1].Close - sessions[0].PreOpen >= TimeSpan.FromDays(1))
+    throw new ArgumentException("a day's sessions must span less than 24 hours");
+```
+
+Strictly less rather than at most, which is what step 2 needs and what step 3 explains. This single
+check does two jobs: it keeps a schedule a description of one repeating day, and it caps how far
+back a query has to look at exactly one day.
+
+### 2. Ask the question against dates rather than times of day
+
+`NextAfter` currently compares `time.TimeOfDay` against offsets and anchors its answer on
+`time.Date`. Both become comparisons of `DateTime` against `anchor.Add(offset)`, where the anchor is
+a candidate date rather than always today.
+
+Finding the session in progress becomes a scan over two anchors:
+
+```csharp
+// Yesterday first: a session that began before midnight may still be running. Nothing earlier
+// can reach here, the constructor having capped a day's whole span below 24 hours.
+for (var dayOffset = -1; dayOffset <= 0; dayOffset++)
+{
+    var anchor = time.Date.AddDays(dayOffset);
+    if (SessionAt(anchor, time) is not { } index) continue;
+
+    var session = _sessions[index];
+    return time < anchor.Add(session.Open)
+        ? new ScheduledTransition(anchor.Add(session.Open), OrderBookStatus.Open)
+        : new ScheduledTransition(anchor.Add(session.Close), OrderBookStatus.Closed,
+            EndsTradingDay(index));
+}
+```
+
+Yesterday is tried first because that is where a session in progress can only be: today's sessions
+have not started yet if yesterday's is still running, non-overlap being what the constructor checks.
+
+The out-of-session branch is the same shape - the next pre-open at or after `time`, trying today's
+sessions in order and falling through to tomorrow's first. `SessionAt` keeps its half-open interval
+(`>= PreOpen`, `< Close`), which is what continues to let a close and the next pre-open coincide,
+and which step 3 is about.
+
+`NextSessionAt` and its `(Index, DayOffset)` return exist for a stateful walker that anchors
+boundaries on its caller's date. Nothing implements that walker - the comment describes a consumer
+that was never written - so both it and `Sessions` should go rather than be carried through this
+change and left wrong. `EndsTradingDay` stays; it is asked by `NextAfter` itself.
+
+### 3. Decide what a shared boundary means
+
+`MarketSchedule` currently permits one session's `PreOpen` to equal the previous session's `Close`,
+and then cannot reach both: standing on the close, the next question steps over the pre-open and
+lands on the boundary after it, so a session opens without ever pre-opening. The comment on
+`NextAfter` says as much and leaves the question open.
+
+Overnight schedules make it reachable rather than hypothetical, because they are how a nearly
+continuous venue is written and a nearly continuous venue is exactly one whose sessions touch. The
+recommendation is to close it by construction: require a strictly positive gap between one session's
+close and the next's pre-open, and between the day's last close and tomorrow's first pre-open (which
+step 1's strict inequality already gives).
+
+That costs nothing real. Venues that run almost around the clock still stop - CME's maintenance
+window is an hour, Eurex's is minutes - and a venue that genuinely never closes is one session with
+no boundary rather than two that touch. It also turns a latent wrong answer into an exception at the
+point the schedule is written, which is where it can be understood.
+
+The alternative is a query that carries the status the caller last applied, so it can distinguish
+standing on a close from standing on a pre-open. That makes `NextAfter` stateful in its arguments to
+serve a case with no venue behind it, and is not recommended.
+
+### 4. Say which day a session belongs to
+
+This is the one behavioural decision in the plan, and it is the reason the change is not just
+arithmetic in `MarketSchedule`.
+
+A session that opens on Sunday evening and closes on Monday afternoon is Monday's trading day
+throughout - a trade printed at 22:00 on Sunday is a Monday trade. Nothing in the engine can know
+that today, because the two places that need a date read it off the wall clock:
+
+- `OrderBook.CreateOrder` rejects a GTD order whose date is before `DateOnly.FromDateTime(time)`.
+- `ExpireOrders` retires GTD orders whose date is at or before `DateOnly.FromDateTime(time)`.
+
+Under a same-day schedule those agree with the trading day. Under an overnight one they do not: an
+order sent at 22:00 on Sunday good till Monday is, by the wall clock, good till tomorrow - and it
+would then survive the Monday-afternoon close it was meant to die at, because that close falls on
+Monday and the order is good till Monday. Off by one session, in the direction that leaves an order
+resting that a participant believes has expired.
+
+So the trading day becomes something the schedule states rather than something the book infers:
+
+- `TradingSession` gains `int TradeDateOffset = 0` - how many days past its anchor date the session's
+  trading day falls. Globex's Sunday evening session carries 1; a lunch-broken cash session carries
+  0, which is the default and which is why no existing schedule changes.
+- `ScheduledTransition` gains `DateOnly TradeDate`, computed as `anchor.AddDays(session.TradeDateOffset)`.
+- The `PreOpenTrading`, `OpenTrading` and `CloseTrading` actions gain an optional `TradeDate`. The
+  `Sequencer` fills it from the transition; a caller driving a book by hand leaves it null.
+- `OrderBook` keeps the current trading day in a field, set on a phase whose `StartsSession` is true
+  and defaulting to the instant's own date when the action does not say - which is exactly today's
+  behaviour, so a book driven directly through `OrderBookExtensions` is unaffected. The two reads
+  above consult that field instead of the clock.
+
+The sequence and trade id seed in `UpdateStatus` should come from the same field. It is derived from
+the transition instant today, which for an overnight session means ids carrying the date the session
+started rather than the day it belongs to. The `Math.Max` that keeps the seed forward-only means
+this is not a correctness problem either way, but an id whose date is the trading day is the one
+worth having, and once the field exists it is free.
+
+### 5. Tests
+
+`MarketScheduleTests` is where most of this is provable, and it should get an overnight schedule
+beside the two it already has - `(17:00, 17:00, 40:00)`, a day with nothing else in it:
+
+- Asked before the pre-open, the pre-open today.
+- Asked during the evening, the close - tomorrow's date, this session's.
+- Asked after midnight, still that same close, anchored on yesterday. This is the case that fails
+  outright today and is the point of the change.
+- Asked between the close and the next pre-open, that pre-open, today.
+- A schedule spanning 24 hours or more, rejected.
+- Touching boundaries, rejected (step 3).
+
+Then a schedule with an evening session and a next-day cash session, to prove `EndsTradingDay` still
+names the day's last close when that close is on a different date to the pre-open that began the
+day, and that the two sessions do not overlap across the wrap.
+
+Beyond the schedule, one venue-level test in `tests/Circus.Tests/Sessions`: run a book through an
+overnight session with a Day order and a GTD order resting, and prove both survive midnight and
+retire at the session's close rather than at the date change. That is the assertion a participant
+would actually make, and it is the one step 4 exists for.
+
+`Circus.Tests.Venues` runs one trace through several venue shapes and is where a schedule that
+crosses midnight belongs next, once the above lands - the trace is stamped within a day today and
+would need its own instants moved, so it is a follow-on rather than part of this.
+
+### 6. README
+
+`Overnight sessions (spanning midnight)` sits under Sessions, unchecked until the above lands.
+
+## What this does not do
+
+Time zones and daylight saving. A schedule is offsets against whatever `DateTime` it is given, and
+the venue supplies UTC. A 17:00 Chicago boundary is 22:00 UTC for part of the year and 23:00 for the
+rest, and nothing here shifts with it. That is already true of same-day schedules and is not made
+worse by this change, but overnight sessions are where it starts to matter - a product that trades
+almost around the clock has its boundaries in one particular local evening, and an hour's drift in
+them is an hour of the wrong status. A schedule that carries a `TimeZoneInfo` and resolves its
+offsets against the anchor date's local midnight is the shape that fixes it, and it composes with
+everything above: the anchor date is already the unit this plan works in.
+
+Holidays and half-days, which remain what `NextAfter`'s nullable return is written for and which
+nothing here brings closer or pushes further away.

--- a/src/Circus/Actions/OrderBookAction.cs
+++ b/src/Circus/Actions/OrderBookAction.cs
@@ -15,12 +15,25 @@ public abstract record OrderBookAction
     public DateTime Time { get; init; }
 }
 
-public sealed record PreOpenTrading : OrderBookAction
+// The day the venue says it is trading over this boundary. Null leaves the book to date itself
+// from the instant the action is stamped, which is what a same-day schedule means anyway and what
+// a caller driving a book by hand gets without saying anything.
+//
+// A session that runs past midnight is why this exists. Its business belongs to one trading day
+// throughout, and for the part of it before midnight that day is not the date on the clock - so
+// an order good till a date, which is a statement about trading days, cannot be measured against
+// the clock either. Whoever owns the schedule knows the answer; the book does not.
+public abstract record SessionAction : OrderBookAction
+{
+    public DateOnly? TradeDate { get; init; }
+}
+
+public sealed record PreOpenTrading : SessionAction
 {
     public decimal? ReferencePrice { get; init; }
 }
 
-public sealed record OpenTrading : OrderBookAction
+public sealed record OpenTrading : SessionAction
 {
     public decimal? ReferencePrice { get; init; }
 }
@@ -28,7 +41,7 @@ public sealed record OpenTrading : OrderBookAction
 // A trading day can hold several sessions, and only the last close of the day retires that
 // day's Day/GoodTilDate orders - an intra-day close (a lunch break, say) leaves them resting.
 // Defaults to true so a single-session day needs to say nothing.
-public sealed record CloseTrading : OrderBookAction
+public sealed record CloseTrading : SessionAction
 {
     public bool EndsTradingDay { get; init; } = true;
 }

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -159,6 +159,15 @@ public class OrderBook : IOrderBook
     // Keyed by InternalId, not ExchangeOrderId - the latter changes across an order's life.
     private readonly Dictionary<long, InternalOrder> _orders = new();
 
+    // The day the venue last said it was trading, carried on the session actions that move the
+    // book between phases. Null until something says, which is the state a book driven by hand
+    // stays in - and TradingDayOn then dates it from the clock, exactly as it always did.
+    //
+    // Held rather than read off each action because the question is asked by order flow too: a
+    // GTD order arriving mid-session is good till a trading day, and the action creating it
+    // carries no schedule.
+    private DateOnly? _tradeDate;
+
     // every (companyId, clientOrderId) pair ever assigned by a client, permanently reserved -
     // used for per-client uniqueness checks, ownership enforcement, and Update/Cancel lookups
     private readonly Dictionary<(string CompanyId, string ClientOrderId), InternalOrder> _clientOrderIndex = new();
@@ -333,9 +342,9 @@ public class OrderBook : IOrderBook
             UpdateOrder update => UpdateOrder(update.CompanyId, update.ClientOrderId,
                 update.PreviousClientOrderId, update.NewTotalQuantity, update.Price, update.TriggerPrice, time),
             CancelOrder cancel => CancelOrder(cancel.CompanyId, cancel.ClientOrderId, cancel.PreviousClientOrderId, time),
-            PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice, true, OrderBookStatusChangeReason.Requested, time),
-            OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice, true, OrderBookStatusChangeReason.Requested, time),
-            CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay, OrderBookStatusChangeReason.Requested, time),
+            PreOpenTrading s => UpdateStatus(OrderBookStatus.PreOpen, s.ReferencePrice, true, OrderBookStatusChangeReason.Requested, time, s.TradeDate),
+            OpenTrading s => UpdateStatus(OrderBookStatus.Open, s.ReferencePrice, true, OrderBookStatusChangeReason.Requested, time, s.TradeDate),
+            CloseTrading c => UpdateStatus(OrderBookStatus.Closed, null, c.EndsTradingDay, OrderBookStatusChangeReason.Requested, time, c.TradeDate),
             PauseTrading => UpdateStatus(OrderBookStatus.Paused, null, true, OrderBookStatusChangeReason.Requested, time),
             HaltTrading => UpdateStatus(OrderBookStatus.Halted, null, true, OrderBookStatusChangeReason.Requested, time),
 
@@ -467,7 +476,7 @@ public class OrderBook : IOrderBook
             !_matcher.HasSufficientLiquidity(side, priceTicks!.Value, gateMinQty, selfMatchPreventionId,
                 selfMatchPreventionInstruction))
             return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InsufficientLiquidityForMinQuantity, time);
-        if (validity is OrderValidity.GoodTilDate { Date: var goodTilDate } && goodTilDate < DateOnly.FromDateTime(time))
+        if (validity is OrderValidity.GoodTilDate { Date: var goodTilDate } && goodTilDate < TradingDayOn(time))
             return RejectCreate(companyId, clientOrderId, OrderRejectedReason.InvalidExpireDate, time);
 
         _nextSequenceNumber++;
@@ -1366,8 +1375,15 @@ public class OrderBook : IOrderBook
     // last of them ends it. The phase table stays the authority on whether a phase expires day
     // orders at all - this only says whether this particular close is that day's last.
     private List<OrderBookEvent> UpdateStatus(OrderBookStatus status, decimal? referencePrice = null,
-        bool endsTradingDay = true, OrderBookStatusChangeReason reason = OrderBookStatusChangeReason.Requested, DateTime time = default)
+        bool endsTradingDay = true, OrderBookStatusChangeReason reason = OrderBookStatusChangeReason.Requested,
+        DateTime time = default, DateOnly? tradeDate = null)
     {
+        // Before anything reads it, and on every session action that carries one rather than only
+        // on the one that starts a session: a book driven straight to a close - or to an open,
+        // without a pre-open ahead of it - is still owed the day it is closing for. A transition
+        // that says nothing leaves the book dated where it was.
+        if (tradeDate.HasValue) _tradeDate = tradeDate;
+
         if (referencePrice.HasValue && TryConvertToTicks(referencePrice, out var referenceTicks))
         {
             foreach (var phase in _phases.Values)
@@ -1401,14 +1417,19 @@ public class OrderBook : IOrderBook
 
         if (arriving.StartsSession)
         {
-            // Seeded from the date so an id carries the day it was issued, but only ever
-            // forwards: a second session on the same date computes a seed the counter has
+            // Seeded from the trading day so an id carries the day it was issued, but only ever
+            // forwards: a second session on the same day computes a seed the counter has
             // already passed and so continues from where it was. Restarting it would re-issue
             // ids that orders surviving the previous session (GTC, or GTD not yet due) still
             // hold, and _orders is keyed on exactly that. Math.Max is also what keeps a replay
             // whose clock moves backwards from colliding - a run of ids that no longer encodes
-            // its date beats one that repeats itself.
-            var seed = ((time.Year * 10000) + (time.Month * 100) + time.Day) * 10000000000L;
+            // its day beats one that repeats itself.
+            //
+            // The trading day rather than the clock's date, so an overnight session's ids carry
+            // the day they trade for from the evening onwards rather than changing over at
+            // midnight halfway through.
+            var day = TradingDayOn(time);
+            var seed = ((day.Year * 10000) + (day.Month * 100) + day.Day) * 10000000000L;
             _nextSequenceNumber = Math.Max(_nextSequenceNumber, seed);
 
             // Trade ids carry the day and never run backwards for the same reasons, though a
@@ -1438,9 +1459,14 @@ public class OrderBook : IOrderBook
         return events;
     }
 
+    // The trading day as of `time`: what the schedule last said, or the date on the clock when
+    // nothing has. The two agree for every schedule that stays within its day, which is why a
+    // book nobody tells behaves as it always did.
+    private DateOnly TradingDayOn(DateTime time) => _tradeDate ?? DateOnly.FromDateTime(time);
+
     private IEnumerable<OrderBookEvent> ExpireOrders(DateTime time)
     {
-        var today = DateOnly.FromDateTime(time);
+        var today = TradingDayOn(time);
         var orders = _orders.Values.Where(o =>
             o.Validity is OrderValidity.Day ||
             (o.Validity is OrderValidity.GoodTilDate { Date: var date } && date <= today))

--- a/src/Circus/OrderBookExtensions.cs
+++ b/src/Circus/OrderBookExtensions.cs
@@ -102,20 +102,23 @@ public static class OrderBookExtensions
             PreviousClientOrderId = previousClientOrderId
         });
 
+    // tradeDate left out dates the book from the instant, which is what a schedule that stays
+    // within its day means anyway - a caller driving a book by hand only needs it for a session
+    // that runs past midnight.
     public static IReadOnlyList<OrderBookEvent> PreOpenTrading(this IOrderBook book,
-        decimal? referencePrice = null, DateTime time = default) =>
+        decimal? referencePrice = null, DateTime time = default, DateOnly? tradeDate = null) =>
         book.Process(new PreOpenTrading
-            { Symbol = book.Symbol, Time = time, ReferencePrice = referencePrice });
+            { Symbol = book.Symbol, Time = time, ReferencePrice = referencePrice, TradeDate = tradeDate });
 
     public static IReadOnlyList<OrderBookEvent> OpenTrading(this IOrderBook book,
-        decimal? referencePrice = null, DateTime time = default) =>
+        decimal? referencePrice = null, DateTime time = default, DateOnly? tradeDate = null) =>
         book.Process(new OpenTrading
-            { Symbol = book.Symbol, Time = time, ReferencePrice = referencePrice });
+            { Symbol = book.Symbol, Time = time, ReferencePrice = referencePrice, TradeDate = tradeDate });
 
     public static IReadOnlyList<OrderBookEvent> CloseTrading(this IOrderBook book, bool endsTradingDay = true,
-        DateTime time = default) =>
+        DateTime time = default, DateOnly? tradeDate = null) =>
         book.Process(new CloseTrading
-            { Symbol = book.Symbol, Time = time, EndsTradingDay = endsTradingDay });
+            { Symbol = book.Symbol, Time = time, EndsTradingDay = endsTradingDay, TradeDate = tradeDate });
 
     public static IReadOnlyList<OrderBookEvent> PauseTrading(this IOrderBook book, DateTime time = default) =>
         book.Process(new PauseTrading { Symbol = book.Symbol, Time = time });

--- a/src/Circus/Sequencing/Sequencer.cs
+++ b/src/Circus/Sequencing/Sequencer.cs
@@ -220,11 +220,18 @@ public sealed class Sequencer
     private static OrderBookAction ToAction(string symbol, ScheduledTransition transition) =>
         transition.Status switch
         {
-            OrderBookStatus.PreOpen => new PreOpenTrading {Symbol = symbol, Time = transition.Time},
-            OrderBookStatus.Open => new OpenTrading {Symbol = symbol, Time = transition.Time},
+            OrderBookStatus.PreOpen => new PreOpenTrading
+            {
+                Symbol = symbol, Time = transition.Time, TradeDate = transition.TradeDate
+            },
+            OrderBookStatus.Open => new OpenTrading
+            {
+                Symbol = symbol, Time = transition.Time, TradeDate = transition.TradeDate
+            },
             OrderBookStatus.Closed => new CloseTrading
             {
-                Symbol = symbol, Time = transition.Time, EndsTradingDay = transition.EndsTradingDay
+                Symbol = symbol, Time = transition.Time, TradeDate = transition.TradeDate,
+                EndsTradingDay = transition.EndsTradingDay
             },
             _ => throw new ArgumentOutOfRangeException(nameof(transition), transition.Status,
                 "a schedule moves a book between pre-open, open and closed, and nowhere else")

--- a/src/Circus/Sessions/MarketSchedule.cs
+++ b/src/Circus/Sessions/MarketSchedule.cs
@@ -6,11 +6,17 @@ namespace Circus.Sessions;
 // boundaries it has passed. A queue in front of several books needs the asking shape: it holds
 // one pending transition per book and wants the next one, not a catch-up.
 //
-// The session list describes one day, repeated: past the day's last close the schedule rolls into
-// tomorrow's first session. Holidays, half-days and a session spanning midnight are not modelled
-// - TradingSession says why the last of those cannot be.
+// The session list describes one day, repeated, and a day here is an anchor date rather than a
+// calendar day: sessions carry offsets from their anchor's midnight, so a session may close on
+// the day after the one it began on. What a day may not do is reach further than that, which is
+// what keeps this a repeating description and what bounds how far back a query has to look.
+//
+// Holidays and half-days are not modelled. The nullable return on NextAfter is where they would
+// show up.
 public sealed class MarketSchedule
 {
+    private static readonly TimeSpan Day = TimeSpan.FromDays(1);
+
     private readonly IReadOnlyList<TradingSession> _sessions;
 
     // A single continuous session, the common case.
@@ -26,14 +32,33 @@ public sealed class MarketSchedule
         for (var i = 0; i < sessions.Count; i++)
         {
             var session = sessions[i];
-            if (session.PreOpen > session.Open) throw new ArgumentException("pre-open must be before open");
-            if (session.Open > session.Close) throw new ArgumentException("open must be before close");
 
-            // Ordered and non-overlapping in one check: a session may begin the moment the
-            // previous one closes, but not before.
-            if (i > 0 && session.PreOpen < sessions[i - 1].Close)
-                throw new ArgumentException("sessions must be ordered and must not overlap");
+            // Strictly ordered, within a session and between neighbours alike. Two boundaries on
+            // one instant cannot both be reached by a query keyed on time - the first is returned
+            // and asking on from it steps over the second, so a session would open without
+            // pre-opening, or begin without the one before it having closed. Venues that run
+            // almost around the clock still stop, so requiring a gap costs nothing real and turns
+            // an answer that would quietly be wrong into an exception where the schedule is
+            // written.
+            if (session.PreOpen >= session.Open) throw new ArgumentException("pre-open must be before open");
+            if (session.Open >= session.Close) throw new ArgumentException("open must be before close");
+
+            if (i > 0 && session.PreOpen <= sessions[i - 1].Close)
+                throw new ArgumentException("sessions must be ordered and must not overlap or touch");
         }
+
+        // The first session begins on the anchor day itself. Without this an anchor would name no
+        // particular day, and the one-day lookback below would not be enough to find a session in
+        // progress.
+        if (sessions[0].PreOpen < TimeSpan.Zero || sessions[0].PreOpen >= Day)
+            throw new ArgumentException("the first session must pre-open within its own day");
+
+        // A day repeated is only a description of anything if one day's sessions end before the
+        // next day's begin. Strictly under 24 hours rather than at most, for the same reason
+        // neighbours may not touch: the day's last close and tomorrow's first pre-open are
+        // neighbours too.
+        if (sessions[sessions.Count - 1].Close - sessions[0].PreOpen >= Day)
+            throw new ArgumentException("a day's sessions must span less than 24 hours");
 
         _sessions = sessions;
     }
@@ -44,67 +69,62 @@ public sealed class MarketSchedule
     // contract past its last trading day, is the same question with a finite answer.
     //
     // Strictly after `time`, so a caller standing on a boundary it has just handled is told the
-    // one that follows rather than handed the same one back. The corollary is that two boundaries
-    // sharing an instant - a session closing exactly as the next pre-opens, which the constructor
-    // permits - cannot both be reached this way: the close is returned, and asking again from
-    // there steps over the pre-open. A stateful walker that iterates by status rather than by time
-    // handles such a day correctly. Anything iterating by time alone wants either distinct
-    // instants or a query carrying where it left off, and which of those is right is a question
-    // for whatever ends up consuming this.
+    // one that follows rather than handed the same one back. Every boundary is reachable that
+    // way, because the constructor refuses a schedule that would put two of them on one instant.
     public ScheduledTransition? NextAfter(DateTime time)
     {
-        var timeOfDay = time.TimeOfDay;
-
-        // Inside a session: whichever of that session's own remaining boundaries comes next.
-        var current = SessionAt(timeOfDay);
-        if (current != null)
+        // Yesterday's anchor first, because that is the only place a session in progress can be
+        // if there is one: sessions do not overlap, so one still running from yesterday means
+        // none of today's has begun. Nothing earlier can reach here - a day spans under 24 hours
+        // and starts within its anchor, so the day before yesterday closed before today began.
+        for (var dayOffset = -1; dayOffset <= 0; dayOffset++)
         {
-            var session = _sessions[current.Value];
-            return timeOfDay < session.Open
-                ? new ScheduledTransition(time.Date.Add(session.Open), OrderBookStatus.Open)
-                : new ScheduledTransition(time.Date.Add(session.Close), OrderBookStatus.Closed,
-                    EndsTradingDay(current.Value));
+            var anchor = time.Date.AddDays(dayOffset);
+            if (SessionAt(anchor, time) is not { } index) continue;
+
+            // Inside a session: whichever of that session's own remaining boundaries comes next.
+            var session = _sessions[index];
+            return time < anchor.Add(session.Open)
+                ? new ScheduledTransition(anchor.Add(session.Open), OrderBookStatus.Open,
+                    TradeDateOn(anchor, index))
+                : new ScheduledTransition(anchor.Add(session.Close), OrderBookStatus.Closed,
+                    TradeDateOn(anchor, index), EndsTradingDay(index));
         }
 
-        // Outside every session: the next one pre-opens, today or tomorrow.
-        var (index, dayOffset) = NextSessionAt(timeOfDay);
-        return new ScheduledTransition(time.Date.AddDays(dayOffset).Add(_sessions[index].PreOpen),
-            OrderBookStatus.PreOpen);
-    }
-
-    // The day's sessions, in order. Read by a stateful walker that anchors boundaries on its
-    // caller's own date rather than walking them from the last one.
-    internal IReadOnlyList<TradingSession> Sessions => _sessions;
-
-    // Which session to head for, and whether it falls on the next day. A session already in
-    // progress wins, so a caller starting (or waking) mid-session catches up into it rather than
-    // waiting for the next one.
-    internal (int Index, int DayOffset) NextSessionAt(TimeSpan timeOfDay)
-    {
-        var current = SessionAt(timeOfDay);
-        if (current != null) return (current.Value, 0);
-
-        for (var i = 0; i < _sessions.Count; i++)
+        // Outside every session: the next one to pre-open, on today's anchor or tomorrow's.
+        for (var dayOffset = 0; dayOffset <= 1; dayOffset++)
         {
-            if (_sessions[i].PreOpen > timeOfDay)
-                return (i, 0);
+            var anchor = time.Date.AddDays(dayOffset);
+            for (var i = 0; i < _sessions.Count; i++)
+            {
+                var preOpen = anchor.Add(_sessions[i].PreOpen);
+                if (preOpen > time)
+                    return new ScheduledTransition(preOpen, OrderBookStatus.PreOpen, TradeDateOn(anchor, i));
+            }
         }
 
-        // Past the last close of the day - start again with tomorrow's first session.
-        return (0, 1);
+        // Unreachable: tomorrow's anchor is midnight tonight at the earliest, which is ahead of
+        // any instant today, so the loop above always finds something.
+        return null;
     }
 
     // Only the day's last session ends the trading day; closing for a break leaves Day orders
     // resting for the session still to come.
-    internal bool EndsTradingDay(int sessionIndex) => sessionIndex == _sessions.Count - 1;
+    private bool EndsTradingDay(int sessionIndex) => sessionIndex == _sessions.Count - 1;
 
-    // The session `timeOfDay` falls inside, if any. Half-open, so a session's close is not part
-    // of it - which is what lets a close and the next pre-open share an instant.
-    private int? SessionAt(TimeSpan timeOfDay)
+    // The day a session's business belongs to. An evening session that trades for tomorrow says
+    // so on itself, so this is the anchor date and nothing about where the boundary happens to
+    // land on a calendar.
+    private DateOnly TradeDateOn(DateTime anchor, int sessionIndex) =>
+        DateOnly.FromDateTime(anchor.AddDays(_sessions[sessionIndex].TradeDateOffset));
+
+    // The session anchored on `anchor` that `time` falls inside, if any. Half-open, so a
+    // session's close is not part of it.
+    private int? SessionAt(DateTime anchor, DateTime time)
     {
         for (var i = 0; i < _sessions.Count; i++)
         {
-            if (timeOfDay >= _sessions[i].PreOpen && timeOfDay < _sessions[i].Close)
+            if (time >= anchor.Add(_sessions[i].PreOpen) && time < anchor.Add(_sessions[i].Close))
                 return i;
         }
 

--- a/src/Circus/Sessions/ScheduledTransition.cs
+++ b/src/Circus/Sessions/ScheduledTransition.cs
@@ -1,9 +1,14 @@
 namespace Circus.Sessions;
 
-// One boundary a schedule has coming: when it falls, and the status it moves the book to.
+// One boundary a schedule has coming: when it falls, which trading day it belongs to, and the
+// status it moves the book to.
+//
+// TradeDate is the day the venue says it is trading over this boundary, which is the session's
+// anchor date shifted by its TradeDateOffset. It is not read off Time: an overnight session's
+// pre-open and open fall on the calendar day before the one they trade for.
 //
 // EndsTradingDay carries the same meaning it has on CloseTrading: false for a session closing
 // with another still to come the same day, so Day orders rest across a lunch break. True (the
 // default) for every other status, which ends nothing.
-public readonly record struct ScheduledTransition(DateTime Time, OrderBookStatus Status,
+public readonly record struct ScheduledTransition(DateTime Time, OrderBookStatus Status, DateOnly TradeDate,
     bool EndsTradingDay = true);

--- a/src/Circus/Sessions/TradingSession.cs
+++ b/src/Circus/Sessions/TradingSession.cs
@@ -1,9 +1,17 @@
 namespace Circus.Sessions;
 
-// One session's boundaries as times of day. A day's schedule is an ordered, non-overlapping
-// list of these - a single continuous session for most products, two or more for one that
-// breaks (a lunch recess, a separate evening session).
+// One session's boundaries, as offsets from the start of the day it is anchored on. A day's
+// schedule is an ordered, non-overlapping list of these - a single continuous session for most
+// products, two or more for one that breaks (a lunch recess, a separate evening session).
 //
-// All three times fall within the same day, so a session cannot span midnight. An overnight
-// product would need boundaries that carry a day offset, which nothing here models yet.
-public record TradingSession(TimeSpan PreOpen, TimeSpan Open, TimeSpan Close);
+// Offsets rather than times of day, so a session may run past midnight: an offset at or beyond 24
+// hours falls on the day after its anchor. A product pre-opening at 16:45, opening at 17:00 and
+// closing at 16:00 the following afternoon is `(16:45, 17:00, 40:00)`. MarketSchedule keeps a
+// day's whole span under 24 hours, so a session reaches at most into the day after its anchor.
+//
+// TradeDateOffset is the day the session's business belongs to, counted from its anchor. An
+// evening session that is the next day's trading carries 1; everything else carries 0, which is
+// why a schedule that stays within its day says nothing about it. This is the day an order good
+// till a date is measured against, and it is not the date on the wall clock: every instant of an
+// overnight session before midnight is dated a day behind the trading day it belongs to.
+public record TradingSession(TimeSpan PreOpen, TimeSpan Open, TimeSpan Close, int TradeDateOffset = 0);

--- a/tests/Circus.Tests/Sessions/MarketScheduleTests.cs
+++ b/tests/Circus.Tests/Sessions/MarketScheduleTests.cs
@@ -199,16 +199,19 @@ public class MarketScheduleTests
         }
 
         // assert - the whole day in order, then the roll into the next one
+        var today = DateOnly.FromDateTime(Day);
+        var tomorrow = DateOnly.FromDateTime(NextDay);
+
         Assert.AreEqual(
             new[]
             {
-                new ScheduledTransition(Day.Add(Morning.PreOpen), OrderBookStatus.PreOpen),
-                new ScheduledTransition(Day.Add(Morning.Open), OrderBookStatus.Open),
-                new ScheduledTransition(Day.Add(Morning.Close), OrderBookStatus.Closed, false),
-                new ScheduledTransition(Day.Add(Afternoon.PreOpen), OrderBookStatus.PreOpen),
-                new ScheduledTransition(Day.Add(Afternoon.Open), OrderBookStatus.Open),
-                new ScheduledTransition(Day.Add(Afternoon.Close), OrderBookStatus.Closed),
-                new ScheduledTransition(NextDay.Add(Morning.PreOpen), OrderBookStatus.PreOpen)
+                new ScheduledTransition(Day.Add(Morning.PreOpen), OrderBookStatus.PreOpen, today),
+                new ScheduledTransition(Day.Add(Morning.Open), OrderBookStatus.Open, today),
+                new ScheduledTransition(Day.Add(Morning.Close), OrderBookStatus.Closed, today, false),
+                new ScheduledTransition(Day.Add(Afternoon.PreOpen), OrderBookStatus.PreOpen, today),
+                new ScheduledTransition(Day.Add(Afternoon.Open), OrderBookStatus.Open, today),
+                new ScheduledTransition(Day.Add(Afternoon.Close), OrderBookStatus.Closed, today),
+                new ScheduledTransition(NextDay.Add(Morning.PreOpen), OrderBookStatus.PreOpen, tomorrow)
             },
             walk);
     }
@@ -228,28 +231,6 @@ public class MarketScheduleTests
 
         // assert
         Assert.AreEqual(first, again);
-    }
-
-    [Test]
-    public void NextAfter_CloseTouchingTheNextPreOpen_StepsOverThePreOpen()
-    {
-        // arrange - a session beginning the moment the previous one closes puts two boundaries on
-        // one instant, and a query keyed on time alone cannot return both
-        var touching = new TradingSession(new TimeSpan(11, 0, 0), new TimeSpan(11, 30, 0),
-            new TimeSpan(16, 0, 0));
-        var schedule = new MarketSchedule(new[] {Morning, touching});
-
-        // act
-        var close = NextAfter(schedule, Day.Add(new TimeSpan(10, 0, 0)));
-        var afterTheClose = NextAfter(schedule, close.Time);
-
-        // assert - the close is reached, and asking on from it lands on the open rather than the
-        // pre-open sharing that instant. A limitation of asking by time, pinned here so whatever
-        // consumes this next has to decide about it rather than discover it
-        Assert.AreEqual(OrderBookStatus.Closed, close.Status);
-        Assert.AreEqual(Day.Add(Morning.Close), close.Time);
-        Assert.AreEqual(OrderBookStatus.Open, afterTheClose.Status);
-        Assert.AreEqual(Day.Add(touching.Open), afterTheClose.Time);
     }
 
     [Test]
@@ -302,13 +283,175 @@ public class MarketScheduleTests
     }
 
     [Test]
-    public void Constructor_TouchingSessions_Success()
+    public void Constructor_TouchingSessions_ArgumentException()
     {
-        // arrange - a session may begin the moment the previous one closes
+        // arrange - a session beginning the moment the previous one closes puts two boundaries on
+        // one instant, and a query keyed on time alone cannot return both: the close would be
+        // answered and asking on from it would step over the pre-open, opening a session that
+        // never pre-opened
         var touching = new TradingSession(new TimeSpan(11, 0, 0), new TimeSpan(11, 30, 0),
             new TimeSpan(16, 0, 0));
 
         // assert
-        new MarketSchedule(new[] {Morning, touching});
+        Assert.Catch<ArgumentException>(
+            () => new MarketSchedule(new[] {Morning, touching})
+        );
+    }
+
+    [Test]
+    public void Constructor_OpenOnThePreOpen_ArgumentException()
+    {
+        // assert - the same instant shared by two of one session's own boundaries, and skipped
+        // for the same reason
+        Assert.Catch<ArgumentException>(
+            () => new MarketSchedule(PreOpen, PreOpen, Close)
+        );
+    }
+
+    [Test]
+    public void Constructor_CloseOnTheOpen_ArgumentException()
+    {
+        // assert
+        Assert.Catch<ArgumentException>(
+            () => new MarketSchedule(PreOpen, Open, Open)
+        );
+    }
+
+    [Test]
+    public void Constructor_DaySpanningTwentyFourHours_ArgumentException()
+    {
+        // assert - the day's last close landing on tomorrow's first pre-open, which is the wrap
+        // around version of two sessions touching
+        Assert.Catch<ArgumentException>(
+            () => new MarketSchedule(new TimeSpan(17, 0, 0), new TimeSpan(17, 30, 0), new TimeSpan(41, 0, 0))
+        );
+    }
+
+    [Test]
+    public void Constructor_FirstPreOpenPastItsOwnDay_ArgumentException()
+    {
+        // assert - an anchor that names no particular day
+        Assert.Catch<ArgumentException>(
+            () => new MarketSchedule(new TimeSpan(25, 0, 0), new TimeSpan(25, 30, 0), new TimeSpan(30, 0, 0))
+        );
+    }
+
+    // Globex's shape: pre-open in the late afternoon, open an evening, close the following
+    // afternoon. The whole session is one trading day and it is the day it closes on, so its
+    // evening half is dated a day ahead of the clock.
+    private static readonly TradingSession Overnight =
+        new(new TimeSpan(16, 45, 0), new TimeSpan(17, 0, 0), new TimeSpan(40, 0, 0), TradeDateOffset: 1);
+
+    private static MarketSchedule OvernightSession() => new(new[] {Overnight});
+
+    [Test]
+    public void NextAfter_DuringTheMorning_ClosesThisAfternoon()
+    {
+        // act - a venue this shape is in a session for all but 45 minutes of the day, and the
+        // session it is in at breakfast is the one that opened last night
+        var next = NextAfter(OvernightSession(), Day.Add(new TimeSpan(9, 0, 0)));
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.Closed, next.Status);
+        Assert.AreEqual(Day.Add(new TimeSpan(16, 0, 0)), next.Time);
+        Assert.AreEqual(DateOnly.FromDateTime(Day), next.TradeDate,
+            "last night's session trades for today");
+    }
+
+    [Test]
+    public void NextAfter_DuringTheEvening_ClosesTomorrowAfternoon()
+    {
+        // act
+        var next = NextAfter(OvernightSession(), Day.Add(new TimeSpan(20, 0, 0)));
+
+        // assert - the close is on the next calendar day, which no same-day schedule can say
+        Assert.AreEqual(OrderBookStatus.Closed, next.Status);
+        Assert.AreEqual(NextDay.Add(new TimeSpan(16, 0, 0)), next.Time);
+        Assert.IsTrue(next.EndsTradingDay);
+    }
+
+    [Test]
+    public void NextAfter_AfterMidnight_StillInLastNightsSession()
+    {
+        // act - the case a schedule anchored on the asking date cannot answer: nothing opened
+        // today, and what is running began yesterday
+        var next = NextAfter(OvernightSession(), NextDay.Add(new TimeSpan(2, 0, 0)));
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.Closed, next.Status);
+        Assert.AreEqual(NextDay.Add(new TimeSpan(16, 0, 0)), next.Time);
+        Assert.AreEqual(DateOnly.FromDateTime(NextDay), next.TradeDate,
+            "past midnight the clock has caught up with the trading day, which never moved");
+    }
+
+    [Test]
+    public void NextAfter_BetweenTheCloseAndTheNextPreOpen_PreOpensTonight()
+    {
+        // act - the maintenance window, the only part of the day this venue is not in a session
+        var next = NextAfter(OvernightSession(), NextDay.Add(new TimeSpan(16, 30, 0)));
+
+        // assert
+        Assert.AreEqual(OrderBookStatus.PreOpen, next.Status);
+        Assert.AreEqual(NextDay.Add(Overnight.PreOpen), next.Time);
+    }
+
+    [Test]
+    public void NextAfter_OvernightWalkedForward_VisitsEveryBoundaryInOrder()
+    {
+        // arrange
+        var schedule = OvernightSession();
+        var walk = new List<ScheduledTransition>();
+
+        // From inside the maintenance window, the only instant of the day this venue is between
+        // sessions rather than in one.
+        var time = Day.Add(new TimeSpan(16, 30, 0));
+
+        // act
+        for (var i = 0; i < 4; i++)
+        {
+            var next = NextAfter(schedule, time);
+            walk.Add(next);
+            time = next.Time;
+        }
+
+        // assert - one session per calendar day, each dated a day ahead of the day it opens on,
+        // and the close of one landing between the pre-open and open of nothing at all
+        var dayAfter = NextDay.AddDays(1);
+        Assert.AreEqual(
+            new[]
+            {
+                new ScheduledTransition(Day.Add(Overnight.PreOpen), OrderBookStatus.PreOpen,
+                    DateOnly.FromDateTime(NextDay)),
+                new ScheduledTransition(Day.Add(Overnight.Open), OrderBookStatus.Open,
+                    DateOnly.FromDateTime(NextDay)),
+                new ScheduledTransition(NextDay.Add(new TimeSpan(16, 0, 0)), OrderBookStatus.Closed,
+                    DateOnly.FromDateTime(NextDay)),
+                new ScheduledTransition(NextDay.Add(Overnight.PreOpen), OrderBookStatus.PreOpen,
+                    DateOnly.FromDateTime(dayAfter))
+            },
+            walk);
+    }
+
+    [Test]
+    public void NextAfter_DaySessionThenAnEveningOne_DatesEachToItsOwnTradingDay()
+    {
+        // arrange - a cash session trading for today, and an evening one that is tomorrow's
+        // business already, which is what makes the trade date a property of the session rather
+        // than of the calendar
+        var cash = new TradingSession(new TimeSpan(8, 0, 0), new TimeSpan(8, 30, 0), new TimeSpan(16, 0, 0));
+        var evening = new TradingSession(new TimeSpan(17, 0, 0), new TimeSpan(17, 30, 0),
+            new TimeSpan(21, 0, 0), TradeDateOffset: 1);
+        var schedule = new MarketSchedule(new[] {cash, evening});
+
+        // act
+        var cashClose = NextAfter(schedule, Day.Add(new TimeSpan(12, 0, 0)));
+        var eveningClose = NextAfter(schedule, Day.Add(new TimeSpan(18, 0, 0)));
+
+        // assert - and only the evening close ends a trading day, the cash close being a session
+        // with another still to come
+        Assert.AreEqual(DateOnly.FromDateTime(Day), cashClose.TradeDate);
+        Assert.IsFalse(cashClose.EndsTradingDay);
+        Assert.AreEqual(DateOnly.FromDateTime(NextDay), eveningClose.TradeDate);
+        Assert.IsTrue(eveningClose.EndsTradingDay);
     }
 }

--- a/tests/Circus.Tests/Sessions/OvernightSessionTests.cs
+++ b/tests/Circus.Tests/Sessions/OvernightSessionTests.cs
@@ -99,7 +99,7 @@ public class OvernightSessionTests
         // falls on Monday and is the same day's, so the trade date never moves within a session
         var session = dispatched.Select(d => d.Action).OfType<SessionAction>().ToList();
         Assert.AreEqual(3, session.Count);
-        CollectionAssert.AreEqual(new DateOnly?[] {MondayDate, MondayDate, MondayDate},
+        Assert.AreEqual(new DateOnly?[] {MondayDate, MondayDate, MondayDate},
             session.Select(a => a.TradeDate).ToList());
         Assert.AreEqual(Sunday, session[0].Time.Date);
         Assert.AreEqual(Monday, session[2].Time.Date);

--- a/tests/Circus.Tests/Sessions/OvernightSessionTests.cs
+++ b/tests/Circus.Tests/Sessions/OvernightSessionTests.cs
@@ -1,0 +1,204 @@
+using Circus.Actions;
+using Circus.Events;
+using Circus.Sequencing;
+using Circus.Sessions;
+using NUnit.Framework;
+
+namespace Circus.Tests.Sessions;
+
+// A session that opens one evening and closes the next afternoon, driven end to end through a
+// sequencer - the schedule producing the boundaries, the book acting on them.
+//
+// What is worth holding is that the trading day and the calendar disagree for the first half of
+// such a session, and that everything measured in trading days follows the venue rather than the
+// clock. An order resting at 23:00 on Sunday belongs to Monday's session; midnight is not a
+// boundary, and nothing about it retires anything.
+[TestFixture]
+public class OvernightSessionTests
+{
+    private static readonly Instrument Gold = new("GCZ6", 10, 10);
+
+    // Sunday evening through Monday afternoon, which is Monday's trading day throughout.
+    private static readonly TradingSession Overnight =
+        new(new TimeSpan(16, 45, 0), new TimeSpan(17, 0, 0), new TimeSpan(40, 0, 0), TradeDateOffset: 1);
+
+    private static readonly DateTime Sunday = new(2000, 1, 2);
+    private static readonly DateTime Monday = new(2000, 1, 3);
+
+    private static readonly DateOnly MondayDate = DateOnly.FromDateTime(Monday);
+    private static readonly DateOnly SundayDate = DateOnly.FromDateTime(Sunday);
+
+    // 40 hours past Sunday's midnight, which is Monday afternoon.
+    private static readonly DateTime Close = Sunday.Add(new TimeSpan(40, 0, 0));
+
+    private static MarketSchedule Schedule() => new(new[] {Overnight});
+
+    // Registered in the maintenance window ahead of the session, so the sequencer's first
+    // boundary is that session's own pre-open rather than something it has already missed.
+    private static (Sequencer Sequencer, OrderBook Book) Venue()
+    {
+        var book = new OrderBook(Gold);
+        var sequencer = new Sequencer(Sunday.Add(new TimeSpan(16, 30, 0)));
+        sequencer.Add(book, Schedule());
+        return (sequencer, book);
+    }
+
+    private static CreateLimitOrder Order(string clientOrderId, OrderValidity validity, DateTime time) =>
+        new()
+        {
+            Symbol = Gold.Symbol, Time = time, CompanyId = "Company1", ClientOrderId = clientOrderId,
+            OrderValidity = validity, Side = Side.Buy, Quantity = 5, Price = 100
+        };
+
+    private static IReadOnlyList<OrderBookEvent> EventsOf(IReadOnlyList<Dispatched> dispatched) =>
+        dispatched.SelectMany(d => d.Events).ToList();
+
+    [Test]
+    public void AdvanceTo_DrivesTheBookAcrossMidnight()
+    {
+        // arrange
+        var (sequencer, book) = Venue();
+
+        // act - to the middle of the night, hours past the date change
+        var dispatched = sequencer.AdvanceTo(Monday.Add(new TimeSpan(3, 0, 0)));
+
+        // assert - the evening's two boundaries and nothing else. Midnight is not a boundary
+        Assert.AreEqual(2, dispatched.Count);
+        Assert.IsInstanceOf<PreOpenTrading>(dispatched[0].Action);
+        Assert.IsInstanceOf<OpenTrading>(dispatched[1].Action);
+        Assert.AreEqual(OrderBookStatus.Open, book.Status);
+    }
+
+    [Test]
+    public void AdvanceTo_TheSessionsClose_IsOnTheFollowingAfternoon()
+    {
+        // arrange
+        var (sequencer, book) = Venue();
+
+        // act
+        var dispatched = sequencer.AdvanceTo(Close);
+
+        // assert - a boundary 40 hours past its anchor, landing on the day after the one the
+        // session opened on
+        var close = dispatched.Select(d => d.Action).OfType<CloseTrading>().Single();
+        Assert.AreEqual(Monday.Add(new TimeSpan(16, 0, 0)), close.Time);
+        Assert.IsTrue(close.EndsTradingDay);
+        Assert.AreEqual(OrderBookStatus.Closed, book.Status);
+    }
+
+    [Test]
+    public void SessionActions_CarryTheTradingDayRatherThanTheDate()
+    {
+        // arrange
+        var (sequencer, _) = Venue();
+
+        // act
+        var dispatched = sequencer.AdvanceTo(Close);
+
+        // assert - the pre-open and open fall on Sunday and are Monday's business; the close
+        // falls on Monday and is the same day's, so the trade date never moves within a session
+        var session = dispatched.Select(d => d.Action).OfType<SessionAction>().ToList();
+        Assert.AreEqual(3, session.Count);
+        CollectionAssert.AreEqual(new DateOnly?[] {MondayDate, MondayDate, MondayDate},
+            session.Select(a => a.TradeDate).ToList());
+        Assert.AreEqual(Sunday, session[0].Time.Date);
+        Assert.AreEqual(Monday, session[2].Time.Date);
+    }
+
+    [Test]
+    public void DayOrder_RestingOverMidnight_ExpiresAtTheSessionsClose()
+    {
+        // arrange - a day order sent in the evening, which under a calendar-day reading would be
+        // yesterday's by the time the session ends
+        var (sequencer, _) = Venue();
+        sequencer.Submit(Order("Day1", new OrderValidity.Day(), Sunday.Add(new TimeSpan(23, 0, 0))));
+
+        // act - to just before the close, then over it
+        var overnight = sequencer.AdvanceTo(Monday.Add(new TimeSpan(15, 59, 0)));
+        var atTheClose = sequencer.AdvanceTo(Close);
+
+        // assert
+        Assert.IsEmpty(EventsOf(overnight).OfType<ExpireOrderConfirmed>(),
+            "midnight retires nothing - the session it was sent into is still running");
+
+        var expired = EventsOf(atTheClose).OfType<ExpireOrderConfirmed>().Single();
+        Assert.AreEqual("Day1", expired.Order.ClientOrderId);
+        Assert.AreEqual(Close, expired.Time);
+    }
+
+    [Test]
+    public void GoodTilDate_ForTheTradingDay_ExpiresAtThatSessionsClose()
+    {
+        // arrange - good till Monday, sent on Sunday evening into Monday's session
+        var (sequencer, _) = Venue();
+        sequencer.Submit(Order("GTD1", new OrderValidity.GoodTilDate {Date = MondayDate},
+            Sunday.Add(new TimeSpan(23, 0, 0))));
+
+        // act
+        var dispatched = sequencer.AdvanceTo(Close);
+
+        // assert - the close is the end of the day the order was good till, so it goes there.
+        // Dating the book from the clock would have retired it at this same close for the wrong
+        // reason, having read the whole evening as Sunday
+        var expired = EventsOf(dispatched).OfType<ExpireOrderConfirmed>().Single();
+        Assert.AreEqual("GTD1", expired.Order.ClientOrderId);
+        Assert.AreEqual(Close, expired.Time);
+    }
+
+    [Test]
+    public void GoodTilDate_ForTheDayTheSessionOpenedOn_IsRejected()
+    {
+        // arrange - good till Sunday, sent at 23:00 on Sunday. By the clock that is today and the
+        // order has hours left; by the trading day the venue is already on Monday and Sunday is
+        // behind it, so this is a date in the past
+        var (sequencer, _) = Venue();
+        sequencer.Submit(Order("Stale", new OrderValidity.GoodTilDate {Date = SundayDate},
+            Sunday.Add(new TimeSpan(23, 0, 0))));
+
+        // act
+        var dispatched = sequencer.AdvanceTo(Close);
+
+        // assert
+        var rejected = EventsOf(dispatched).OfType<CreateOrderRejected>().Single();
+        Assert.AreEqual("Stale", rejected.ClientOrderId);
+        Assert.AreEqual(OrderRejectedReason.InvalidExpireDate, rejected.Reason);
+    }
+
+    [Test]
+    public void ExchangeOrderIds_AreSeededFromTheTradingDay()
+    {
+        // arrange
+        var (sequencer, _) = Venue();
+        sequencer.Submit(Order("Evening", new OrderValidity.Day(), Sunday.Add(new TimeSpan(23, 0, 0))));
+
+        // act
+        var dispatched = sequencer.AdvanceTo(Close);
+
+        // assert - Monday's run of ids, issued on Sunday evening. A seed taken from the clock
+        // would start the session on Sunday's run and step up to Monday's at midnight, halfway
+        // through a session whose ids are supposed to name one day
+        var created = EventsOf(dispatched).OfType<CreateOrderConfirmed>().Single();
+        var seed = ((MondayDate.Year * 10000) + (MondayDate.Month * 100) + MondayDate.Day) * 10000000000L;
+        var id = long.Parse(created.Order.ExchangeOrderId);
+
+        Assert.GreaterOrEqual(id, seed);
+        Assert.Less(id, seed + 10000000000L);
+    }
+
+    [Test]
+    public void ADayDrivenByHand_StillDatesItselfFromTheClock()
+    {
+        // arrange - no schedule involved, so nothing tells the book which day it is trading
+        var book = new OrderBook(Gold);
+
+        // act
+        book.PreOpenTrading(time: Monday.Add(new TimeSpan(9, 0, 0)));
+        book.OpenTrading(time: Monday.Add(new TimeSpan(9, 30, 0)));
+        book.CreateLimitOrder("Company1", "Day1", new OrderValidity.Day(), Side.Buy, 5, 100,
+            time: Monday.Add(new TimeSpan(10, 0, 0)));
+        var closed = book.CloseTrading(time: Monday.Add(new TimeSpan(17, 0, 0)));
+
+        // assert - which is what every schedule that stays within its day means anyway
+        Assert.AreEqual("Day1", closed.OfType<ExpireOrderConfirmed>().Single().Order.ClientOrderId);
+    }
+}


### PR DESCRIPTION
A session's boundaries become offsets from the day it is anchored on rather than times within it, so one may close on the day after it opened. Globex's day is `(16:45, 17:00, 40:00)` - pre-open in the late afternoon, open an evening, close the following afternoon.

`TradingSession`'s old comment was the specification being replaced: *"All three times fall within the same day, so a session cannot span midnight."*

## The schedule

`MarketSchedule` keeps a day's whole span under 24 hours and its first pre-open within its own anchor day. Together those keep it a description of one repeating day and bound the lookback to a single anchor: `NextAfter` tries yesterday's anchor first, because a session in progress can only be there - sessions do not overlap, so one still running from last night means none of today's has begun. Everything that compared a `TimeOfDay` against an offset now compares a `DateTime` against an anchored one.

`NextSessionAt` and `Sessions` are gone. Both existed for a stateful walker that anchors boundaries on its caller's date; nothing implements that walker, so carrying them through this change would only have left them wrong.

## Boundaries must be strictly ordered

Within a session and between neighbours alike. Two boundaries on one instant cannot both be reached by a query keyed on time - the first is answered and asking on from it steps over the second, so a session would open without pre-opening. That was already true and already commented on in `NextAfter`, with a test pinning the wrong answer so whatever consumed it would have to decide.

Overnight schedules are what make it reachable rather than hypothetical, because a venue running almost around the clock is exactly one whose sessions touch. Venues that run almost around the clock still stop - CME's maintenance window is an hour, Eurex's is minutes - so requiring a gap costs nothing real and turns an answer that would quietly be wrong into an exception where the schedule is written.

## Which day a session is trading for

The one behavioural change, and the reason this is not just arithmetic in `MarketSchedule`.

The book dated itself from the clock in three places: GTD validity on create, GTD and Day expiry at a close, and the seed its exchange order ids run from. That agrees with the trading day only while a session stays inside its date. An order sent at 23:00 on Sunday good till Monday would otherwise have survived the Monday-afternoon close it was meant to die at, having been read as good till tomorrow - off by one session, in the direction that leaves an order resting a participant believes has expired.

So the trading day becomes something the schedule states. `TradingSession` gains a `TradeDateOffset`, `ScheduledTransition` a `TradeDate`, and the three status actions carry it through a new `SessionAction` base. The sequencer fills it from the transition; the book holds what it was last told and measures all three against that. A book driven by hand is told nothing, falls back to the clock, and behaves exactly as it did.

## Tests

`MarketScheduleTests` gains an overnight schedule beside the two it had: the pre-open and open on one date and the close on the next, the after-midnight query that fails outright without this change, the maintenance window, a full walk, and a day-plus-evening schedule where two sessions on one anchor trade for different days. The two tests pinning touching boundaries now assert they are refused, and the constructor cases cover the span and first-pre-open bounds.

`OvernightSessionTests` runs the whole thing through a sequencer: Day and GTD orders resting across midnight and retiring at the session's close rather than at the date change, a GTD dated for the day the session opened on rejected as past, ids seeded from the trading day, and a hand-driven book still dating itself from the clock.

## Not in this change

Time zones and DST. A schedule is offsets against whatever `DateTime` it is given, and nothing shifts with local time - already true of same-day schedules, but overnight sessions are where it starts to matter, since a product trading almost around the clock has its boundaries in one particular local evening. `docs/overnight-sessions-plan.md` covers the shape that would fix it.

The `Circus.Tests.Venues` trace is stamped within a day and would need its instants moved to run under a schedule that crosses midnight; that is noted in the plan as the one outstanding step.

## Verification

CI is green - build, the full test suite, and the samples run. Nothing was built locally: this environment's egress policy blocks the .NET SDK download hosts (`builds.dotnet.microsoft.com` returns 403), so CI was the first build, and the first run caught one compile error (NUnit 4 has no `CollectionAssert` in the main namespace), fixed in the second commit.