### PR TITLE
Carry the instrument's whole state on each event that moves part of it

### DIFF
--- a/src/Circus/Events/OrderBookEvent.cs
+++ b/src/Circus/Events/OrderBookEvent.cs
@@ -23,8 +23,16 @@ public abstract record MarketEvent(string Symbol, DateTime Time) : OrderBookEven
 // ResumesAt is when a timed interruption is due to end, and is null for everything else - which
 // includes an interruption configured to last until told otherwise, and every ordinary
 // transition, since an explicit one supersedes whatever was pending.
+//
+// LimitState is which way a daily limit has the market stuck as this transition happens, and is
+// not a claim that the limit moved - LimitStateChanged below says that. It is carried for the
+// reason UpdateOrderConfirmed carries its Previous fields: so that a consumer wanting the
+// instrument's whole state does not have to remember the half this event is not about. The book
+// already holds it, and BookSnapshot already publishes the same composite, so restating it here
+// costs a field and saves every subscriber an accumulator that can drift and cannot resync.
 public record StatusChanged(string Symbol, DateTime Time, OrderBookStatus Status,
-        OrderBookStatusChangeReason Reason = OrderBookStatusChangeReason.Requested, DateTime? ResumesAt = null)
+        OrderBookStatusChangeReason Reason = OrderBookStatusChangeReason.Requested, DateTime? ResumesAt = null,
+        Side? LimitState = null)
     : MarketEvent(Symbol, Time);
 
 // Addressed to one participant, and never broadcast: CompanyId and ClientOrderId identify who
@@ -126,7 +134,17 @@ public record IndicativePriceChanged(string Symbol, DateTime Time, decimal? Pric
 // Not a status change - a limit-locked market is open, quoting, and trading at the limit. That
 // is the whole difference between a limit and a circuit breaker, so it gets an event of its own
 // rather than a status that would claim otherwise. Emitted only on a change.
-public record LimitStateChanged(string Symbol, DateTime Time, Side? Side, decimal? Price)
+//
+// Status, Reason and ResumesAt are what the instrument's status is while this happens, and say
+// nothing about it having moved - it did not, which is the paragraph above. They are here for the
+// same reason StatusChanged carries LimitState: either event is then a complete picture of the
+// instrument's state, so a consumer assembling that picture holds nothing between messages and a
+// gap costs it the update rather than the truth. That the two stay separate types is what keeps
+// "the status moved" and "the limit moved" tellable apart by a consumer that cares about one and
+// not the other - which is the distinction the paragraph above exists to protect, and merging
+// them into one event would have given up.
+public record LimitStateChanged(string Symbol, DateTime Time, Side? Side, decimal? Price,
+        OrderBookStatus Status, OrderBookStatusChangeReason Reason, DateTime? ResumesAt)
     : MarketEvent(Symbol, Time);
 // One aggregated price level of the working book, as carried inside a LevelsChanged.
 //

--- a/src/Circus/OrderBook.cs
+++ b/src/Circus/OrderBook.cs
@@ -1216,7 +1216,7 @@ public class OrderBook : IOrderBook
                 _resumeAt = breach.ResumeAfter.HasValue ? time + breach.ResumeAfter.Value : null;
                 _statusReason = OrderBookStatusChangeReason.PriceRestriction;
                 events.Add(new StatusChanged(_instrument.Symbol, time, _status, _statusReason,
-                    _resumeAt));
+                    _resumeAt, _limitState));
                 break;
 
             case StopsTriggered(var orders):
@@ -1243,7 +1243,8 @@ public class OrderBook : IOrderBook
             return;
 
         _limitState = side;
-        events.Add(new LimitStateChanged(_instrument.Symbol, time, side, ToDecimal(blockedTicks)));
+        events.Add(new LimitStateChanged(_instrument.Symbol, time, side, ToDecimal(blockedTicks),
+            _status, _statusReason, _resumeAt));
     }
 
     // A print means the market is trading again, wherever it is trading. Releasing on any trade
@@ -1255,7 +1256,8 @@ public class OrderBook : IOrderBook
             return;
 
         _limitState = null;
-        events.Add(new LimitStateChanged(_instrument.Symbol, time, null, null));
+        events.Add(new LimitStateChanged(_instrument.Symbol, time, null, null,
+            _status, _statusReason, _resumeAt));
     }
 
     private void ApplyTrade(InternalOrder resting, InternalOrder aggressor, long priceTicks, int quantity,
@@ -1404,7 +1406,7 @@ public class OrderBook : IOrderBook
             _resumeAt = extension.Value.ResumeAfter.HasValue ? time + extension.Value.ResumeAfter.Value : null;
             _statusReason = OrderBookStatusChangeReason.PriceRestriction;
             return new List<OrderBookEvent>
-                {new StatusChanged(_instrument.Symbol, time, _status, _statusReason, _resumeAt)};
+                {new StatusChanged(_instrument.Symbol, time, _status, _statusReason, _resumeAt, _limitState)};
         }
 
         // Any transition supersedes a pending one, so a session closing over a running pause
@@ -1442,7 +1444,8 @@ public class OrderBook : IOrderBook
         // _resumeAt was cleared above, so this reports nothing pending - which is what an
         // explicit transition means, having just superseded whatever was.
         _statusReason = reason;
-        var events = new List<OrderBookEvent> {new StatusChanged(_instrument.Symbol, time, _status, reason, _resumeAt)};
+        var events = new List<OrderBookEvent>
+            {new StatusChanged(_instrument.Symbol, time, _status, reason, _resumeAt, _limitState)};
 
         // A quoting phase has been accumulating orders for a print, and leaving it is where
         // that print happens - so a second auction phase would need nothing changed here.

--- a/tests/Circus.Tests/MarketData/InstrumentStatusDataProducerTests.cs
+++ b/tests/Circus.Tests/MarketData/InstrumentStatusDataProducerTests.cs
@@ -183,10 +183,15 @@ public class InstrumentStatusDataProducerTests
         // assert
         Assert.AreEqual(OrderBookStatus.Paused, opened.Single().Status);
 
-        // act - a limit event arriving on its own carries the remembered status with it, which
-        // is what holding state is for
+        // act - a limit event arriving on its own still yields the whole composite. It carries the
+        // status itself now rather than the producer remembering it, so this says the same thing
+        // about what a subscriber is told and no longer says anything about where it was held.
         var events = Producer.Process(
-            new OrderBookEvent[] {new LimitStateChanged(book.Symbol, Now1, Side.Sell, 90)});
+            new OrderBookEvent[]
+            {
+                new LimitStateChanged(book.Symbol, Now1, Side.Sell, 90, OrderBookStatus.Paused,
+                    OrderBookStatusChangeReason.Requested, null)
+            });
 
         // assert
         Assert.AreEqual(OrderBookStatus.Paused, events.Single().Status);


### PR DESCRIPTION
`StatusChanged` gains `LimitState`, and `LimitStateChanged` gains `Status`, `Reason` and `ResumesAt`. Either event is now a complete picture of where the instrument is.

## Why

`InstrumentStatusDataProducer` holds four fields — status, reason, resume time, limit state — and assembles them into the composite a subscriber sees. But the book already holds all four (`OrderBook.cs:21,26,43,48`), and `BookSnapshot` already publishes them together. The producer is reconstructing state the book never stopped having.

That is the shape the by-price feed was in before the ladders began reporting their own aggregates, and `MarketByPriceIncrementalProducer`'s comment says what is wrong with it:

> A producer deriving aggregated depth from order events has to hold the book the subscriber is missing, which is what the previous `LevelDataProducer` did — and why it could never resync after a missed event.

Depth moved into the book in #86/#89, the print in #81, order-by-order in #92. Status is the one that did not get the treatment. Restating what the book already knows costs a field on two events and removes the reason to hold anything downstream.

## Why two events and not one

Merging them into a single composite was the obvious alternative and is not what this does. `LimitStateChanged` exists precisely to say that a limit lock is *not* a status change — a limit-locked market is open, quoting, and trading at the limit. Keeping the types apart means a consumer that cares whether the market halted, and not whether it is limit-locked, still tells them apart by type rather than by diffing. An action that does both still says so twice, in the order it did them, and each message is self-consistent as of the moment it was emitted.

The new fields say what the status *is* while the limit moves, not that it moved.

## Scope

No behaviour changes. `InstrumentStatusDataProducer` still accumulates and ignores the new fields — this commit only makes the accumulator unnecessary. Replacing it with a projection is the next commit, and is the first step of collapsing the nine market-data producers into a projection table on `InstrumentFeed`.

`StatusChanged.LimitState` is defaulted so existing construction sites keep compiling; the three new parameters on `LimitStateChanged` are required, so any missed site is a build error rather than a silently wrong value.

## Changes

- `src/Circus/Events/OrderBookEvent.cs` — both records widened, with the reasoning recorded against them
- `src/Circus/OrderBook.cs` — five emit sites pass the fields they already had in scope
- `tests/Circus.Tests/MarketData/InstrumentStatusDataProducerTests.cs` — the one synthetic `LimitStateChanged` in the suite. Its assertion used to prove the producer remembered the status across a limit event; it now proves the subscriber is told the same thing, and says nothing about where it was held

## Verification

**Not built or tested.** The environment this was written in has no .NET SDK and the network policy blocks `builds.dotnet.microsoft.com`, so nothing here has been compiled. CI is the first real check. The change is small and mechanical, but please treat a green build as news rather than a formality.

Every construction site was found by grep rather than by the compiler: `new StatusChanged` and `new LimitStateChanged` appear at five sites in `OrderBook.cs` and two in tests, and all seven are in this diff. No test compares either record by value, so the added fields cannot silently break an assertion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yarn7MXEnUDou63QZKvexp)_